### PR TITLE
refactor(cli): replace yachalk with rich presentation backend

### DIFF
--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -79,9 +79,10 @@ Completed stabilization themes:
 - the first stable-line patch-release work fixed concrete post-1.0 correctness issues, including
   diff output preservation with pruned pipeline views and collision-safe Markdown diff fences;
 - in-memory and streaming pipeline support, richer staged diagnostics exposure, registry
-  query/filter commands, schema versioning, Rich / `rich-click` migration, possible command-help
-  documentation generation, Markdown output refactoring, and broader workflow factoring are
-  explicitly deferred beyond 1.0.
+  query/filter commands, schema versioning, `rich-click` migration, possible command-help
+  documentation generation, Markdown output refactoring, and broader workflow factoring remain
+  explicitly deferred beyond 1.0, while the presentation styling backend has now been migrated from
+  `yachalk` to `rich` behind the existing semantic adapter.
 
 After the final 1.0 release, remaining work is no longer broad architectural redesign. It is limited
 to ecosystem observation, downstream compatibility checks, documentation clarifications, stable 1.x
@@ -294,8 +295,8 @@ The remaining work after `1.0.0` is intentionally narrow and governance-oriented
 - preserving documentation and output-contract consistency;
 - monitoring the finalized CI/release metadata and uv-cache ownership model across ongoing workflow
   runs;
-- planning a possible `rich-click` migration and generated command-help documentation workflow;
-- planning a possible replacement of `yachalk` with `rich` in the presentation layer;
+- planning a possible `rich-click` migration and generated command-help documentation workflow now
+  that the presentation layer itself uses `rich` behind the existing semantic styling adapter;
 - planning the streaming pipeline architecture direction initiated while fixing issue #52;
 - and maintaining explicit post-1.0 scope boundaries.
 
@@ -433,13 +434,14 @@ Human output:
 - keeps TEXT as the console-oriented format;
 - keeps Markdown document-oriented;
 - keeps verbosity/quiet behavior TEXT-specific;
-- and keeps semantic styling routed through the current `yachalk`-based presentation layer.
+- and keeps semantic styling routed through the current `rich`-backed presentation adapter.
 
-Rich or `rich-click` migration remains explicitly deferred beyond 1.0 unless a concrete release
-blocker appears. Post-1.0 planning may evaluate replacing `yachalk` with `rich`, adopting
-`rich-click` for command help rendering, auto-generating command help pages instead of fully
-hand-curating `docs/usage/cli.md` and `docs/usage/commands/`, and refactoring Markdown output where
-that naturally follows from a richer presentation backend.
+The `yachalk` replacement has now been completed by routing semantic styling through a `rich`-backed
+presentation adapter while preserving the existing styling roles and output boundaries. Remaining
+post-1.0 presentation planning may evaluate adopting `rich-click` for command help rendering,
+auto-generating command help pages instead of fully hand-curating `docs/usage/cli.md` and
+`docs/usage/commands/`, and refactoring Markdown output only where that naturally follows from a
+richer presentation backend.
 
 Remaining work is limited to compatibility validation, wording consistency, and downstream consumer
 verification.
@@ -450,8 +452,9 @@ Presentation modernization is explicitly post-1.0 work.
 
 Potential future work includes:
 
-- replacing `yachalk` with `rich` while preserving semantic styling roles, `NO_COLOR` behavior,
-  non-TTY behavior, and deterministic test output;
+- maintaining the completed `yachalk` to `rich` migration behind the existing semantic styling
+  adapter while preserving semantic styling roles, `NO_COLOR` behavior, non-TTY behavior, and
+  deterministic test output;
 - adopting `rich-click` for richer command help output while preserving Click-compatible command
   semantics;
 - evaluating whether command help pages can be generated from the CLI instead of fully hand-curating
@@ -666,6 +669,6 @@ terminology stability, and cross-platform installation behavior.
 The stable 1.x maintenance path is now limited to preserving compatibility, validating published
 artifacts after release, monitoring the CI coverage signal, observing the finalized CI/release
 metadata and cache-ownership model across real workflow runs, and applying focused compatibility or
