### PR TITLE
Refactor/mixins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,30 @@ jobs:
             "3.13") tox -e py313 ;;
           esac
 
+  dev-validation:
+    name: Dev validation (TOPMARK_VALIDATE=1)
+    # Fast, PR-only check that runs ONLY when src/** changed.
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.src_changed == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements-*.txt
+            constraints.txt
+      - run: |
+          python -m pip install -U pip
+          pip install -r requirements-dev.txt
+          pip install -c constraints.txt -e .[test]
+      - run: TOPMARK_VALIDATE=1 pytest -q -m dev_validation
+
   api-snapshot:
+    name: API Snapshot
     # Fast, PR-only check that runs ONLY when src/** changed.
     needs: changes
     if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.src_changed == 'true' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,26 @@ Run the test suite:
 make test
 ```
 
+### Developer validation (optional)
+
+Enable lightweight registry and strategy checks while developing or debugging:
+
+```bash
+TOPMARK_VALIDATE=1 make test
+# or
+TOPMARK_VALIDATE=1 pytest -q
+```
+
+What this checks (dev-only; zero-cost in normal runs):
+
+- Every registered header **processor** maps to a known **FileType**.
+- XML/HTML-like processors use the **character-offset** strategy: they must
+  return `NO_LINE_ANCHOR` from `get_header_insertion_index()` and compute an
+  offset in `get_header_insertion_char_offset()`.
+
+These validations help catch subtle registry or placement regressions early
+(e.g., typos in type keys, accidental line-based use in XML processors).
+
 ### Python version compatibility
 
 TopMark supports Python 3.10–3.13.

--- a/docs/ci/dev-validation.md
+++ b/docs/ci/dev-validation.md
@@ -1,0 +1,69 @@
+<!--
+topmark:header:start
+
+  project      : TopMark
+  file         : dev-validation.md
+  file_relpath : docs/ci/dev-validation.md
+  license      : MIT
+  copyright    : (c) 2025 Olivier Biot
+
+topmark:header:end
+-->
+
+# Developer validation (optional)
+
+TopMark provides opt-in developer-time validations to catch subtle registry
+or placement regressions during refactoring or when adding new processors.
+Enable it by setting `TOPMARK_VALIDATE=1`.
+
+```bash
+TOPMARK_VALIDATE=1 pytest -q
+# or when running the CLI during development
+TOPMARK_VALIDATE=1 topmark processors --format json
+```
+
+## What it checks
+
+- **Registry integrity**: every registered header processor maps to an existing
+  `FileType` name.
+- **Placement strategy for XML/HTML**: processors based on `XmlHeaderProcessor`
+  must signal the **character-offset** strategy by returning `NO_LINE_ANCHOR`
+  from `get_header_insertion_index()`.
+
+These checks run at most once per process and are **no-ops by default**.
+They do not affect end users.
+
+## Why it matters
+
+- Prevents accidental miswiring (e.g., a processor registered under a typo key).
+- Ensures XML/HTML-like processors don’t regress into line-based insertion,
+  which can cause double-wrapped `<!-- -->` header blocks.
+- Mirrors guardrails used by mature Python projects for safer refactors.
+
+## CI usage (example)
+
+Add a dev job in your GitHub Actions workflow to run validations alongside tests:
+
+```yaml
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e .[dev]
+      - name: Run tests with developer validation
+        run: TOPMARK_VALIDATE=1 pytest -q
+```
+
+## Scope and overhead
+
+- Validation is **lightweight** and only performs simple mapping/strategy checks.
+- It does not parse files or run the pipeline; it inspects the composed registry
+  during import time for `topmark.registry.processors`.
+- No runtime overhead for end users unless `TOPMARK_VALIDATE` is set.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
   - CI/CD:
       - CI workflow: ci/ci-workflow.md
       - Release workflow: ci/release-workflow.md
+      - Dev validation: ci/dev-validation.md
   - Contributing: contributing.md
   - API:
       - "Public API": api/public.md

--- a/src/topmark/filetypes/instances.py
+++ b/src/topmark/filetypes/instances.py
@@ -76,16 +76,12 @@ def _iter_plugin_filetypes() -> Iterable[FileType]:
         eps = entry_points()
     except Exception:
         logger.exception("Failed to read entry points")
-        return ()
+        return
 
-    # Python 3.10+ API provides .select; older API uses dict-like .get
-    selector = getattr(eps, "select", None)
-    if callable(selector):
-        candidates: EntryPoints = eps.select(group=ENTRYPOINT_GROUP)
-    else:
-        candidates = eps.get(ENTRYPOINT_GROUP, [])  # type: ignore[assignment]
+    # Python 3.10+ API: EntryPoints.select is available and typed
+    candidates: EntryPoints = eps.select(group=ENTRYPOINT_GROUP)
 
-    for ep in candidates:  # type: ignore[assignment]
+    for ep in candidates:
         try:
             provider: Any = ep.load()
             provided: Any = provider() if callable(provider) else provider

--- a/src/topmark/pipeline/processors/base.py
+++ b/src/topmark/pipeline/processors/base.py
@@ -88,13 +88,13 @@ class HeaderProcessor:
         integrations.
 
     Args:
-        block_prefix (str): The prefix string for block-style header start.
-        block_suffix (str): The suffix string for block-style header end.
-        line_prefix (str): The prefix string for each line within the header block.
-        line_suffix (str): The suffix string for each line within the header block.
-        line_indent (str): The indentation applied to *header field lines* **after**
+        block_prefix (str | None): The prefix string for block-style header start.
+        block_suffix (str | None): The suffix string for block-style header end.
+        line_prefix (str | None): The prefix string for each line within the header block.
+        line_suffix (str | None): The suffix string for each line within the header block.
+        line_indent (str | None): The indentation applied to *header field lines* **after**
             the comment prefix (e.g., spaces after `//`).
-        header_indent (str): The indentation applied *before* the comment prefix; used
+        header_indent (str | None): The indentation applied *before* the comment prefix; used
             to preserve existing leading indentation when replacing an indented
             header block inside a document (e.g., nested JSONC).
 
@@ -129,22 +129,27 @@ class HeaderProcessor:
     def __init__(
         self,
         *,
-        block_prefix: str = "",
-        block_suffix: str = "",
-        line_prefix: str = "",
-        line_suffix: str = "",
-        line_indent: str = "  ",
-        header_indent: str = "",
+        block_prefix: str | None = None,
+        block_suffix: str | None = None,
+        line_prefix: str | None = None,
+        line_suffix: str | None = None,
+        line_indent: str | None = None,
+        header_indent: str | None = None,
     ) -> None:
         self.file_type = None
 
-        self.block_prefix = block_prefix
-        self.block_suffix = block_suffix
-        self.line_prefix = line_prefix
-        self.line_suffix = line_suffix
-
-        self.line_indent = line_indent
-        self.header_indent = header_indent
+        if block_prefix is not None:
+            self.block_prefix = block_prefix
+        if block_suffix is not None:
+            self.block_suffix = block_suffix
+        if line_prefix is not None:
+            self.line_prefix = line_prefix
+        if line_suffix is not None:
+            self.line_suffix = line_suffix
+        if line_indent is not None:
+            self.line_indent = line_indent
+        if header_indent is not None:
+            self.header_indent = header_indent
 
     def parse_fields(self, context: ProcessingContext) -> dict[str, str]:
         """Parse key-value pairs from the detected header block (outer slice).

--- a/src/topmark/pipeline/processors/base.py
+++ b/src/topmark/pipeline/processors/base.py
@@ -585,6 +585,26 @@ class HeaderProcessor:
 
         return lines
 
+    def compute_insertion_anchor(self, lines: list[str]) -> int:
+        """Return a stable line-based insertion anchor for the pipeline.
+
+        This small facade exists so pipeline steps have a single, stable
+        entry point for *line-based* placement. By default, it simply
+        delegates to :py:meth:`get_header_insertion_index`.
+
+        Processors that insert by **character offset** (e.g., XML/HTML) should
+        override :py:meth:`get_header_insertion_index` to return
+        :pydata:`NO_LINE_ANCHOR`, which this method will propagate unchanged.
+
+        Args:
+            lines (list[str]): Full file content split into lines.
+
+        Returns:
+            int: A 0-based line index where a header would be inserted, or
+                :pydata:`NO_LINE_ANCHOR` when line-based anchoring is not used.
+        """
+        return self.get_header_insertion_index(lines)
+
     def get_header_insertion_index(self, file_lines: list[str]) -> int:
         """Determine where to insert the header based on file type policy.
 

