### PR TITLE
fix(pipeline): preserve diff output when pruning pipeline views

### DIFF
--- a/src/topmark/api/commands/pipeline.py
+++ b/src/topmark/api/commands/pipeline.py
@@ -139,6 +139,7 @@ def check(
     run_options: RunOptions = RunOptions(
         apply_changes=apply,
         prune_views=prune_views,
+        keep_diff_view=diff,
     )
 
     api_run: ApiPipelineRun = run_pipeline(
@@ -229,6 +230,7 @@ def strip(
     run_options: RunOptions = RunOptions(
         apply_changes=apply,
         prune_views=prune_views,
+        keep_diff_view=diff,
     )
 
     api_run: ApiPipelineRun = run_pipeline(

--- a/src/topmark/cli/cmd_common.py
+++ b/src/topmark/cli/cmd_common.py
@@ -180,6 +180,7 @@ def build_run_options(
     stdin_mode: bool,
     stdin_filename: str | None,
     prune_views: bool = True,
+    keep_diff_view: bool = False,
 ) -> RunOptions:
     """Build invocation-wide runtime options for a CLI command.
 
@@ -189,6 +190,7 @@ def build_run_options(
         stdin_mode: Whether the command is operating in content-on-STDIN mode.
         stdin_filename: Synthetic file name associated with STDIN content, if any.
         prune_views: If `True`, trim heavy views after the run (keeps summaries). Default: `True`.
+        keep_diff_view: Whether to preserve the diff view.
 
     Returns:
         The execution-only runtime options for the current CLI invocation.
@@ -218,6 +220,7 @@ def build_run_options(
         stdin_mode=stdin_mode,
         stdin_filename=stdin_filename,
         prune_views=prune_views,
+        keep_diff_view=keep_diff_view,
     )
 
     ctx: click.Context | None = click.get_current_context(silent=True)

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -380,6 +380,7 @@ def check_command(
         stdin_mode=plan.stdin_mode,
         stdin_filename=plan.stdin_filename,
         prune_views=prune_views,
+        keep_diff_view=diff,
     )
 
     logger.debug("run options: %s", run_options)

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -367,6 +367,7 @@ def strip_command(
         stdin_mode=plan.stdin_mode,
         stdin_filename=plan.stdin_filename,
         prune_views=prune_views,
+        keep_diff_view=diff,
     )
 
     logger.debug("run options: %s", run_options)

--- a/src/topmark/cli/rendering/unified_diff.py
+++ b/src/topmark/cli/rendering/unified_diff.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 def format_patch_styled(
     *,
     patch: Sequence[str] | str,
-    color: bool,
+    styled: bool,
     show_line_numbers: bool = False,
 ) -> str:
     """Render a styled (optionally colorized) preview of a unified diff.
@@ -55,7 +55,7 @@ def format_patch_styled(
 
     Args:
         patch: A unified diff as either a list/sequence of lines or a single multiline string.
-        color: Whether to emit ANSI-styled output.
+        styled: Whether to emit ANSI-styled output.
         show_line_numbers: Whether to prefix output with line numbers.
 
     Returns:
@@ -70,7 +70,7 @@ def format_patch_styled(
 
     # Resolve stylers once (when `color=False` these resolve to no-ops via style_for_role).
     def styler(role: StyleRole) -> TextStyler:
-        return style_for_role(role, styled=color)
+        return style_for_role(role, styled=styled)
 
     style_meta: TextStyler = styler(StyleRole.DIFF_META)
     style_header: TextStyler = styler(StyleRole.DIFF_HEADER)
@@ -138,7 +138,7 @@ def format_patch_styled(
         # Optional line numbers: style only the gutter.
         if show_line_numbers:
             gutter: str = f"{i:04d}|"
-            if color:
+            if styled:
                 rendered_lines.append(style_line_no(gutter) + rendered)
             else:
                 rendered_lines.append(gutter + content)

--- a/src/topmark/pipeline/engine.py
+++ b/src/topmark/pipeline/engine.py
@@ -210,7 +210,12 @@ def run_steps_for_files(
                 run_options=run_options,
                 policy_registry_override=policy_registry,
             )
-            ctx_obj = runner.run(ctx_obj, pipeline, prune=run_options.prune_views)
+            ctx_obj = runner.run(
+                ctx_obj,
+                pipeline,
+                prune_views=run_options.prune_views,
+                keep_diff_view=run_options.keep_diff_view,
+            )
             results.append(ctx_obj)
         except (FileNotFoundError, PermissionError, IsADirectoryError) as e:
             logger.error("Filesystem error while processing %s: %s", path, e)

--- a/src/topmark/pipeline/runner.py
+++ b/src/topmark/pipeline/runner.py
@@ -32,26 +32,20 @@ if TYPE_CHECKING:
 logger: TopmarkLogger = get_logger(__name__)
 
 
-def trim_views(ctx: ProcessingContext) -> None:
-    """Release heavy in-memory views after the write decision.
-
-    Drops large buffers; retains only summary-friendly data.
-    """
-    ctx.views.release_all()
-
-
 def run(
     ctx: ProcessingContext,
     steps: Sequence[Step[ProcessingContext]],
     *,
-    prune: bool = True,
+    prune_views: bool = True,
+    keep_diff_view: bool = False,
 ) -> ProcessingContext:
     """Execute the pipeline sequentially.
 
     Args:
         ctx: Mutable processing context.
         steps: Ordered sequence of pipeline steps. Each step takes and returns a context.
-        prune: Trim the views at the end of a run to reduce memory usage (default: `True`).
+        prune_views: Trim the views at the end of a run to reduce memory usage (default: `True`).
+        keep_diff_view: Whether to preserve the diff view.
 
     Returns:
         The final processing context after all steps have run.
@@ -59,7 +53,10 @@ def run(
     for step in steps:
         ctx = step(ctx)
 
-    if prune is True:
-        trim_views(ctx)
+    if prune_views is True:
+        # Drops large in-memory buffers from heavy in-memory views;
+        # retains only summary-friendly data.
+        logger.debug("Trimming views; keep_diff_view: %r", keep_diff_view)
+        ctx.views.release_all(keep_diff_view=keep_diff_view)
 
     return ctx

--- a/src/topmark/pipeline/views.py
+++ b/src/topmark/pipeline/views.py
@@ -27,10 +27,17 @@ from typing import TYPE_CHECKING
 from typing import Protocol
 from typing import runtime_checkable
 
+from topmark.core.logging import get_logger
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Mapping
     from collections.abc import Sequence
+
+    from topmark.core.logging import TopmarkLogger
+
+
+logger: TopmarkLogger = get_logger(__name__)
 
 
 @runtime_checkable
@@ -259,8 +266,17 @@ class Views:
     updated: UpdatedView | None = None
     diff: DiffView | None = None
 
-    def release_all(self) -> None:
-        """Release all non-None views safely (idempotent)."""
+    def release_all(
+        self,
+        *,
+        keep_diff_view: bool = False,
+    ) -> None:
+        """Release all non-None views safely (idempotent).
+
+        Args:
+            keep_diff_view: Whether to preserve the diff view.
+        """
+        logger.debug("keep_diff_view: %r", keep_diff_view)
         if self.image:
             self.image.release()
         if self.header:
@@ -271,8 +287,10 @@ class Views:
             self.render.release()
         if self.updated:
             self.updated.release()
-        if self.diff:
+
+        if self.diff and not keep_diff_view:
             self.diff.release()
+
         # HeaderView is intentionally light; no release.
 
     def as_dict(self) -> dict[str, object]:

--- a/src/topmark/presentation/markdown/pipeline.py
+++ b/src/topmark/presentation/markdown/pipeline.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 from topmark.cli.errors import TopmarkCliPipelineError
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
+from topmark.core.logging import get_logger
 from topmark.pipeline.context.policy import effective_would_add_or_update
 from topmark.pipeline.context.policy import effective_would_strip
 from topmark.pipeline.outcomes import Intent
@@ -52,12 +53,15 @@ from topmark.presentation.shared.pipeline import get_file_type_label
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from topmark.core.logging import TopmarkLogger
     from topmark.diagnostic.model import DiagnosticStats
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.hints import Hint
     from topmark.pipeline.outcomes import OutcomeReasonCount
     from topmark.pipeline.views import DiffView
 
+
+logger: TopmarkLogger = get_logger(__name__)
 
 # ---- Hint rendering ----
 
@@ -352,11 +356,15 @@ def _render_per_file_guidance_markdown(
 
         # 5. optional diff block
         if show_diffs:
-            diff: str | None = _render_diff_markdown(ctx.views.diff)
-            if diff:
+            patch: str | None = _render_diff_markdown(
+                ctx.views.diff,
+                keep_diff_view=False,
+            )
+
+            if patch:
                 blocks.append("")
                 blocks.append("```diff")
-                blocks.append(diff.rstrip("\n"))
+                blocks.append(patch.rstrip("\n"))
                 blocks.append("```")
 
         blocks.append("")
@@ -370,25 +378,36 @@ def _render_per_file_guidance_markdown(
 def _render_diff_markdown(
     diff_view: DiffView | None,
     *,
+    keep_diff_view: bool = True,
     show_line_numbers: bool = False,
 ) -> str | None:
     """Render a unified diff as plain Markdown-friendly text.
 
     Args:
         diff_view: Diff view to render.
+        keep_diff_view: Whether to preserve the diff view.
         show_line_numbers: Whether to prepend line numbers.
 
     Returns:
         Rendered diff text, or `None` when no diff is available.
     """
+    logger.debug("diff_view: %r; keep_diff_view: %r", diff_view, keep_diff_view)
     if diff_view is None:
         return None
+
     diff_text: str | None = diff_view.text
     if diff_text:
-        return format_patch_plain(
+        patch: str = format_patch_plain(
             patch=diff_text,
             show_line_numbers=show_line_numbers,
         )
+
+        if not keep_diff_view:
+            # Prune the diff view once the patch has been consumed (rendered)
+            diff_view.release()
+
+        return patch
+
     return None
 
 
@@ -409,15 +428,17 @@ def _render_pipeline_diffs_markdown(
     # Keep Markdown diffs readable and copyable.
     blocks: list[str] = ["## Diffs", ""]
     for ctx in results:
-        diff: str | None = _render_diff_markdown(
+        patch: str | None = _render_diff_markdown(
             ctx.views.diff,
+            keep_diff_view=False,
             show_line_numbers=show_line_numbers,
         )
-        if diff:
+
+        if patch:
             blocks.append(f"### {render_path_display_markdown(ctx)}")
             blocks.append("")
             blocks.append("```diff")
-            blocks.append(diff.rstrip("\n"))
+            blocks.append(patch.rstrip("\n"))
             blocks.append("```")
             blocks.append("")
     if len(blocks) > 2:

--- a/src/topmark/presentation/text/pipeline.py
+++ b/src/topmark/presentation/text/pipeline.py
@@ -39,6 +39,7 @@ from topmark.cli.keys import CliShortOpt
 from topmark.cli.presentation import TextStyler
 from topmark.cli.presentation import style_for_role
 from topmark.cli.rendering.unified_diff import format_patch_styled
+from topmark.core.logging import get_logger
 from topmark.core.presentation import StyleRole
 from topmark.pipeline.context.policy import effective_would_add_or_update
 from topmark.pipeline.context.policy import effective_would_strip
@@ -60,11 +61,15 @@ from topmark.presentation.text.diagnostic import render_diagnostics_text
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from topmark.core.logging import TopmarkLogger
     from topmark.diagnostic.model import DiagnosticStats
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.hints import Hint
     from topmark.pipeline.outcomes import OutcomeReasonCount
     from topmark.pipeline.views import DiffView
+
+
+logger: TopmarkLogger = get_logger(__name__)
 
 
 _HINT_CLUSTER_STYLE_ROLE: Final[dict[str, StyleRole]] = {
@@ -463,6 +468,7 @@ def _render_per_file_guidance_text(
             _render_file_summary_line_text(
                 ctx=ctx,
                 verbosity_level=verbosity_level,
+                styled=styled,
             )
         )
 
@@ -515,18 +521,20 @@ def _render_per_file_guidance_text(
 
         # 5. optional diff block
         if show_diffs:
-            diff: str | None = _render_diff_text(
+            patch: str | None = _render_diff_text(
                 ctx.views.diff,
+                keep_diff_view=False,
                 styled=styled,
             )
-            if diff:
+
+            if patch:
                 parts.append("")
                 parts.append(
                     muted_styler(
                         diff_start_fence,
                     )
                 )
-                parts.append(diff)
+                parts.append(patch)
                 parts.append(
                     muted_styler(
                         diff_end_fence,
@@ -545,6 +553,7 @@ def _render_per_file_guidance_text(
 def _render_diff_text(
     diff_view: DiffView | None,
     *,
+    keep_diff_view: bool = True,
     show_line_numbers: bool = False,
     styled: bool,
 ) -> str | None:
@@ -552,21 +561,31 @@ def _render_diff_text(
 
     Args:
         diff_view: Diff view to render.
+        keep_diff_view: Whether to preserve the diff view.
         show_line_numbers: Whether to prepend line numbers.
         styled: Whether ANSI-capable styling is enabled.
 
     Returns:
         Rendered diff text, or `None` when no diff is available.
     """
+    logger.debug("diff_view: %r; keep_diff_view: %r", diff_view, keep_diff_view)
     if diff_view is None:
         return None
+
     diff_text: str | None = diff_view.text
     if diff_text:
-        return format_patch_styled(
+        patch: str = format_patch_styled(
             patch=diff_text,
-            color=styled,
+            styled=styled,
             show_line_numbers=show_line_numbers,
         )
+
+        if not keep_diff_view:
+            # Prune the diff view once the patch has been consumed (rendered)
+            diff_view.release()
+
+        return patch
+
     return None
 
 
@@ -604,13 +623,15 @@ def _render_pipeline_diffs_text(
     )
 
     for ctx in results:
-        diff: str | None = _render_diff_text(
+        patch: str | None = _render_diff_text(
             ctx.views.diff,
+            keep_diff_view=False,
             styled=styled,
             show_line_numbers=show_line_numbers,
         )
-        if diff:
-            parts.append(diff)
+
+        if patch:
+            parts.append(patch)
 
     parts.append(
         diff_fence_style(

--- a/src/topmark/runtime/model.py
+++ b/src/topmark/runtime/model.py
@@ -52,6 +52,7 @@ class RunOptions:
             when header generation requires a file identity.
         prune_views: Whether heavy views should be trimmed after the run while
             preserving summary-level results.
+        keep_diff_view: Whether to preserve the diff view.
         started_at: Timestamp captured once for the whole run.
     """
 
@@ -61,5 +62,6 @@ class RunOptions:
     stdin_mode: bool = False
     stdin_filename: str | None = None
     prune_views: bool = True
+    keep_diff_view: bool = False
 
     started_at: datetime = field(default_factory=get_utc_now)

--- a/tests/api/test_api_check_and_strip.py
+++ b/tests/api/test_api_check_and_strip.py
@@ -23,6 +23,7 @@ from tests.helpers.api import by_path_outcome
 from tests.helpers.io import read_text
 from topmark import api
 from topmark.api.types import PublicPolicy
+from topmark.core.constants import TOPMARK_START_MARKER
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -134,3 +135,56 @@ def test_strip_apply_removes_headers(
     assert r.written >= 1
     # Header gone
     assert not has_header(read_text(b), proc_py, "\n")
+
+
+# ---- diff tests
+
+
+def test_check_diff_is_available_when_views_are_pruned(
+    repo_py_with_and_without_header: Path,
+) -> None:
+    """API check diff output should survive internal view pruning when requested."""
+    path: Path = repo_py_with_and_without_header / "src" / "without_header.py"
+
+    r: api.RunResult = api.check(
+        [path],
+        apply=False,
+        diff=True,
+        config=None,
+        include_file_types=["python"],
+        prune_views=True,
+    )
+
+    assert len(r.files) == 1
+    diff: str | None = r.files[0].diff
+
+    assert diff is not None
+    assert f"--- {path}" in diff
+    assert f"+++ {path}" in diff
+    assert "@@" in diff
+    assert f"+# {TOPMARK_START_MARKER}" in diff
+
+
+def test_strip_diff_is_available_when_views_are_pruned(
+    repo_py_with_and_without_header: Path,
+) -> None:
+    """API strip diff output should survive internal view pruning when requested."""
+    path: Path = repo_py_with_and_without_header / "src" / "with_header.py"
+
+    r: api.RunResult = api.strip(
+        [path],
+        apply=False,
+        diff=True,
+        config=None,
+        include_file_types=["python"],
+        prune_views=True,
+    )
+
+    assert len(r.files) == 1
+    diff: str | None = r.files[0].diff
+
+    assert diff is not None
+    assert f"--- {path}" in diff
+    assert f"+++ {path}" in diff
+    assert "@@" in diff
+    assert f"-# {TOPMARK_START_MARKER}" in diff

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -41,7 +41,7 @@ def run_cli_in(
     argv: str | Sequence[str] | None,
     *,
     input_text: str | bytes | IO[Any] | None = None,
-    prune: bool = False,
+    prune_views: bool = False,
 ) -> Result:
     """Invoke the CLI with `tmp_path` as the working directory.
 
@@ -56,7 +56,7 @@ def run_cli_in(
         argv: CLI argument vector, e.g. `["--apply", "*.py"]`.
         input_text: Optional standard input to pass to the command.
             This can be a string, bytes, or a file-like object for `--stdin` modes.
-        prune: If `True`, trim heavy views after the run (keeps summaries).
+        prune_views: If `True`, trim heavy views after the run (keeps summaries).
 
     Returns:
         The `click.testing.Result` produced by `click.testing.CliRunner.invoke`.
@@ -76,7 +76,7 @@ def run_cli_in(
             argv,
             input=input_text,
             obj=TopmarkCliState(
-                prune_pipeline_views=prune,
+                prune_pipeline_views=prune_views,
             ),  # inject typed CLI state into Click context (test override)
         )
     finally:
@@ -87,7 +87,7 @@ def run_cli(
     argv: str | Sequence[str] | None,
     *,
     input_text: str | bytes | IO[Any] | None = None,
-    prune: bool = False,
+    prune_views: bool = False,
 ) -> Result:
     """Invoke the CLI without changing the working directory.
 
@@ -103,7 +103,7 @@ def run_cli(
         input_text: Optional standard input to pass
             to the command. This can be a string, bytes, or a file-like object for
             ``--stdin`` modes.
-        prune: If `True`, trim heavy views after the run (keeps summaries).
+        prune_views: If `True`, trim heavy views after the run (keeps summaries).
 
     Returns:
         The `click.testing.Result` produced by `click.testing.CliRunner.invoke`.
@@ -120,7 +120,7 @@ def run_cli(
         argv,
         input=input_text,
         obj=TopmarkCliState(
-            prune_pipeline_views=prune,
+            prune_pipeline_views=prune_views,
         ),  # inject typed CLI state into Click context (test override)
     )
 

--- a/tests/cli/test_diff_output.py
+++ b/tests/cli/test_diff_output.py
@@ -1,0 +1,266 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_diff_output.py
+#   file_relpath : tests/cli/test_diff_output.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""CLI diff-output regression tests for check and strip commands.
+
+These tests verify that `--diff` renders an actual unified diff in both
+per-file and summary output modes. They intentionally exercise the CLI rather
+than only presentation helpers so the selected runtime pipeline, diff view
+lifecycle, report assembly, and output renderer are covered together.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.cli.conftest import assert_WOULD_CHANGE
+from tests.cli.conftest import run_cli_in
+from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
+from topmark.core.constants import TOPMARK_END_MARKER
+from topmark.core.constants import TOPMARK_START_MARKER
+from topmark.core.formats import OutputFormat
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+
+def _write_plain_python_file(tmp_path: Path) -> Path:
+    """Write a Python file without a TopMark header.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        Path to the created file.
+    """
+    path: Path = tmp_path / "example.py"
+    path.write_text('print("hello")\n', encoding="utf-8")
+    return path
+
+
+def _write_markdown_file_with_topmark_header(tmp_path: Path) -> Path:
+    """Write a Markdown file containing a removable TopMark header.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        Path to the created file.
+    """
+    path: Path = tmp_path / "README.md"
+    path.write_text(
+        "\n".join(
+            [
+                "<!--",
+                TOPMARK_START_MARKER,
+                "",
+                "  project   : Example",
+                "  file      : README.md",
+                "  license   : MIT",
+                "",
+                TOPMARK_END_MARKER,
+                "-->",
+                "",
+                "# Example",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _assert_unified_diff_rendered(output: str, *, path_name: str) -> None:
+    """Assert that CLI output contains a unified diff for a file.
+
+    Args:
+        output: Captured CLI output.
+        path_name: Expected file name in diff headers.
+    """
+    assert f"--- {path_name}" in output
+    assert f"+++ {path_name}" in output
+    assert "@@" in output
+
+
+def test_check_diff_text_per_file_output_renders_patch(tmp_path: Path) -> None:
+    """`check --diff` should render a patch in TEXT per-file output."""
+    path: Path = _write_plain_python_file(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RENDER_DIFF,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_WOULD_CHANGE(result)
+    _assert_unified_diff_rendered(result.output, path_name=path.name)
+    assert f"+# {TOPMARK_START_MARKER}" in result.output
+
+
+def test_check_diff_text_summary_output_renders_patch(tmp_path: Path) -> None:
+    """`check --diff --summary` should render a patch in TEXT summary output."""
+    path: Path = _write_plain_python_file(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_WOULD_CHANGE(result)
+    _assert_unified_diff_rendered(result.output, path_name=path.name)
+    assert f"+# {TOPMARK_START_MARKER}" in result.output
+
+
+def test_check_diff_markdown_per_file_output_renders_patch(tmp_path: Path) -> None:
+    """`check --diff --output-format markdown` should render a fenced diff."""
+    path: Path = _write_plain_python_file(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RENDER_DIFF,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_WOULD_CHANGE(result)
+    assert "```diff" in result.output
+    _assert_unified_diff_rendered(result.output, path_name=path.name)
+    assert f"+# {TOPMARK_START_MARKER}" in result.output
+
+
+def test_check_diff_markdown_summary_output_renders_patch(tmp_path: Path) -> None:
+    """Markdown summary output should still render requested check diffs."""
+    path: Path = _write_plain_python_file(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_WOULD_CHANGE(result)
+    assert "## Diffs" in result.output
+    assert "```diff" in result.output
+    _assert_unified_diff_rendered(result.output, path_name=path.name)
+    assert f"+# {TOPMARK_START_MARKER}" in result.output
+
+
+def test_strip_diff_text_per_file_output_renders_patch(tmp_path: Path) -> None:
+    """`strip --diff` should render a patch in TEXT per-file output."""
+    path: Path = _write_markdown_file_with_topmark_header(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.STRIP,
+            CliOpt.RENDER_DIFF,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_WOULD_CHANGE(result)
+    _assert_unified_diff_rendered(result.output, path_name=path.name)
+    assert f"-{TOPMARK_START_MARKER}" in result.output
+    assert "-<!--" in result.output
+
+
+def test_strip_diff_text_summary_output_renders_patch(tmp_path: Path) -> None:
+    """`strip --diff --summary` should render a patch in TEXT summary output."""
+    path: Path = _write_markdown_file_with_topmark_header(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.STRIP,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_WOULD_CHANGE(result)
+    _assert_unified_diff_rendered(result.output, path_name=path.name)
+    assert f"-{TOPMARK_START_MARKER}" in result.output
+    assert "-<!--" in result.output
+
+
+def test_strip_diff_markdown_per_file_output_renders_patch(tmp_path: Path) -> None:
+    """`strip --diff --output-format markdown` should render a fenced diff."""
+    path: Path = _write_markdown_file_with_topmark_header(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.STRIP,
+            CliOpt.RENDER_DIFF,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_WOULD_CHANGE(result)
+    assert "```diff" in result.output
+    _assert_unified_diff_rendered(result.output, path_name=path.name)
+    assert f"-{TOPMARK_START_MARKER}" in result.output
+    assert "-<!--" in result.output
+
+
+def test_strip_diff_markdown_summary_output_renders_patch(tmp_path: Path) -> None:
+    """Markdown summary output should still render requested strip diffs."""
+    path: Path = _write_markdown_file_with_topmark_header(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.STRIP,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_WOULD_CHANGE(result)
+    assert "## Diffs" in result.output
+    assert "```diff" in result.output
+    _assert_unified_diff_rendered(result.output, path_name=path.name)
+    assert f"-{TOPMARK_START_MARKER}" in result.output
+    assert "-<!--" in result.output

--- a/tests/pipeline/test_engine_path_configs.py
+++ b/tests/pipeline/test_engine_path_configs.py
@@ -39,6 +39,17 @@ if TYPE_CHECKING:
     from topmark.config.policy import PolicyRegistry
 
 
+def _fake_runner_run(
+    ctx: Any,
+    pipeline: object,
+    *,
+    prune_views: bool = True,
+    keep_diff_view: bool = False,
+) -> Any:
+    """Faked no-op runner.run()."""
+    return ctx
+
+
 @pytest.mark.pipeline
 def test_run_steps_for_files_uses_path_specific_configs_when_provided(
     tmp_path: Path,
@@ -81,12 +92,9 @@ def test_run_steps_for_files_uses_path_specific_configs_when_provided(
         policy_calls.append(config)
         return {"header_fields": tuple(config.header_fields)}
 
-    def fake_runner_run(ctx: Any, pipeline: object, *, prune: bool = True) -> Any:
-        return ctx
-
     monkeypatch.setattr(engine, "ProcessingContext", FakeProcessingContext)
     monkeypatch.setattr(engine, "make_policy_registry", fake_make_policy_registry)
-    monkeypatch.setattr(engine.runner, "run", fake_runner_run)
+    monkeypatch.setattr(engine.runner, "run", _fake_runner_run)
 
     run_options: RunOptions = RunOptions(apply_changes=False)
 
@@ -153,12 +161,9 @@ def test_run_steps_for_files_falls_back_to_shared_config_without_path_configs(
         policy_calls.append(config)
         return {"header_fields": tuple(config.header_fields)}
 
-    def fake_runner_run(ctx: Any, pipeline: object, *, prune: bool = True) -> Any:
-        return ctx
-
     monkeypatch.setattr(engine, "ProcessingContext", FakeProcessingContext)
     monkeypatch.setattr(engine, "make_policy_registry", fake_make_policy_registry)
-    monkeypatch.setattr(engine.runner, "run", fake_runner_run)
+    monkeypatch.setattr(engine.runner, "run", _fake_runner_run)
 
     run_options: RunOptions = RunOptions(apply_changes=False)
 

--- a/tests/processors/test_cblock.py
+++ b/tests/processors/test_cblock.py
@@ -150,7 +150,7 @@ def test_cblock_detect_existing_header_with_star_prefix(tmp_path: Path) -> None:
     ctx_check = runner.run(
         ctx_check,
         pipeline,
-        prune=False,  # We must inspect ctx_check.views.header
+        prune_views=False,  # We must inspect ctx_check.views.header
     )
 
     assert ctx_check.views.header is not None

--- a/tests/processors/test_pound.py
+++ b/tests/processors/test_pound.py
@@ -123,7 +123,7 @@ def test_pound_processor_detects_existing_header(tmp_path: Path) -> None:
     ctx = runner.run(
         ctx,
         pipeline,
-        prune=False,  # We must inspect ctx_check.views.header
+        prune_views=False,  # We must inspect ctx_check.views.header
     )
 
     assert ctx.file_type and ctx.file_type.local_key == "python"

--- a/tests/processors/test_slash.py
+++ b/tests/processors/test_slash.py
@@ -138,7 +138,7 @@ def test_slash_detect_existing_header(tmp_path: Path) -> None:
     ctx = runner.run(
         ctx,
         pipeline,
-        prune=False,  # We must inspect ctx_check.views.header
+        prune_views=False,  # We must inspect ctx_check.views.header
     )
 
     assert ctx.views.header is not None

--- a/tests/processors/test_slash_indent.py
+++ b/tests/processors/test_slash_indent.py
@@ -116,7 +116,7 @@ def test_jsonc_replace_preserves_pre_prefix_indent(tmp_path: Path) -> None:
     )
 
     pipeline: Sequence[Step[ProcessingContext]] = Pipeline.CHECK_APPLY.steps
-    ctx = runner.run(ctx, pipeline, prune=False)
+    ctx = runner.run(ctx, pipeline, prune_views=False)
 
     out: list[str] = materialize_updated_lines(ctx)
     # Start marker line should still carry the same pre-prefix indent


### PR DESCRIPTION
Preserve computed diff views when `--diff` is requested so `topmark check` and `topmark strip` can render unified diffs after pipeline view pruning.

The fix wires diff-view preservation through CLI and API run options, updates pipeline runner pruning to retain the diff view when requested, and ensures text/Markdown diff renderers consume the patch before releasing the view.

Also renames the runner pruning option from `prune` to `prune_views` for clarity, removes the unused `trim_views()` helper, and adds CLI/API regression coverage for diff output with view pruning enabled.

Closes #52.