-correctness fixes only. New broad scope, architectural churn, presentation-backend migration,
-streaming pipeline redesign, generated command-help documentation, and output-contract redesign
-remain out of scope unless required by a concrete stable 1.x issue.
+correctness fixes only. New broad scope, architectural churn, `rich-click` adoption, streaming
+pipeline redesign, generated command-help documentation, and output-contract redesign remain out of
+scope unless required by a concrete stable 1.x issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,12 @@ dependencies = [
   "packaging>=25.0,<27.0.0",
   # Git-style pattern matching for file inclusion/exclusion:
   "pathspec>=1.1.0,<1.2.0",
+  # Rich rendering on the terminal (ANSI, Markdown, tables...):
+  "rich>=15.0.0,<16.0.0",
   # TOML configuration file manipulation:
   "tomlkit>=0.15.0,<0.16.0",
   # Add typing extensions and deprecation annotations:
   "typing-extensions>=4.15.0,<5.0.0",
-  # ANSI-colored terminal output:
-  "yachalk>=0.1.8,<0.2.0",
 ]
 
   [project.optional-dependencies]
@@ -136,6 +136,8 @@ dependencies = [
     "pydocstringformatter>=0.7.3,<1.0.0",
     # Extra Markdown extensions:
     "pymdown-extensions>=10.17.1,<11.0.0",
+    # Rich rendering on the terminal (ANSI, Markdown, tables...):
+    "rich>=15.0.0,<16.0.0",
     # Python linter and formatter (formatter used for docs tooling):
     "ruff>=0.14.5,<0.16.0",
     # Add typing extensions and deprecation annotations:

--- a/src/topmark/cli/presentation.py
+++ b/src/topmark/cli/presentation.py
@@ -12,7 +12,7 @@
 
 This module maps backend-agnostic semantic style roles
 ([`StyleRole`][topmark.core.presentation.StyleRole]) to concrete terminal styling callables
-(currently backed by yachalk).
+(currently backed by Rich).
 
 Design goals:
     * Keep all ANSI / terminal styling confined to the CLI layer.
@@ -44,15 +44,17 @@ Example: custom theme with overrides
 ------------------------------------
 
 ```py
-from yachalk import chalk
-from topmark.cli.presentation import Theme, DEFAULT_THEME, style_for_role
+from topmark.cli.presentation import DEFAULT_THEME
+from topmark.cli.presentation import Theme
+from topmark.cli.presentation import rich_styler
+from topmark.cli.presentation import style_for_role
 from topmark.core.presentation import StyleRole
 
 custom_theme = Theme(
     base=DEFAULT_THEME.base,
     overrides={
-        StyleRole.ERROR: chalk.bg_red.white.bold,
-        StyleRole.WARNING: chalk.yellow,
+        StyleRole.ERROR: rich_styler("bold white on red"),
+        StyleRole.WARNING: rich_styler("yellow"),
     },
 )
 
@@ -70,14 +72,14 @@ override dictionaries:
 soft_theme = Theme(
     base=DEFAULT_THEME.base,
     overrides={
-        StyleRole.CHANGED: chalk.cyan,
+        StyleRole.CHANGED: rich_styler("cyan"),
     },
 )
 
 minimal_theme = Theme(
     base=soft_theme.base,
     overrides={
-        StyleRole.ERROR: chalk.red,
+        StyleRole.ERROR: rich_styler("red"),
     },
 )
 ```
@@ -91,14 +93,53 @@ from __future__ import annotations
 from collections.abc import Callable
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Final
 from typing import TypeAlias
 
-from yachalk import chalk
+from rich.console import Console as RichConsole
+from rich.text import Text
 
 from topmark.core.presentation import StyleRole
 
 TextStyler: TypeAlias = Callable[[str], str]
 """Callable which styles a str."""
+
+_RICH_CONSOLE: Final[RichConsole] = RichConsole(
+    color_system="standard",
+    force_terminal=True,
+    legacy_windows=False,
+    no_color=False,
+    soft_wrap=True,
+    width=120,
+)
+
+
+def rich_styler(style: str) -> TextStyler:
+    """Return a `TextStyler` backed by Rich.
+
+    The returned callable preserves the existing TopMark presentation contract:
+    callers pass a plain string and receive a string containing terminal styling
+    sequences. Rich renderables remain confined to this CLI adapter module.
+
+    This helper is intended for programmatic theme definitions and test-specific
+    theme overrides. It is not a user-facing configuration API; serialized theme
+    configuration should be designed separately if TopMark adds configurable
+    palettes in the future.
+
+    Args:
+        style: Rich style expression, such as `"bold red"` or `"cyan dim"`.
+
+    Returns:
+        A callable that renders text using the requested Rich style.
+    """
+
+    def apply_style(text: str) -> str:
+        rich_text = Text(text, style=style)
+        with _RICH_CONSOLE.capture() as capture:
+            _RICH_CONSOLE.print(rich_text, end="")
+        return capture.get()
+
+    return apply_style
 
 
 def no_style_for_role(s: str) -> str:
@@ -108,33 +149,33 @@ def no_style_for_role(s: str) -> str:
 
 DEFAULT_STYLE_ROLE_MAPPING: dict[StyleRole, TextStyler] = {
     # Severities
-    StyleRole.INFO: chalk.blue,
-    StyleRole.WARNING: chalk.yellow_bright,
-    StyleRole.ERROR: chalk.red_bright.bold,
+    StyleRole.INFO: rich_styler("blue"),
+    StyleRole.WARNING: rich_styler("bright_yellow"),
+    StyleRole.ERROR: rich_styler("bold bright_red"),
     # Generic outcomes / states
-    StyleRole.OK: chalk.green,
-    StyleRole.MUTED: chalk.gray,
-    StyleRole.EMPHASIS: chalk.bold,
-    StyleRole.ITALIC: chalk.italic,
+    StyleRole.OK: rich_styler("green"),
+    StyleRole.MUTED: rich_styler("grey50"),
+    StyleRole.EMPHASIS: rich_styler("bold"),
+    StyleRole.ITALIC: rich_styler("italic"),
     # Change semantics
-    StyleRole.UNCHANGED: chalk.green,
-    StyleRole.WOULD_CHANGE: chalk.yellow_bright.bold,
-    StyleRole.CHANGED: chalk.green_bright.bold,
+    StyleRole.UNCHANGED: rich_styler("green"),
+    StyleRole.WOULD_CHANGE: rich_styler("bold bright_yellow"),
+    StyleRole.CHANGED: rich_styler("bold bright_green"),
     # Other common buckets
-    StyleRole.SKIPPED: chalk.blue,
-    StyleRole.UNSUPPORTED: chalk.magenta,
-    StyleRole.BLOCKED_POLICY: chalk.red,
-    StyleRole.PENDING: chalk.gray.italic,
+    StyleRole.SKIPPED: rich_styler("blue"),
+    StyleRole.UNSUPPORTED: rich_styler("magenta"),
+    StyleRole.BLOCKED_POLICY: rich_styler("red"),
+    StyleRole.PENDING: rich_styler("italic grey50"),
     # Unified diffs
-    StyleRole.DIFF_HEADER: chalk.bold.cyan,
-    StyleRole.DIFF_META: chalk.italic.blue,
-    StyleRole.DIFF_ADD: chalk.bold.green,
-    StyleRole.DIFF_DEL: chalk.bold.red,
-    StyleRole.DIFF_LINE_NO: chalk.white.dim,
+    StyleRole.DIFF_HEADER: rich_styler("bold cyan"),
+    StyleRole.DIFF_META: rich_styler("italic blue"),
+    StyleRole.DIFF_ADD: rich_styler("bold green"),
+    StyleRole.DIFF_DEL: rich_styler("bold red"),
+    StyleRole.DIFF_LINE_NO: rich_styler("dim white"),
     # Generic formats
-    StyleRole.HEADING_TITLE: chalk.bold.underline,
-    StyleRole.MARKER_LINE: chalk.cyan.dim,
-    StyleRole.CONFIG_FILE: chalk.cyan,
+    StyleRole.HEADING_TITLE: rich_styler("bold underline"),
+    StyleRole.MARKER_LINE: rich_styler("dim cyan"),
+    StyleRole.CONFIG_FILE: rich_styler("cyan"),
 }
 
 
@@ -147,10 +188,14 @@ class Theme:
     Lookups are performed in this order:
         1) overrides (if provided)
         2) base mapping
