### PR TITLE
chore(api): sync PublicPolicy TypedDict with internal policy options

### DIFF
--- a/src/topmark/api/protocols.py
+++ b/src/topmark/api/protocols.py
@@ -84,12 +84,16 @@ class PublicPolicy(TypedDict, total=False):
     are optional; unspecified options inherit from project/default config.
 
     Keys:
-        add_only: When `True`, allow only **insertion** of missing headers.
-            Updates to existing headers are blocked.
-        update_only: When `True`, allow only **updates** to existing headers.
-            Insertion of missing headers is blocked.
-        allow_header_in_empty_files: Permit inserting a header in an otherwise
-            empty file (e.g., `__init__.py`).
+        add_only: Only add missing headers; do not update existing ones.
+        update_only: Only update existing headers; do not add new ones.
+        allow_header_in_empty_files: Allow inserting headers in empty files (e.g., `__init__.py`).
+        render_empty_header_when_no_fields: Allow inserting empty headers when no fields are
+            defined.
+        allow_reflow: If True, allow reflowing file content when inserting a header. This
+            potentially breaks check/strip idempotence.
+        allow_content_probe: Whether the resolver may consult file contents during file-type
+            detection. True allows content-based probes, False forces name/extension-only
+            resolution.
 
     Notes:
         This is a stable public contract; the internal policy may have additional
@@ -99,7 +103,9 @@ class PublicPolicy(TypedDict, total=False):
     add_only: bool
     update_only: bool
     allow_header_in_empty_files: bool
-    # future: allow_unsafe_insert, allow_strip_on_malformed, etc.
+    render_empty_header_when_no_fields: bool
+    allow_reflow: bool
+    allow_content_probe: bool
 
 
 class PublicPolicyByType(TypedDict, total=False):

--- a/src/topmark/config/machine/payloads.py
+++ b/src/topmark/config/machine/payloads.py
@@ -8,7 +8,6 @@
 #
 # topmark:header:end
 
-
 """Machine-output payload builders for TopMark config commands.
 
 This module contains *pure* helpers that build strongly-typed payload objects

--- a/src/topmark/config/machine/schemas.py
+++ b/src/topmark/config/machine/schemas.py
@@ -8,7 +8,6 @@
 #
 # topmark:header:end
 
-
 """Schema objects for config-related machine output.
 
 This module defines small dataclasses used as the *typed payload layer* for

--- a/src/topmark/config/machine/serializers.py
+++ b/src/topmark/config/machine/serializers.py
@@ -8,7 +8,6 @@
 #
 # topmark:header:end
 
-
 """Serialization helpers for config-related machine output.
 
 This module turns *shaped* config records/envelopes into JSON or NDJSON strings.

--- a/src/topmark/config/policy.py
+++ b/src/topmark/config/policy.py
@@ -63,7 +63,7 @@ class Policy:
         allow_header_in_empty_files: Allow inserting headers in empty files (e.g., `__init__.py`).
         render_empty_header_when_no_fields: Allow inserting empty headers when no fields are
             defined.
-        allow_reflow: If True, allow revlowing file content when inserting a header. This
+        allow_reflow: If True, allow reflowing file content when inserting a header. This
             potentially breaks check/strip idempotence.
         allow_content_probe: Whether the resolver may consult file contents during file-type
             detection. True allows content-based probes, False forces name/extension-only

--- a/src/topmark/pipeline/steps/writer.py
+++ b/src/topmark/pipeline/steps/writer.py
@@ -1,4 +1,3 @@
-# src/topmark/pipeline/steps/writer.py
 # topmark:header:start
 #
 #   project      : TopMark

--- a/src/topmark/registry/registry.py
+++ b/src/topmark/registry/registry.py
@@ -8,7 +8,6 @@
 #
 # topmark:header:end
 
-
 """Public registries for TopMark file types and header processors.
 
 This module exposes structured, read-only oriented registries plus optional


### PR DESCRIPTION
- extend PublicPolicy TypedDict with render_empty_header_when_no_fields, allow_reflow, and allow_content_probe
- simplify PublicPolicy key descriptions for API readability
- clean whitespace and stale comments
- fix typo in Policy docstring