### PR TITLE
fix(markdown): render diffs with collision-safe code fences

### DIFF
--- a/src/topmark/presentation/markdown/pipeline.py
+++ b/src/topmark/presentation/markdown/pipeline.py
@@ -44,6 +44,7 @@ from topmark.pipeline.status import WriteStatus
 from topmark.presentation.formatters.unified_diff import format_patch_plain
 from topmark.presentation.markdown.diagnostic import render_diagnostics_markdown
 from topmark.presentation.markdown.utils import markdown_code_span
+from topmark.presentation.markdown.utils import render_fenced_code_block_markdown
 from topmark.presentation.markdown.utils import render_markdown_table
 from topmark.presentation.markdown.utils import render_path_display_markdown
 from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
@@ -363,9 +364,12 @@ def _render_per_file_guidance_markdown(
 
             if patch:
                 blocks.append("")
-                blocks.append("```diff")
-                blocks.append(patch.rstrip("\n"))
-                blocks.append("```")
+                blocks.append(
+                    render_fenced_code_block_markdown(
+                        text=patch.rstrip("\n"),
+                        language="diff",
+                    )
+                )
 
         blocks.append("")
 
@@ -437,9 +441,12 @@ def _render_pipeline_diffs_markdown(
         if patch:
             blocks.append(f"### {render_path_display_markdown(ctx)}")
             blocks.append("")
-            blocks.append("```diff")
-            blocks.append(patch.rstrip("\n"))
-            blocks.append("```")
+            blocks.append(
+                render_fenced_code_block_markdown(
+                    text=patch.rstrip("\n"),
+                    language="diff",
+                )
+            )
             blocks.append("")
     if len(blocks) > 2:
         blocks.append("")

--- a/src/topmark/presentation/markdown/utils.py
+++ b/src/topmark/presentation/markdown/utils.py
@@ -75,6 +75,34 @@ def markdown_escape(text: str) -> str:
     return f"{fence}{padding}{text}{padding}{fence}"
 
 
+def render_fenced_code_block_markdown(
+    *,
+    text: str,
+    language: str | None = None,
+) -> str:
+    """Render a Markdown fenced code block using a collision-safe fence.
+
+    Args:
+        text: Code block content.
+        language: Optional Markdown language identifier.
+
+    Returns:
+        Markdown fenced code block.
+    """
+    backtick_matches: list[str] = re.findall(r"`{3,}", text)
+    fence_len: int = max([len(match) for match in backtick_matches] + [2]) + 1
+    fence: str = "`" * fence_len
+    opening: str = f"{fence}{language or ''}"
+
+    return "\n".join(
+        [
+            opening,
+            text.rstrip("\n"),
+            fence,
+        ]
+    )
+
+
 def render_markdown_table(
     headers: Sequence[str],
     rows: Sequence[Sequence[str]],

--- a/tests/presentation/test_diff_render.py
+++ b/tests/presentation/test_diff_render.py
@@ -15,7 +15,10 @@ Covers `render_patch` inputs and output type guarantees.
 
 from __future__ import annotations
 
+import textwrap
+
 from topmark.presentation.formatters.unified_diff import format_patch_plain
+from topmark.presentation.markdown.utils import render_fenced_code_block_markdown
 
 
 def test_render_patch_accepts_str_and_list() -> None:
@@ -38,3 +41,67 @@ def test_render_patch_empty_input_is_safe() -> None:
         patch="",
     )
     assert isinstance(s, str)
+
+
+def test_render_fenced_code_block_markdown_uses_diff_language() -> None:
+    """Markdown diff blocks should include the requested language marker."""
+    patch: str = textwrap.dedent("""\
+        --- a
+        +++ b
+        -foo
+        +bar
+        """)
+    rendered: str = render_fenced_code_block_markdown(
+        text=patch,
+        language="diff",
+    )
+
+    assert rendered.startswith("```diff\n")
+    assert rendered.endswith("\n```")
+    assert "-foo" in rendered
+    assert "+bar" in rendered
+
+
+def test_render_fenced_code_block_markdown_avoids_backtick_collision() -> None:
+    """Markdown fences should be longer than any backtick run in diff content."""
+    patch: str = textwrap.dedent("""\
+        --- README.md
+        +++ README.md
+        +```python
+        +print("hello")
+        +```
+        """)
+    rendered: str = render_fenced_code_block_markdown(
+        text=patch,
+        language="diff",
+    )
+
+    lines: list[str] = rendered.splitlines()
+
+    assert lines[0] == "````diff"
+    assert lines[-1] == "````"
+    assert "+```python" in rendered
+    assert "+```" in rendered
+
+
+def test_render_fenced_code_block_markdown_handles_longer_backtick_runs() -> None:
+    """Markdown fences should grow beyond longer nested code fences."""
+    patch: str = textwrap.dedent("""\
+        --- docs/example.md
+        +++ docs/example.md
+        +````markdown
+        +```python
+        +pass
+        +```
+        +````
+        """)
+    rendered: str = render_fenced_code_block_markdown(
+        text=patch,
+        language="diff",
+    )
+
+    lines: list[str] = rendered.splitlines()
+
+    assert lines[0] == "`````diff"
+    assert lines[-1] == "`````"
+    assert "+````markdown" in rendered


### PR DESCRIPTION
Render Markdown diff output using dynamically sized fenced code blocks instead of hard-coded triple-backtick fences.

This prevents invalid Markdown when unified diffs contain changed Markdown content with nested code fences.

Adds presentation tests covering normal diff fences, triple-backtick collisions, and longer nested backtick runs.

Closes #56.