-        3) `_noop` fallback
+        3) `no_style_for_role` fallback
 
     This keeps the default styling stable while allowing caller-controlled theming
     (e.g., alternate palettes, accessibility themes, tests).
+
+    Themes intentionally remain immutable, mapping-based value objects. This keeps
+    the semantic styling boundary small, strictly typed, and independent from any
+    future user-facing theme configuration format.
 
     Attributes:
         base: Base mapping from `StyleRole` to a `TextStyler`.
@@ -179,7 +224,7 @@ def style_for_role(
     """Return a string styler for the given semantic `StyleRole`.
 
     This function maps core semantic roles onto concrete terminal styling.
-    It is intentionally CLI-only (depends on `yachalk`).
+    It is intentionally CLI-only and depends on Rich through this adapter module.
 
     Callers should still gate styling themselves when color is disabled and
     fall back to a no-op.
@@ -208,7 +253,7 @@ def maybe_style(
 
     Args:
         text: Input text to render.
-        styler: Callable that applies styling to a string (for example, a `chalk.*` function).
+        styler: Callable that applies styling to a string.
         styled: When False, return `text` unchanged.
 
     Returns:

--- a/src/topmark/cli/rendering/unified_diff.py
+++ b/src/topmark/cli/rendering/unified_diff.py
@@ -10,15 +10,15 @@
 
 r"""Unified diff rendering helpers for CLI (optional ANSI styling).
 
-This module formats unified diffs for human-facing CLI output. It is allowed to
-depend on a styling backend (currently `yachalk`) and provides a single helper
-that can emit either styled or plain output depending on the caller's color
-settings.
+This module formats unified diffs for human-facing CLI output. It uses the
+semantic styling adapter from [topmark.cli.presentation][] and provides a single
+helper that can emit either styled or plain output depending on the caller's
+color settings.
 
 Notes:
     - Control characters such as CR/LF are escaped ("\\r", "\\n") so previews are stable.
-    - For non-ANSI contexts (or when color is disabled), callers can either set
-      `color=False` or use `topmark.utils.diff.format_patch_text`.
+    - For non-ANSI contexts (or when styling is disabled), callers can either set
+      `styled=False` or use `topmark.utils.diff.format_patch_text`.
 """
 
 from __future__ import annotations
@@ -68,7 +68,7 @@ def format_patch_styled(
         # Convert to list to allow multiple passes
         lines = list(patch)
 
-    # Resolve stylers once (when `color=False` these resolve to no-ops via style_for_role).
+    # Resolve stylers once (when `styled=False` these resolve to no-ops via style_for_role).
     def styler(role: StyleRole) -> TextStyler:
         return style_for_role(role, styled=styled)
 

--- a/src/topmark/core/enum_mixins.py
+++ b/src/topmark/core/enum_mixins.py
@@ -23,7 +23,8 @@ Provided:
 
 Design:
     - Keep the functions *pure* and side-effect free.
-    - Avoid bringing UI libraries (e.g. yachalk) into this module.
+    - Avoid bringing presentation/UI libraries (for example Rich or terminal styling
+      adapters) into this module.
     - Prefer functions over overly clever metaclass tricks for type-checker sanity.
 
 Example:

--- a/src/topmark/core/presentation.py
+++ b/src/topmark/core/presentation.py
@@ -13,8 +13,8 @@
 This module defines a small, stable vocabulary of *semantic* style roles and a lightweight enum base
 that can carry such roles.
 
-The key goal is to keep **core** code free of any concrete presentation backend (ANSI, Rich,
-yachalk, etc.) while still allowing it to attach meaningful styling intent to domain concepts.
+The key goal is to keep **core** code free of any concrete presentation backend while still allowing
+it to attach meaningful styling intent to domain concepts.
 
 Core modules should depend only on:
 

--- a/tools/docs/check_docs_hygiene.py
+++ b/tools/docs/check_docs_hygiene.py
@@ -47,10 +47,38 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Final
 
-from yachalk import chalk
+from rich.console import Console as RichConsole
+from rich.text import Text
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+# Rich styling helper for terminal diagnostics
+_RICH_CONSOLE: Final[RichConsole] = RichConsole(
+    color_system="standard",
+    force_terminal=True,
+    legacy_windows=False,
+    no_color=False,
+    soft_wrap=True,
+    width=120,
+)
+
+
+def _style(text: object, style: str) -> str:
+    """Return text rendered with a Rich style for docs-tool diagnostics.
+
+    Args:
+        text: Value to render.
+        style: Rich style expression.
+
+    Returns:
+        Styled terminal string.
+    """
+    rich_text = Text(str(text), style=style)
+    with _RICH_CONSOLE.capture() as capture:
+        _RICH_CONSOLE.print(rich_text, end="")
+    return capture.get()
+
 
 # Default Markdown paths to process.
 # The docs-hygiene scan covers documentation sources recursively and top-level Markdown files.
@@ -238,9 +266,11 @@ class Diagnostic:
             f"{self.path.as_posix()}:{self.line}" if self.line is not None else self.path.as_posix()
         )
         label = (
-            chalk.red.bold("error") if self.severity == "error" else chalk.yellow.bold("warning")
+            _style("error", "bold red")
+            if self.severity == "error"
+            else _style("warning", "bold yellow")
         )
-        return f"{chalk.bold(location)}: {label}: {self.message}"
+        return f"{_style(location, 'bold')}: {label}: {self.message}"
 
 
 def iter_markdown_files(paths: Sequence[str] | None) -> list[Path]:
@@ -959,7 +989,7 @@ def main(
                 if not allow_re or not allow_re.search(url):
                     ln: int = _abs_line(m, docstring=ds, start_lineno=start_lineno)
                     errors.append(
-                        f"{chalk.bold(path)}:{chalk.bold(ln)}: "
+                        f"{_style(path, 'bold')}:{_style(ln, 'bold')}: "
                         f"avoid raw URL in docstring -> {url}"
                         f"  (docstring {start_lineno}-{end_lineno})"
                     )  # Include docstring range for quick context
@@ -982,14 +1012,15 @@ def main(
                 lines: list[str] = []
                 for name, ln in sorted(set(missing)):
                     lines.append(
-                        f"{chalk.bold(path)}:{chalk.bold(ln)}: "
+                        f"{_style(path, 'bold')}:{_style(ln, 'bold')}: "
                         "internal names should be reference-linked: "
                         f"{name}  (docstring {start_lineno}-{end_lineno})\n"
-                        + chalk.italic(
+                        + _style(
                             "\tuse "
-                            + chalk.yellow.bold(f"[`{name}`][]")
+                            + _style(f"[`{name}`][]", "bold yellow")
                             + " or "
-                            + chalk.yellow.bold(f"[Text][{name}]")
+                            + _style(f"[Text][{name}]", "bold yellow"),
+                            "italic",
                         )
                     )  # Show both exact line and encompassing docstring range
 

--- a/uv.lock
+++ b/uv.lock
@@ -599,15 +599,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-resources"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1556,15 +1547,6 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "82.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
-]
-
-[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1675,9 +1657,9 @@ dependencies = [
     { name = "click" },
     { name = "packaging" },
     { name = "pathspec" },
+    { name = "rich" },
     { name = "tomlkit" },
     { name = "typing-extensions" },
-    { name = "yachalk" },
 ]
 
 [package.optional-dependencies]
@@ -1709,6 +1691,7 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pydocstringformatter" },
     { name = "pymdown-extensions" },
+    { name = "rich" },
     { name = "ruff" },
     { name = "typing-extensions" },
 ]
@@ -1751,6 +1734,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.1,<10.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.1.0,<8.0.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.8.0,<4.0.0" },
+    { name = "rich", specifier = ">=15.0.0,<16.0.0" },
+    { name = "rich", marker = "extra == 'docs'", specifier = ">=15.0.0,<16.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.5,<0.16.0" },
     { name = "ruff", marker = "extra == 'docs'", specifier = ">=0.14.5,<0.16.0" },
     { name = "taplo", marker = "extra == 'dev'", specifier = ">=0.9.3,<0.10.0" },
@@ -1759,7 +1744,6 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.15.0,<5.0.0" },
     { name = "typing-extensions", marker = "extra == 'docs'", specifier = ">=4.15.0,<5.0.0" },
     { name = "uv", marker = "extra == 'dev'", specifier = ">=0.5.0,<0.12.0" },
-    { name = "yachalk", specifier = ">=0.1.8,<0.2.0" },
 ]
 provides-extras = ["dev", "docs", "test", "typing"]
 
@@ -1909,19 +1893,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
-]
-
-[[package]]
-name = "yachalk"
-version = "0.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-resources" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/e6/17b8642bc554083ca149f69c6b61a801e81afcbd60bb4aa22783d54322ed/yachalk-0.1.8.tar.gz", hash = "sha256:bb9b52fda52f34679c9b13d4284a8603eacb9da9d6365b870e0a0c8c41ea9382", size = 17079, upload-time = "2025-10-10T15:50:05.887Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/3f/233733fddeaf60920d0e08f94e862b5b178c07740342623d00d02211c16f/yachalk-0.1.8-py3-none-any.whl", hash = "sha256:9667709f53a6121b2b272f1e31a77259b98308b267ce8a8591e26e76a9517fb3", size = 13928, upload-time = "2025-10-10T15:50:05.04Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the CLI styling backend with Rich while preserving TopMark's existing semantic presentation adapter.

- add Rich as the terminal rendering dependency and remove yachalk
- keep StyleRole, Theme, TextStyler, style_for_role(), and maybe_style() as the stable presentation boundary
- add a Rich-backed rich_styler() helper for programmatic theme overrides
- update unified diff rendering docs to refer to the presentation adapter
- keep core presentation modules backend-independent
- migrate docs hygiene diagnostics from yachalk to a local Rich helper
- update the roadmap to mark the yachalk replacement as complete while keeping rich-click, generated help docs, and Markdown refactoring deferred