--- a/src/topmark/pipeline/processors/base.py
+++ b/src/topmark/pipeline/processors/base.py
@@ -16,6 +16,20 @@ parsing, and rendering header fields according to comment styles and file extens
 
 The module also supports associating processors with file types to enable flexible,
 extensible header processing in the TopMark pipeline.
+
+Placement strategies
+--------------------
+TopMark supports two complementary placement strategies:
+
+* **Line-based insertion** (default): processors return a line anchor from
+  `get_header_insertion_index()`; pipeline steps use `compute_insertion_anchor()`
+  as the façade to obtain that anchor.
+* **Character-offset insertion** (for positional formats like XML/HTML): processors
+  return `NO_LINE_ANCHOR` from `get_header_insertion_index()` and implement
+  `get_header_insertion_char_offset()` to compute a byte/character offset.
+
+The pipeline first attempts text-based insertion when a char offset is provided;
+otherwise it falls back to the line-based strategy using the computed anchor.
 """
 
 from __future__ import annotations
@@ -80,6 +94,13 @@ class HeaderProcessor:
         ``line_suffix``, ``block_prefix``, ``block_suffix``) and may override any of
         the hooks documented below to support format‑specific behavior (e.g., XML
         prolog placement or Markdown fences).
+
+    Placement strategies:
+        - **Line-based** (default): override `get_header_insertion_index()` if needed.
+          Pipeline steps call `compute_insertion_anchor()` as a stable façade.
+        - **Character-offset** (XML/HTML-like): return `NO_LINE_ANCHOR` from
+          `get_header_insertion_index()` and implement
+          `get_header_insertion_char_offset()`; the pipeline will prefer this path.
 
     Public API note:
         In the stable public surface, consider typing against a minimal protocol

--- a/src/topmark/pipeline/processors/mixins.py
+++ b/src/topmark/pipeline/processors/mixins.py
@@ -1,0 +1,169 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : mixins.py
+#   file_relpath : src/topmark/pipeline/processors/mixins.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Common mixins for header processors.
+
+These mixins provide reusable behavior for:
+
+* Line-comment based processors (e.g., Pound/Slash) via [`LineCommentMixin`][].
+* Positional, tag- or prolog-sensitive processors (e.g., XML/HTML) via
+  [`XmlPositionalMixin`][].
+* Shebang-aware insertion rules via [`ShebangAwareMixin`][].
+
+They **do not** change public behavior on their own. Processors can adopt these
+mixins to share well-tested logic and reduce duplication.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final, Sequence
+
+_RE_SHEBANG: Final[re.Pattern[str]] = re.compile(r"^#!")
+_RE_XML_DECL: Final[re.Pattern[str]] = re.compile(r"^\s*<\?xml\b", re.IGNORECASE)
+_RE_DOCDECL: Final[re.Pattern[str]] = re.compile(r"^\s*<!DOCTYPE\b", re.IGNORECASE)
+_RE_HTML_COMMENT_OPEN: Final[re.Pattern[str]] = re.compile(r"^\s*<!--")
+_RE_BOM: Final[str] = "\ufeff"
+
+
+class ShebangAwareMixin:
+    """Utilities to skip shebang lines when inserting headers.
+
+    Notes:
+        These helpers operate on line-oriented content. Processors that manage
+        character offsets should translate as needed (e.g., `splitlines(True)`).
+    """
+
+    def _skip_shebang(self, lines: Sequence[str]) -> int:
+        """Return the insertion start index after an optional shebang.
+
+        BOM handling is performed upstream in the reader step; this mixin does not
+        attempt to normalize or validate BOM+shebang combinations.
+        """
+        i = 0
+        if lines and _RE_SHEBANG.match(lines[0] or ""):
+            i = 1
+        return i
+
+
+class LineCommentMixin(ShebangAwareMixin):
+    """Shared helpers for line-comment based processors.
+
+    Processors should define:
+        * ``line_prefix``: the comment introducer for a header line (e.g., ``# ``).
+        * ``line_suffix`` (optional): trailing comment portion to append (e.g., `` */``).
+
+    Methods here centralize header line normalization, scanning, and safe
+    insertion point computation (shebang aware).
+    """
+
+    #: Override per concrete processor, e.g., "# ", "// ", "; ", "-- "
+    line_prefix: str = ""
+    #: Optional suffix appended after content (rare for line comments)
+    line_suffix: str = ""
+
+    # ---- Line classification -------------------------------------------------
+
+    def is_header_line(self, line: str) -> bool:
+        """Return True if the line begins with the configured comment prefix."""
+        return bool(self.line_prefix) and line.startswith(self.line_prefix)
+
+    def strip_line_prefix(self, line: str) -> str:
+        """Remove a single leading comment prefix; return original if absent."""
+        if self.is_header_line(line):
+            return line[len(self.line_prefix) :]
+        return line
+
+    def render_header_line(self, payload: str) -> str:
+        """Render a header line with prefix (+ optional suffix).
+
+        The caller is responsible for appending a newline when assembling
+        multiple lines.
+        """
+        if self.line_suffix:
+            return f"{self.line_prefix}{payload}{self.line_suffix}"
+        return f"{self.line_prefix}{payload}"
+
+    # ---- Insertion index helpers --------------------------------------------
+
+    def find_insertion_index(self, lines: Sequence[str]) -> int:
+        """Determine where a header should be inserted for line-comment files.
+
+        Behavior:
+            * If a FileTypeHeaderPolicy is attached to this processor's file type
+              and explicitly sets ``supports_shebang=False``, do **not** skip a
+              leading shebang even if present.
+            * Otherwise, skip a leading shebang at line 0.
+            * If the policy declares an ``encoding_line_regex``, and a shebang was
+              skipped, also skip a single encoding line immediately following.
+        """
+        # Default: honor policy when present; otherwise use conservative defaults.
+        policy = getattr(getattr(self, "file_type", None), "header_policy", None)
+
+        # If the policy explicitly disables shebang support, do not skip it.
+        if policy is not None and not getattr(policy, "supports_shebang", False):
+            return 0
+
+        # By default (or if supports_shebang=True), skip a leading shebang.
+        i = self._skip_shebang(lines)
+
+        # If an encoding regex is declared, skip a single encoding line after shebang.
+        enc_re = getattr(policy, "encoding_line_regex", None) if policy is not None else None
+        if i == 1 and enc_re:
+            try:
+                enc_pattern: re.Pattern[str] = re.compile(enc_re)
+                if len(lines) > 1 and enc_pattern.search(lines[1]):
+                    i = 2
+            except re.error:
+                # Invalid encoding regex should not break header insertion.
+                pass
+
+        return i
+
+
+class XmlPositionalMixin:
+    """Helpers for tag-sensitive (positional) processors like XML/HTML.
+
+    This mixin offers small, composable predicates and insertion index logic
+    that respect XML declarations and document type declarations (DOCTYPE).
+    """
+
+    # ---- Prolog / declaration predicates ------------------------------------
+
+    def is_xml_declaration(self, line: str) -> bool:
+        """Return True for an XML declaration line (``<?xml ...?>``)."""
+        return bool(_RE_XML_DECL.match(line))
+
+    def is_doctype_declaration(self, line: str) -> bool:
+        """Return True for a DOCTYPE declaration line."""
+        return bool(_RE_DOCDECL.match(line))
+
+    def is_html_comment_open(self, line: str) -> bool:
+        """Return True if the line opens an HTML/XML comment block."""
+        return bool(_RE_HTML_COMMENT_OPEN.match(line))
+
+    # ---- Insertion index helpers --------------------------------------------
+
+    def find_xml_insertion_index(self, lines: Sequence[str]) -> int:
+        """Return the line index after XML declaration and DOCTYPE (if present).
+
+        This respects (in order):
+            1. BOM on first line,
+            2. optional XML declaration on the (new) first line,
+            3. optional DOCTYPE declaration on the next line.
+        """
+        i = 0
+        if lines and lines[0].startswith(_RE_BOM):
+            i = 1
+        if i < len(lines) and self.is_xml_declaration(lines[i]):
+            i += 1
+        if i < len(lines) and self.is_doctype_declaration(lines[i]):
+            i += 1
+        return i

--- a/src/topmark/pipeline/processors/mixins.py
+++ b/src/topmark/pipeline/processors/mixins.py
@@ -12,10 +12,10 @@
 
 These mixins provide reusable behavior for:
 
-* Line-comment based processors (e.g., Pound/Slash) via [`LineCommentMixin`][].
+* Line-comment based processors (e.g., Pound/Slash) via ``LineCommentMixin``.
 * Positional, tag- or prolog-sensitive processors (e.g., XML/HTML) via
-  [`XmlPositionalMixin`][].
-* Shebang-aware insertion rules via [`ShebangAwareMixin`][].
+  ``XmlPositionalMixin``.
+* Shebang-aware insertion rules via ``ShebangAwareMixin``.
 
 They **do not** change public behavior on their own. Processors can adopt these
 mixins to share well-tested logic and reduce duplication.

--- a/src/topmark/pipeline/processors/mixins.py
+++ b/src/topmark/pipeline/processors/mixins.py
@@ -154,14 +154,13 @@ class XmlPositionalMixin:
     def find_xml_insertion_index(self, lines: Sequence[str]) -> int:
         """Return the line index after XML declaration and DOCTYPE (if present).
 
-        This respects (in order):
-            1. BOM on first line,
-            2. optional XML declaration on the (new) first line,
-            3. optional DOCTYPE declaration on the next line.
+        Notes:
+            BOM handling is performed upstream in the reader step; this helper
+            assumes lines are already normalized. The check is purely line-based
+            and does not attempt to coalesce declaration/content that share a
+            single line (the XML processor's char-offset path covers that case).
         """
         i = 0
-        if lines and lines[0].startswith(_RE_BOM):
-            i = 1
         if i < len(lines) and self.is_xml_declaration(lines[i]):
             i += 1
         if i < len(lines) and self.is_doctype_declaration(lines[i]):

--- a/src/topmark/pipeline/processors/mixins.py
+++ b/src/topmark/pipeline/processors/mixins.py
@@ -128,6 +128,56 @@ class LineCommentMixin(ShebangAwareMixin):
         return i
 
 
+# ---------------------------------------------------------------------------
+# BlockCommentMixin: helpers for block-comment based processors
+# ---------------------------------------------------------------------------
+
+
+class BlockCommentMixin:
+    """Shared helpers for block-comment processors (e.g., CSS/JS C-style).
+
+    Processors should define:
+        * ``block_prefix``: the opening delimiter (e.g., ``/*`` or ``<!--``).
+        * ``block_suffix``: the closing delimiter (e.g., ``*/`` or ``-->``).
+
+    The helpers here are intentionally minimal; they can be expanded as we
+    migrate concrete processors and spot duplication opportunities.
+    """
+
+    block_prefix: str = ""
+    block_suffix: str = ""
+
+    def is_block_prefix(self, line: str) -> bool:
+        """Return True if ``line.strip()`` equals the configured block prefix."""
+        return line.strip() == (self.block_prefix or "")
+
+    def is_block_suffix(self, line: str) -> bool:
+        """Return True if ``line.strip()`` equals the configured block suffix."""
+        return line.strip() == (self.block_suffix or "")
+
+    def render_block_line(self, payload: str) -> str:
+        """Render a content line inside a block (identity for now)."""
+        return payload
+
+    def ensure_block_padding(self, rendered_lines: list[str], *, newline: str) -> list[str]:
+        r"""Ensure the block text ends with a newline.
+
+        Args:
+            rendered_lines (list[str]): Lines that compose the block (including delimiters).
+            newline (str): Newline string to enforce at the end ("\n" or "\r\n").
+
+        Returns:
+            list[str]: Possibly adjusted copy with a trailing newline present.
+        """
+        out: list[str] = list(rendered_lines)
+        if not out:
+            return out
+        last = out[-1]
+        if not (last.endswith("\n") or last.endswith("\r\n")):
+            out[-1] = last + newline
+        return out
+
+
 class XmlPositionalMixin:
     """Helpers for tag-sensitive (positional) processors like XML/HTML.
 

--- a/src/topmark/pipeline/processors/pound.py
+++ b/src/topmark/pipeline/processors/pound.py
@@ -24,6 +24,7 @@ from topmark.filetypes.registry import register_filetype
 from topmark.pipeline.processors.base import (
     HeaderProcessor,
 )
+from topmark.pipeline.processors.mixins import LineCommentMixin
 
 if TYPE_CHECKING:
     from topmark.filetypes.policy import FileTypeHeaderPolicy
@@ -46,17 +47,21 @@ logger: TopmarkLogger = get_logger(__name__)
 @register_filetype("shell")
 @register_filetype("toml")
 @register_filetype("yaml")
-class PoundHeaderProcessor(HeaderProcessor):
-    """Processor for files with pound-prefixed comments.
+class PoundHeaderProcessor(LineCommentMixin, HeaderProcessor):
+    """Header processor for line-comment `#` files (uses LineCommentMixin).
 
     This processor handles files that use `#` for comments, such as Python scripts,
     shell scripts, and Makefiles. It processes the header using the pipeline dispatcher.
+
+    Respects FileTypeHeaderPolicy for shebang and encoding line handling.
     """
 
+    # LineCommentMixin:
+    line_prefix = "#"
+
     def __init__(self) -> None:
-        super().__init__(
-            line_prefix="#",
-        )
+        # Rely on the class attribute for LineCommentMixin; just run base init.
+        super().__init__()
 
     def prepare_header_for_insertion(
         self,

--- a/src/topmark/pipeline/processors/slash.py
+++ b/src/topmark/pipeline/processors/slash.py
@@ -22,6 +22,7 @@ from topmark.config.logging import TopmarkLogger, get_logger
 from topmark.file_resolver import detect_newline
 from topmark.filetypes.registry import register_filetype
 from topmark.pipeline.processors.base import HeaderProcessor
+from topmark.pipeline.processors.mixins import LineCommentMixin
 
 logger: TopmarkLogger = get_logger(__name__)
 
@@ -38,14 +39,18 @@ logger: TopmarkLogger = get_logger(__name__)
 @register_filetype("swift")
 @register_filetype("typescript")
 @register_filetype("vscode-jsonc")
-class SlashHeaderProcessor(HeaderProcessor):
+class SlashHeaderProcessor(LineCommentMixin, HeaderProcessor):
     """Processor for files that accept C-style comments.
 
     We render the header as `//`-prefixed lines. Shebang handling is disabled.
     """
 
+    # LineCommentMixin:
+    line_prefix = "//"
+
     def __init__(self) -> None:
-        super().__init__(line_prefix="//")
+        # Rely on the class attribute for LineCommentMixin; just run base init.
+        super().__init__()
 
     def prepare_header_for_insertion(
         self,

--- a/src/topmark/pipeline/processors/xml.py
+++ b/src/topmark/pipeline/processors/xml.py
@@ -38,14 +38,13 @@ from topmark.pipeline.processors.mixins import XmlPositionalMixin
 class XmlHeaderProcessor(XmlPositionalMixin, HeaderProcessor):
     """Header processor for XML/HTML-like formats (uses XmlPositionalMixin).
 
-    Respects XML declaration and DOCTYPE placement. Text insertion hooks may
-    be used when declarations and content share a line; otherwise falls back
-    to line-based insertion. This class remains policy-aware via the base
-    processor for whitespace and alignment.
+    This processor uses the **character-offset** strategy for placement:
+    `get_header_insertion_index()` returns `NO_LINE_ANCHOR` and
+    `get_header_insertion_char_offset()` computes the insertion offset. The
+    pipeline falls back to line-based insertion only when no offset is returned.
 
-    Supported families include HTML, Markdown (HTML comments), XML and common
-    XML-derived formats, as well as component templates that accept HTML comments
-    (e.g., .vue, .svelte).
+    It still leverages the base processor for rendering, whitespace alignment,
+    and policy-aware behavior where applicable.
     """
 
     def __init__(self) -> None:

--- a/src/topmark/pipeline/processors/xml.py
+++ b/src/topmark/pipeline/processors/xml.py
@@ -23,6 +23,7 @@ from topmark.filetypes.registry import register_filetype
 from topmark.pipeline.processors.base import (
     HeaderProcessor,
 )
+from topmark.pipeline.processors.mixins import XmlPositionalMixin
 
 
 @register_filetype("html")
@@ -34,8 +35,13 @@ from topmark.pipeline.processors.base import (
 @register_filetype("xml")
 @register_filetype("xsl")
 @register_filetype("xslt")
-class XmlHeaderProcessor(HeaderProcessor):
-    """Processor for files with HTML/XML-style block comments (<!-- ... -->).
+class XmlHeaderProcessor(XmlPositionalMixin, HeaderProcessor):
+    """Header processor for XML/HTML-like formats (uses XmlPositionalMixin).
+
+    Respects XML declaration and DOCTYPE placement. Text insertion hooks may
+    be used when declarations and content share a line; otherwise falls back
+    to line-based insertion. This class remains policy-aware via the base
+    processor for whitespace and alignment.
 
     Supported families include HTML, Markdown (HTML comments), XML and common
     XML-derived formats, as well as component templates that accept HTML comments
@@ -48,6 +54,8 @@ class XmlHeaderProcessor(HeaderProcessor):
             block_suffix="-->",
         )
 
+    # XML/HTML processor uses a char-offset insertion strategy;
+    # line-based helper is intentionally not used.
     def get_header_insertion_index(self, file_lines: list[str]) -> int:
         """Not used: return NO_LINE_ANCHOR.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def as_typed_mark(mark: Any) -> Callable[[F], F]:
 mark_integration = as_typed_mark(pytest.mark.integration)
 mark_pipeline = as_typed_mark(pytest.mark.pipeline)
 mark_cli = as_typed_mark(pytest.mark.cli)
+mark_dev_validation = as_typed_mark(pytest.mark.dev_validation)
 
 
 def parametrize(*args: Any, **kwargs: Any) -> Callable[[F], F]:

--- a/tests/filetypes/test_instances_plugins.py
+++ b/tests/filetypes/test_instances_plugins.py
@@ -49,6 +49,6 @@ def test_plugins_are_discovered(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda: SimpleNamespace(select=_select),
     )
     # clear cache
-    get_file_type_registry.cache_clear()  # type: ignore[attr-defined]
+    get_file_type_registry.cache_clear()
     reg: dict[str, FileType] = get_file_type_registry()
     assert "pluggy" in reg

--- a/tests/pipeline/processors/test_anchor_helper.py
+++ b/tests/pipeline/processors/test_anchor_helper.py
@@ -1,0 +1,41 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_anchor_helper.py
+#   file_relpath : tests/pipeline/processors/test_anchor_helper.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Unit tests for the compute_insertion_anchor helper (line-based facade)."""
+
+from __future__ import annotations
+
+from topmark.pipeline.processors.base import NO_LINE_ANCHOR, HeaderProcessor
+
+
+class _FakeLine(HeaderProcessor):
+    """Stub that returns a fixed line index from get_header_insertion_index."""
+
+    def get_header_insertion_index(self, file_lines: list[str]) -> int:  # noqa: D401
+        return 3
+
+
+class _FakeNoLine(HeaderProcessor):
+    """Stub that signals char-offset insertion via NO_LINE_ANCHOR."""
+
+    def get_header_insertion_index(self, file_lines: list[str]) -> int:  # noqa: D401
+        return NO_LINE_ANCHOR
+
+
+def test_compute_insertion_anchor_delegates_default() -> None:
+    """Delegates to get_header_insertion_index (line index)."""
+    p = _FakeLine()
+    assert p.compute_insertion_anchor(["a", "b"]) == 3
+
+
+def test_compute_insertion_anchor_propagates_no_line_anchor() -> None:
+    """Propagates NO_LINE_ANCHOR for char-offset processors."""
+    p = _FakeNoLine()
+    assert p.compute_insertion_anchor(["a"]) == NO_LINE_ANCHOR

--- a/tests/pipeline/processors/test_cblock.py
+++ b/tests/pipeline/processors/test_cblock.py
@@ -162,22 +162,6 @@ def test_cblock_detect_existing_header_without_star_on_directives(tmp_path: Path
 
 
 @mark_pipeline
-def test_cblock_idempotent_reapply_no_diff(tmp_path: Path) -> None:
-    """Re-applying insertion is a no-op for C-block targets (e.g., SCSS)."""
-    f: Path = tmp_path / "idem.scss"
-    f.write_text("$x: 1;\nbody{margin:$x}\n")
-
-    cfg: Config = MutableConfig.from_defaults().freeze()
-
-    ctx1: ProcessingContext = run_insert(f, cfg)
-    with f.open("w", encoding="utf-8", newline="") as fp:
-        fp.write("".join(ctx1.updated_file_lines or []))
-
-    ctx2: ProcessingContext = run_insert(f, cfg)
-    assert (ctx2.updated_file_lines or []) == (ctx1.updated_file_lines or [])
-
-
-@mark_pipeline
 def test_cblock_crlf_preserves_newlines(tmp_path: Path) -> None:
     """Preserve CRLF newlines on Windows-style CSS inputs."""
     f: Path = tmp_path / "win.less"

--- a/tests/pipeline/processors/test_cblock_affixes.py
+++ b/tests/pipeline/processors/test_cblock_affixes.py
@@ -1,0 +1,25 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_cblock_affixes.py
+#   file_relpath : tests/pipeline/processors/test_cblock_affixes.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Verify CBlockHeaderProcessor affixes/indent are honored at runtime."""
+
+from __future__ import annotations
+
+from topmark.pipeline.processors.cblock import CBlockHeaderProcessor
+
+
+def test_cblock_affixes_are_set_via_class_attrs() -> None:
+    """Affixes/indent from class attrs persist after base __init__."""
+    p = CBlockHeaderProcessor()
+    assert p.block_prefix == "/*"
+    assert p.block_suffix == "*/"
+    assert p.line_prefix == "*"
+    assert p.line_suffix == ""
+    assert p.line_indent == "  "

--- a/tests/pipeline/processors/test_idempotency.py
+++ b/tests/pipeline/processors/test_idempotency.py
@@ -1,0 +1,103 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_idempotency.py
+#   file_relpath : tests/pipeline/processors/test_idempotency.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Golden behavior guards: idempotency and whitespace policy invariants."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.pipeline.conftest import run_insert
+from topmark.config import Config, MutableConfig
+from topmark.constants import TOPMARK_END_MARKER
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.pipeline.context import ProcessingContext
+
+
+# Reuse the helper from an existing test module to execute the insert pipeline.
+# This avoids duplicating runner setup logic.
+
+
+@pytest.mark.parametrize(
+    "filename, content",
+    [
+        ("idem.py", "print('hello')\n"),
+        ("script.py", "#!/usr/bin/env python3\n# coding: utf-8\nprint(1)\n"),  # Pound/line-comment
+        ("app.js", "console.log('hi');\n"),  # Slash/line-comment
+        ("main.c", "int main(){return 0;}\n"),  # C-block
+        ("doc.xml", '<?xml version="1.0" encoding="UTF-8"?>\n<root/>\n'),  # XML char-offset
+        ("idem.html", "<html><body>hi</body></html>\n"),
+        ("idem.scss", "$x: 1;\nbody{margin:$x}\n"),
+    ],
+)
+def test_idempotent_double_insert(tmp_path: Path, filename: str, content: str) -> None:
+    """Running the insert pipeline twice should produce identical output."""
+    f: Path = tmp_path / filename
+    f.write_text(content)
+
+    cfg: Config = MutableConfig.from_defaults().freeze()
+
+    # First run inserts a header (if not present yet)
+    ctx1: ProcessingContext = run_insert(f, cfg)
+    lines1: list[str] = ctx1.updated_file_lines or []
+
+    # Write updates to file
+    with f.open("w", encoding="utf-8", newline="") as fp:
+        fp.write("".join(lines1))
+
+    # Second run should be a no-op (idempotent)
+    ctx2: ProcessingContext = run_insert(f, cfg)
+    lines2: list[str] = ctx2.updated_file_lines or []
+
+    assert lines2 == lines1, "Second run must be a no-op (idempotent)"
+    # Header should exist after first insert; guard it lightly
+    assert ctx1.existing_header_range is not None or ctx2.existing_header_range is not None
+
+
+@pytest.mark.parametrize(
+    "filename, content",
+    [
+        ("script.py", "print(1)\n"),  # Pound/line-comment
+        ("app.js", "console.log('hi');\n"),  # Slash/line-comment
+        ("main.c", "int main(){return 0;}\n"),  # C-block
+    ],
+)
+def test_blank_line_after_header_for_line_and_block(
+    tmp_path: Path, filename: str, content: str
+) -> None:
+    """There is exactly one blank line after the inserted header block."""
+    f: Path = tmp_path / filename
+    f.write_text(content)
+
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
+
+    lines: list[str] = ctx.updated_file_lines or []
+
+    # Find the line index of the end-of-header marker (comment-wrapped).
+    end_idx = -1
+    for i, line in enumerate(lines):
+        if TOPMARK_END_MARKER in line:
+            end_idx: int = i
+            break
+
+    assert end_idx >= 0, "inserted header must contain an end marker"
+
+    # Next line should be blank, and the following should be non-blank (if any)
+    if end_idx + 1 < len(lines):
+        assert lines[end_idx + 1].strip() == ""
+    if end_idx + 2 < len(lines):
+        assert lines[end_idx + 2].strip() != ""

--- a/tests/pipeline/processors/test_idempotency.py
+++ b/tests/pipeline/processors/test_idempotency.py
@@ -88,10 +88,10 @@ def test_blank_line_after_header_for_line_and_block(
     lines: list[str] = ctx.updated_file_lines or []
 
     # Find the line index of the end-of-header marker (comment-wrapped).
-    end_idx = -1
+    end_idx: int = -1
     for i, line in enumerate(lines):
         if TOPMARK_END_MARKER in line:
-            end_idx: int = i
+            end_idx = i
             break
 
     assert end_idx >= 0, "inserted header must contain an end marker"

--- a/tests/pipeline/processors/test_mixins.py
+++ b/tests/pipeline/processors/test_mixins.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 from topmark.pipeline.processors.mixins import (
+    BlockCommentMixin,
     LineCommentMixin,
     XmlPositionalMixin,
 )
@@ -133,3 +134,27 @@ def test_line_mixin_skips_encoding_line_after_shebang() -> None:
 
     lines: list[str] = ["#!/usr/bin/env python\n", "# coding: utf-8\n", "print(1)\n"]
     assert p.find_insertion_index(lines) == 2
+
+
+# --- BlockCommentMixin tests ------------------------------------------------
+
+
+class _Block(BlockCommentMixin):
+    block_prefix = "/*"
+    block_suffix = "*/"
+
+
+def test_block_predicates() -> None:
+    """Detect block prefix/suffix by stripped equality."""
+    b = _Block()
+    assert b.is_block_prefix("  /*  ")
+    assert b.is_block_suffix("*/")
+    assert not b.is_block_prefix("<--")
+
+
+def test_block_padding_ensures_trailing_newline() -> None:
+    """Ensure block text ends with a newline."""
+    b = _Block()
+    lines = ["/*", " header ", "*/"]
+    out = b.ensure_block_padding(lines, newline="\n")
+    assert out[-1].endswith("\n")

--- a/tests/pipeline/processors/test_mixins.py
+++ b/tests/pipeline/processors/test_mixins.py
@@ -1,0 +1,136 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_mixins.py
+#   file_relpath : tests/pipeline/processors/test_mixins.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Unit tests for processor mixins (line-based and positional)."""
+
+from __future__ import annotations
+
+from topmark.pipeline.processors.mixins import (
+    LineCommentMixin,
+    XmlPositionalMixin,
+)
+
+
+class _LineProc(LineCommentMixin):
+    line_prefix = "# "
+
+
+def test_line_is_header_line() -> None:
+    """Detect header line by prefix."""
+    p = _LineProc()
+    assert p.is_header_line("# hello")
+    assert not p.is_header_line("hello # world")
+    assert not p.is_header_line("hello")
+
+
+def test_line_strip_prefix() -> None:
+    """Strip only one leading prefix."""
+    p = _LineProc()
+    assert p.strip_line_prefix("# a") == "a"
+    assert p.strip_line_prefix("# # b") == "# b"
+    assert p.strip_line_prefix("raw") == "raw"
+
+
+def test_line_render_header_line() -> None:
+    """Render line with prefix (no suffix by default)."""
+    p = _LineProc()
+    assert p.render_header_line("title") == "# title"
+
+
+def test_shebang_skip_without_bom() -> None:
+    """Insertion index skips shebang only."""
+    p = _LineProc()
+    lines: list[str] = ["#!/usr/bin/env python3", "print(42)"]
+    assert p.find_insertion_index(lines) == 1
+
+
+class _Xml(XmlPositionalMixin):
+    pass
+
+
+def test_xml_insertion_after_decl_and_doctype() -> None:
+    """XML insertion index sits after XML decl and DOCTYPE."""
+    x = _Xml()
+    lines: list[str] = [
+        "<?xml version='1.0' encoding='UTF-8'?>",
+        "<!DOCTYPE note SYSTEM 'Note.dtd'>",
+        "<note>",
+    ]
+    assert x.find_xml_insertion_index(lines) == 2
+
+
+def test_xml_insertion_with_bom_only() -> None:
+    """XML insertion index skips just the BOM when present."""
+    bom = "\ufeff"
+    x = _Xml()
+    lines: list[str] = [bom + "<note>", "<to>Tove</to>"]
+    assert x.find_xml_insertion_index(lines) == 1
+
+
+def test_xml_declaration_predicate() -> None:
+    """Detect XML declaration line."""
+    x = _Xml()
+    assert x.is_xml_declaration("<?xml version='1.0'?>")
+    assert not x.is_xml_declaration("<note>")
+
+
+def test_doctype_predicate() -> None:
+    """Detect DOCTYPE declaration line."""
+    x = _Xml()
+    assert x.is_doctype_declaration("<!DOCTYPE html>")
+    assert not x.is_doctype_declaration("<html>")
+
+
+def test_line_mixin_respects_no_shebang_policy() -> None:
+    """Do not skip shebang when policy.supports_shebang is False."""
+    from topmark.filetypes.base import FileType
+    from topmark.filetypes.policy import FileTypeHeaderPolicy
+    from topmark.pipeline.processors.mixins import LineCommentMixin
+
+    class _P(LineCommentMixin):
+        line_prefix = "# "
+
+    p = _P()
+    p.file_type = FileType(  # type: ignore[attr-defined]
+        name="fake",
+        extensions=[".fake"],
+        filenames=[],
+        patterns=[],
+        description="",
+        header_policy=FileTypeHeaderPolicy(supports_shebang=False),
+    )
+
+    lines: list[str] = ["#!/usr/bin/env fake", "echo hi\n"]
+    assert p.find_insertion_index(lines) == 0
+
+
+def test_line_mixin_skips_encoding_line_after_shebang() -> None:
+    """Skip encoding line after shebang if policy encoding_line_regex is set."""
+    from topmark.filetypes.base import FileType
+    from topmark.filetypes.policy import FileTypeHeaderPolicy
+    from topmark.pipeline.processors.mixins import LineCommentMixin
+
+    class _P(LineCommentMixin):
+        line_prefix = "# "
+
+    p = _P()
+    p.file_type = FileType(  # type: ignore[attr-defined]
+        name="py",
+        extensions=[".py"],
+        filenames=[],
+        patterns=[],
+        description="",
+        header_policy=FileTypeHeaderPolicy(
+            supports_shebang=True, encoding_line_regex=r"coding[:=]\s*([-\w.]+)"
+        ),
+    )
+
+    lines: list[str] = ["#!/usr/bin/env python\n", "# coding: utf-8\n", "print(1)\n"]
+    assert p.find_insertion_index(lines) == 2

--- a/tests/pipeline/processors/test_mixins.py
+++ b/tests/pipeline/processors/test_mixins.py
@@ -66,12 +66,11 @@ def test_xml_insertion_after_decl_and_doctype() -> None:
     assert x.find_xml_insertion_index(lines) == 2
 
 
-def test_xml_insertion_with_bom_only() -> None:
-    """XML insertion index skips just the BOM when present."""
-    bom = "\ufeff"
+def test_xml_insertion_does_not_handle_bom() -> None:
+    """Xml mixin leaves BOM handling to the reader step."""
     x = _Xml()
-    lines: list[str] = [bom + "<note>", "<to>Tove</to>"]
-    assert x.find_xml_insertion_index(lines) == 1
+    lines: list[str] = ["\ufeff<note>", "<to>Tove</to>"]
+    assert x.find_xml_insertion_index(lines) == 0
 
 
 def test_xml_declaration_predicate() -> None:

--- a/tests/pipeline/processors/test_pound.py
+++ b/tests/pipeline/processors/test_pound.py
@@ -730,34 +730,6 @@ def test_pound_crlf_leading_blank_and_banner(tmp_path: Path) -> None:
     assert banner_idx == end_idx + 2
 
 
-@mark_pipeline
-def test_pound_idempotent_reapply_no_diff(tmp_path: Path) -> None:
-    """Idempotency: running insertion twice should not change the file the second time.
-
-    We first insert a header into a file that has none, then write the updated
-    lines back to disk and run insertion again. The second run should produce
-    exactly the same content (no additional changes).
-    """
-    f: Path = tmp_path / "idem.py"
-    f.write_text("print('hello')\n")
-
-    cfg: Config = MutableConfig.from_defaults().freeze()
-
-    # First insertion
-    ctx1: ProcessingContext = run_insert(f, cfg)
-    lines1: list[str] = ctx1.updated_file_lines or []
-
-    # Persist result to disk, preserving exact line endings
-    with f.open("w", encoding="utf-8", newline="") as fp:
-        fp.write("".join(lines1))
-
-    # Second insertion
-    ctx2: ProcessingContext = run_insert(f, cfg)
-    lines2: list[str] = ctx2.updated_file_lines or []
-
-    assert lines2 == lines1, "Second run must be a no-op (idempotent)"
-
-
 # --- strip_header_block: test both with and without span, preserving shebang ---
 @mark_pipeline
 def test_strip_header_block_with_and_without_span_preserves_shebang(tmp_path: Path) -> None:

--- a/tests/pipeline/processors/test_xml.py
+++ b/tests/pipeline/processors/test_xml.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from topmark.pipeline.contracts import Step
+    from topmark.pipeline.processors.base import HeaderProcessor
 
 logger: TopmarkLogger = get_logger(__name__)
 
@@ -434,7 +435,7 @@ def test_xml_strip_header_block_respects_declaration(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    proc: XmlHeaderProcessor | None = get_processor_for_file(f)
+    proc: HeaderProcessor | None = get_processor_for_file(f)
     assert proc is not None
 
     lines: list[str] = f.read_text(encoding="utf-8").splitlines(keepends=True)

--- a/tests/pipeline/processors/test_xml.py
+++ b/tests/pipeline/processors/test_xml.py
@@ -18,6 +18,7 @@ XML declaration.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tests.conftest import mark_pipeline
@@ -193,19 +194,19 @@ def test_vue_top_of_file(tmp_path: Path) -> None:
 
     Uses HTML-style comments for the header block.
     """
-    f = tmp_path / "App.vue"
+    f: Path = tmp_path / "App.vue"
     f.write_text("<template>\n  <div/>\n</template>\n")
 
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
-    sig = expected_block_lines_for(f)
+    lines: list[str] = ctx.updated_file_lines or []
+    sig: BlockSignatures = expected_block_lines_for(f)
     if "block_open" in sig:
         assert find_line(lines, sig["block_open"]) == 0
     assert find_line(lines, sig["start_line"]) == 1
     if "block_close" in sig:
-        close_idx = find_line(lines, sig["block_close"])
+        close_idx: int = find_line(lines, sig["block_close"])
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
@@ -215,19 +216,19 @@ def test_svelte_top_of_file(tmp_path: Path) -> None:
 
     Uses HTML-style comments for the header block.
     """
-    f = tmp_path / "Widget.svelte"
+    f: Path = tmp_path / "Widget.svelte"
     f.write_text("<script>\n  let x = 1;\n</script>\n")
 
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
-    sig = expected_block_lines_for(f)
+    lines: list[str] = ctx.updated_file_lines or []
+    sig: BlockSignatures = expected_block_lines_for(f)
     if "block_open" in sig:
         assert find_line(lines, sig["block_open"]) == 0
     assert find_line(lines, sig["start_line"]) == 1
     if "block_close" in sig:
-        close_idx = find_line(lines, sig["block_close"])
+        close_idx: int = find_line(lines, sig["block_close"])
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
@@ -238,29 +239,29 @@ def test_xml_single_line_declaration(tmp_path: Path) -> None:
     Verifies that char-offset insertion splits the line after the declaration,
     inserts a blank, then the header block.
     """
-    f = tmp_path / "singleline_decl.xml"
+    f: Path = tmp_path / "singleline_decl.xml"
     # No newline between declaration and root element
     f.write_text('<?xml version="1.0"?><root/>\n')
 
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
-    sig = expected_block_lines_for(f)
+    lines: list[str] = ctx.updated_file_lines or []
+    sig: BlockSignatures = expected_block_lines_for(f)
 
     # The first line should end with the XML declaration (we inserted the first newline)
     assert lines[0].lstrip("\ufeff").startswith("<?xml")
 
     # Expect: line 0 = decl, line 1 = blank, line 2 = block open, line 3 = start
     if "block_open" in sig:
-        open_idx = find_line(lines, sig["block_open"])
+        open_idx: int = find_line(lines, sig["block_open"])
         assert open_idx == 2
-    start_idx = find_line(lines, sig["start_line"])
+    start_idx: int = find_line(lines, sig["start_line"])
     assert start_idx == 3
 
     # Ensure a trailing blank after the header block
     if "block_close" in sig:
-        close_idx = find_line(lines, sig["block_close"])
+        close_idx: int = find_line(lines, sig["block_close"])
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
@@ -271,29 +272,29 @@ def test_xml_single_line_decl_and_doctype(tmp_path: Path) -> None:
     Confirms correct splitting and placement when both declaration and DOCTYPE
     precede the root on the same physical line.
     """
-    f = tmp_path / "singleline_decl_doctype.xml"
+    f: Path = tmp_path / "singleline_decl_doctype.xml"
     # XML declaration, DOCTYPE, and root all on a single line
     f.write_text('<?xml version="1.0"?><!DOCTYPE note SYSTEM "Note.dtd"><note/>\n')
 
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
-    sig = expected_block_lines_for(f)
+    lines: list[str] = ctx.updated_file_lines or []
+    sig: BlockSignatures = expected_block_lines_for(f)
 
     # First logical line contains decl+doctype (newline inserted by header placement)
     assert lines[0].lstrip("\ufeff").startswith("<?xml")
 
     # Expect: line 0 = decl+doctype, line 1 = blank, line 2 = block open, line 3 = start
     if "block_open" in sig:
-        open_idx = find_line(lines, sig["block_open"])
+        open_idx: int = find_line(lines, sig["block_open"])
         assert open_idx == 2
-    start_idx = find_line(lines, sig["start_line"])
+    start_idx: int = find_line(lines, sig["start_line"])
     assert start_idx == 3
 
     # Ensure a trailing blank after the header block
     if "block_close" in sig:
-        close_idx = find_line(lines, sig["block_close"])
+        close_idx: int = find_line(lines, sig["block_close"])
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
@@ -304,14 +305,14 @@ def test_html_with_existing_banner_comment(tmp_path: Path) -> None:
     Ensures the TopMark block is inserted first and the previous banner follows
     after the block close.
     """
-    f = tmp_path / "banner.html"
+    f: Path = tmp_path / "banner.html"
     f.write_text("<!-- existing:license banner -->\n<html></html>\n")
 
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
-    sig = expected_block_lines_for(f)
+    lines: list[str] = ctx.updated_file_lines or []
+    sig: BlockSignatures = expected_block_lines_for(f)
 
     # Header must start at very top
     if "block_open" in sig:
@@ -320,10 +321,10 @@ def test_html_with_existing_banner_comment(tmp_path: Path) -> None:
 
     # The pre-existing banner should appear after the TopMark header block
     if "block_close" in sig:
-        close_idx = find_line(lines, sig["block_close"])
+        close_idx: int = find_line(lines, sig["block_close"])
         assert close_idx + 1 < len(lines)
         # First non-TopMark comment line should be the banner
-        banner_idx = find_line(lines, "<!-- existing:license banner -->")
+        banner_idx: int = find_line(lines, "<!-- existing:license banner -->")
         assert banner_idx > close_idx
 
 
@@ -334,22 +335,22 @@ def test_markdown_with_existing_banner_comment(tmp_path: Path) -> None:
     Confirms block placement and ordering of the prior banner comment after the
     TopMark header.
     """
-    f = tmp_path / "BANNER.md"
+    f: Path = tmp_path / "BANNER.md"
     f.write_text("<!-- md:banner -->\n# Title\n\n")
 
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
-    sig = expected_block_lines_for(f)
+    lines: list[str] = ctx.updated_file_lines or []
+    sig: BlockSignatures = expected_block_lines_for(f)
 
     if "block_open" in sig:
         assert find_line(lines, sig["block_open"]) == 0
     assert find_line(lines, sig["start_line"]) == 1
 
     if "block_close" in sig:
-        close_idx = find_line(lines, sig["block_close"])
-        banner_idx = find_line(lines, "<!-- md:banner -->")
+        close_idx: int = find_line(lines, sig["block_close"])
+        banner_idx: int = find_line(lines, "<!-- md:banner -->")
         assert banner_idx > close_idx
 
 
@@ -360,14 +361,14 @@ def test_xml_decl_then_existing_banner_comment(tmp_path: Path) -> None:
     Validates that the header is anchored after the XML declaration and precedes
     the existing banner comment.
     """
-    f = tmp_path / "doc_with_banner.xml"
+    f: Path = tmp_path / "doc_with_banner.xml"
     f.write_text('<?xml version="1.0"?>\n<!-- xml:banner -->\n<root/>\n')
 
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
-    sig = expected_block_lines_for(f)
+    lines: list[str] = ctx.updated_file_lines or []
+    sig: BlockSignatures = expected_block_lines_for(f)
 
     assert lines[0].lstrip("\ufeff").startswith("<?xml")
     if "block_open" in sig:
@@ -376,8 +377,8 @@ def test_xml_decl_then_existing_banner_comment(tmp_path: Path) -> None:
 
     # Ensure banner comes AFTER the TopMark header block
     if "block_close" in sig:
-        close_idx = find_line(lines, sig["block_close"])
-        banner_idx = find_line(lines, "<!-- xml:banner -->")
+        close_idx: int = find_line(lines, sig["block_close"])
+        banner_idx: int = find_line(lines, "<!-- xml:banner -->")
         assert banner_idx > close_idx
 
 
@@ -388,7 +389,7 @@ def test_xml_decl_doctype_then_existing_banner_comment(tmp_path: Path) -> None:
     Ensures the header is placed after the declaration and DOCTYPE but before the
     banner comment.
     """
-    f = tmp_path / "doc_with_prolog_banner.xml"
+    f: Path = tmp_path / "doc_with_prolog_banner.xml"
     f.write_text(
         '<?xml version="1.0"?>\n'
         '<!DOCTYPE note SYSTEM "Note.dtd">\n'
@@ -396,11 +397,11 @@ def test_xml_decl_doctype_then_existing_banner_comment(tmp_path: Path) -> None:
         "<note/>\n"
     )
 
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
-    sig = expected_block_lines_for(f)
+    lines: list[str] = ctx.updated_file_lines or []
+    sig: BlockSignatures = expected_block_lines_for(f)
 
     assert lines[0].lstrip("\ufeff").startswith("<?xml")
     if "block_open" in sig:
@@ -408,32 +409,9 @@ def test_xml_decl_doctype_then_existing_banner_comment(tmp_path: Path) -> None:
     assert find_line(lines, sig["start_line"]) == 4
 
     if "block_close" in sig:
-        close_idx = find_line(lines, sig["block_close"])
-        banner_idx = find_line(lines, "<!-- xml:prolog-banner -->")
+        close_idx: int = find_line(lines, sig["block_close"])
+        banner_idx: int = find_line(lines, "<!-- xml:prolog-banner -->")
         assert banner_idx > close_idx
-
-
-@mark_pipeline
-def test_xml_idempotent_reapply_no_diff(tmp_path: Path) -> None:
-    """Idempotent re-application for HTML/XML-like files.
-
-    The second run after writing the first output must produce identical content.
-    """
-    f = tmp_path / "idem.html"
-    f.write_text("<html><body>hi</body></html>\n")
-
-    cfg = MutableConfig.from_defaults().freeze()
-
-    ctx1 = run_insert(f, cfg)
-    lines1 = ctx1.updated_file_lines or []
-
-    with f.open("w", encoding="utf-8", newline="") as fp:
-        fp.write("".join(lines1))
-
-    ctx2 = run_insert(f, cfg)
-    lines2 = ctx2.updated_file_lines or []
-
-    assert lines2 == lines1, "Second run must be a no-op (idempotent) for XML/HTML"
 
 
 # --- strip_header_block: test XML declaration is preserved, header is removed ---
@@ -446,7 +424,7 @@ def test_xml_strip_header_block_respects_declaration(tmp_path: Path) -> None:
     """
     from topmark.pipeline.processors import get_processor_for_file
 
-    f = tmp_path / "strip_doc.xml"
+    f: Path = tmp_path / "strip_doc.xml"
     f.write_text(
         '<?xml version="1.0"?>\n'
         f"<!-- {TOPMARK_START_MARKER} -->\n"
@@ -456,18 +434,22 @@ def test_xml_strip_header_block_respects_declaration(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    proc = get_processor_for_file(f)
+    proc: XmlHeaderProcessor | None = get_processor_for_file(f)
     assert proc is not None
 
-    lines = f.read_text(encoding="utf-8").splitlines(keepends=True)
+    lines: list[str] = f.read_text(encoding="utf-8").splitlines(keepends=True)
 
     # 1) With explicit span for the HTML-style comment block
+    new1: list[str] = []
+    span1: tuple[int, int] | None = None
     new1, span1 = proc.strip_header_block(lines=lines, span=(1, 3))
     assert new1[0].lstrip("\ufeff").startswith("<?xml"), "XML declaration must remain"
     assert TOPMARK_START_MARKER not in "".join(new1)
     assert span1 == (1, 3)
 
     # 2) Let the processor detect bounds itself
+    new2: list[str] = []
+    span2: tuple[int, int] | None = None
     new2, span2 = proc.strip_header_block(lines=lines)
     # Declaration must remain identical on the auto-detect path as well
     assert new2[0].lstrip("\ufeff").startswith("<?xml"), "XML declaration must remain (auto-detect)"
@@ -482,14 +464,14 @@ def test_markdown_fenced_code_no_insertion_inside(tmp_path: Path) -> None:
     The header must be placed at the top of the document and the original fenced
     code block must remain intact.
     """
-    f = tmp_path / "FENCE.md"
+    f: Path = tmp_path / "FENCE.md"
     f.write_text(f"```html\n<!-- {TOPMARK_START_MARKER} -->\n```\nReal content\n")
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
 
-    lines = ctx.updated_file_lines or []
+    lines: list[str] = ctx.updated_file_lines or []
     # Header should be at top (before the fenced block) and not inside it
-    sig = expected_block_lines_for(f)
+    sig: BlockSignatures = expected_block_lines_for(f)
     if "block_open" in sig:
         assert find_line(lines, sig["block_open"]) == 0
     assert find_line(lines, sig["start_line"]) == 1
@@ -505,17 +487,17 @@ def test_xml_doctype_with_internal_subset(tmp_path: Path) -> None:
     Confirms header insertion occurs after the declaration and the entirety of the
     multi-line DOCTYPE, followed by a single blank line.
     """
-    f = tmp_path / "subset.xml"
+    f: Path = tmp_path / "subset.xml"
     f.write_text('<?xml version="1.0"?>\n<!DOCTYPE root [\n  <!ELEMENT root EMPTY>\n]>\n<root/>\n')
-    cfg = MutableConfig.from_defaults().freeze()
-    ctx = run_insert(f, cfg)
-    lines = ctx.updated_file_lines or []
+    cfg: Config = MutableConfig.from_defaults().freeze()
+    ctx: ProcessingContext = run_insert(f, cfg)
+    lines: list[str] = ctx.updated_file_lines or []
 
     assert lines[0].lstrip("\ufeff").startswith("<?xml")
 
     # header begins after declaration + doctype + one blank
-    sig = expected_block_lines_for(f)
-    start_idx = find_line(lines, sig["start_line"])
+    sig: BlockSignatures = expected_block_lines_for(f)
+    start_idx: int = find_line(lines, sig["start_line"])
 
     assert start_idx == 5  # decl(0) doctype(1..3) blank(4) start(5)
 
@@ -531,9 +513,9 @@ def test_xml_bom_preserved_text_insert(tmp_path: Path) -> None:
     Args:
         tmp_path (Path): Temporary directory provided by pytest.
     """
-    f = tmp_path / "bom.xml"
+    f: Path = tmp_path / "bom.xml"
     f.write_bytes(b"\xef\xbb\xbf<?xml version='1.0'?>\n<root/>\n")
-    ctx = run_insert(f, MutableConfig.from_defaults().freeze())
+    ctx: ProcessingContext = run_insert(f, MutableConfig.from_defaults().freeze())
 
     assert (ctx.updated_file_lines or [])[0].startswith("\ufeff")
 
@@ -541,7 +523,8 @@ def test_xml_bom_preserved_text_insert(tmp_path: Path) -> None:
 def test_xml_processor_respects_prolog_and_removes_block() -> None:
     """Header block removal while preserving `<?xml ...?>` prolog line."""
     xp = XmlHeaderProcessor()
-    lines = [
+    # TODO use the pipeline instead!
+    lines: list[str] = [
         '<?xml version="1.0"?>\n',
         f"<!-- {TOPMARK_START_MARKER} -->\n",
         "<!-- h -->\n",
@@ -549,9 +532,11 @@ def test_xml_processor_respects_prolog_and_removes_block() -> None:
         "<root/>\n",
     ]
 
+    new: list[str] = []
+    span: tuple[int, int] | None = None
     new, span = xp.strip_header_block(lines=lines, span=(1, 3))
 
-    body = "".join(new)
+    body: str = "".join(new)
 
     assert body.startswith("<?xml")
     assert "<root/>" in body

--- a/tests/pipeline/processors/test_xml_anchor.py
+++ b/tests/pipeline/processors/test_xml_anchor.py
@@ -1,0 +1,22 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_xml_anchor.py
+#   file_relpath : tests/pipeline/processors/test_xml_anchor.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Assert XML processor reports NO_LINE_ANCHOR (char-offset strategy)."""
+
+from __future__ import annotations
+
+from topmark.pipeline.processors.base import NO_LINE_ANCHOR
+from topmark.pipeline.processors.xml import XmlHeaderProcessor
+
+
+def test_xml_processor_reports_no_line_anchor() -> None:
+    """get_header_insertion_index returns NO_LINE_ANCHOR."""
+    p = XmlHeaderProcessor()
+    assert p.get_header_insertion_index(["<xml>"]) == NO_LINE_ANCHOR

--- a/tests/pipeline/test_registry_validation.py
+++ b/tests/pipeline/test_registry_validation.py
@@ -26,10 +26,7 @@ if TYPE_CHECKING:
     from topmark.filetypes.base import FileType
 
 
-# Apply the dev-validation mark to the whole module
-pytestmark = [mark_dev_validation]
-
-
+@mark_dev_validation
 def test_registered_processors_map_to_existing_filetypes() -> None:
     """Every registered processor references an existing FileType."""
     ft_reg: Dict[str, FileType] = get_file_type_registry()
@@ -39,6 +36,7 @@ def test_registered_processors_map_to_existing_filetypes() -> None:
     assert missing == [], f"Processors registered for unknown file types: {missing!r}"
 
 
+@mark_dev_validation
 def test_one_processor_per_filetype() -> None:
     """There is at most one processor registered per file type name."""
     proc_reg: Dict[str, HeaderProcessor] = get_header_processor_registry()
@@ -74,6 +72,7 @@ def test_one_processor_per_filetype() -> None:
         "markdown",
     ],
 )
+@mark_dev_validation
 def test_xml_like_types_report_no_line_anchor(ft_name: str) -> None:
     """XML-like processors indicate char-offset placement via NO_LINE_ANCHOR."""
     proc_reg: Dict[str, HeaderProcessor] = get_header_processor_registry()

--- a/tests/pipeline/test_registry_validation.py
+++ b/tests/pipeline/test_registry_validation.py
@@ -1,0 +1,88 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_registry_validation.py
+#   file_relpath : tests/pipeline/test_registry_validation.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""CI guardrails for processor↔filetype registry integrity and strategy usage."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Type
+
+import pytest
+
+from tests.conftest import mark_dev_validation
+from topmark.filetypes.instances import get_file_type_registry
+from topmark.filetypes.registry import get_header_processor_registry
+from topmark.pipeline.processors.base import NO_LINE_ANCHOR, HeaderProcessor
+from topmark.pipeline.processors.xml import XmlHeaderProcessor
+
+if TYPE_CHECKING:
+    from topmark.filetypes.base import FileType
+
+
+# Apply the dev-validation mark to the whole module
+pytestmark = [mark_dev_validation]
+
+
+def test_registered_processors_map_to_existing_filetypes() -> None:
+    """Every registered processor references an existing FileType."""
+    ft_reg: Dict[str, FileType] = get_file_type_registry()
+    proc_reg: Dict[str, HeaderProcessor] = get_header_processor_registry()
+
+    missing: list[str] = [name for name in proc_reg.keys() if name not in ft_reg]
+    assert missing == [], f"Processors registered for unknown file types: {missing!r}"
+
+
+def test_one_processor_per_filetype() -> None:
+    """There is at most one processor registered per file type name."""
+    proc_reg: Dict[str, HeaderProcessor] = get_header_processor_registry()
+
+    # Keys are type names; duplicates would be impossible by design,
+    # but keep a guard that class names aren’t reused across different types.
+
+    class_by_type: Dict[str, type[HeaderProcessor]] = {
+        ft_name: proc.__class__ for ft_name, proc in proc_reg.items()
+    }
+
+    # Inverse map: class -> [types]
+    by_class: Dict[Type[HeaderProcessor], list[str]] = {}
+    for ft_name, cls in class_by_type.items():
+        by_class.setdefault(cls, []).append(ft_name)
+
+    # Accept that one processor class can serve multiple types (e.g., Slash),
+    # but ensure we don’t accidentally register multiple instances under the same type.
+    assert len(proc_reg) == len(set(proc_reg.keys()))
+
+
+@pytest.mark.parametrize(
+    "ft_name",
+    [
+        "xml",
+        "html",
+        "xhtml",
+        "svg",
+        "xsl",
+        "xslt",
+        "svelte",
+        "vue",
+        "markdown",
+    ],
+)
+def test_xml_like_types_report_no_line_anchor(ft_name: str) -> None:
+    """XML-like processors indicate char-offset placement via NO_LINE_ANCHOR."""
+    proc_reg: Dict[str, HeaderProcessor] = get_header_processor_registry()
+
+    # Some of these types may not be present in every build; skip if unregistered.
+    proc: HeaderProcessor | None = proc_reg.get(ft_name)
+    if proc is None:
+        pytest.skip(f"file type not registered: {ft_name}")
+
+    # If a type is mapped to XmlHeaderProcessor, it must use NO_LINE_ANCHOR.
+    if isinstance(proc, XmlHeaderProcessor):
+        assert proc.get_header_insertion_index(["<root/>"]) == NO_LINE_ANCHOR


### PR DESCRIPTION
## What
- Introduce reusable processor mixins:
  - `LineCommentMixin` (Pound/Slash), `BlockCommentMixin` (C-block), `XmlPositionalMixin` (predicates; XML still uses char-offset).
- Add `compute_insertion_anchor()` façade and route updater through it (no behavior change).
- Fix XML re-apply idempotency by anchoring bounds via char offset → avoid double `<!-- … -->`.
- Tighten typing and micro-perf:
  - `HeaderProcessor.__init__` preserves subclass class attributes unless explicitly overridden.
  - Cache `encoding_line_regex` (compiled once per pattern); mark `NO_LINE_ANCHOR` as `Final[int]`.
- Add dev/CI guardrails:
  - New `TOPMARK_VALIDATE=1` hook validates processor↔filetype mapping and XML char-offset strategy.
  - CI job runs only tests marked `dev_validation`.
- Docs:
  - Placement strategies (line vs char-offset) documented in `base.py` / `xml.py`.
  - `CONTRIBUTING.md` + `docs/ci/dev-validation.md`.

## Why
- Reduces duplication across processors; clarifies insertion strategies.
- Improves maintainability and robustness; prevents regressions (XML double-wrap).
- Provides opt-in developer checks with zero runtime cost for users.

## Tests
- New/updated tests:
  - Guard tests for XML `NO_LINE_ANCHOR` and C-block affixes.
  - Idempotency consolidated + whitespace guard.
  - Registry validation tests (marked `dev_validation`).
- All tests green locally and in CI (including `dev-validation` job).

## CI
- Adds “Dev validation (`TOPMARK_VALIDATE=1`)" job gated on `src/**` PR changes, runs only `-m dev_validation`.

## Breaking changes
- None (behavior preserved except XML re-apply bug fix).

## Notes for reviewers
- Processor files now inherit appropriate mixins; constructors call `super().__init__()` without affix overrides.
- XML processors must continue to return `NO_LINE_ANCHOR` and supply a char offset.