### PR TITLE
refactor(cli): adopt rich-click for help rendering

### DIFF
--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -79,10 +79,10 @@ Completed stabilization themes:
 - the first stable-line patch-release work fixed concrete post-1.0 correctness issues, including
   diff output preservation with pruned pipeline views and collision-safe Markdown diff fences;
 - in-memory and streaming pipeline support, richer staged diagnostics exposure, registry
-  query/filter commands, schema versioning, `rich-click` migration, possible command-help
-  documentation generation, Markdown output refactoring, and broader workflow factoring remain
-  explicitly deferred beyond 1.0, while the presentation styling backend has now been migrated from
-  `yachalk` to `rich` behind the existing semantic adapter.
+  query/filter commands, schema versioning, possible command-help documentation generation, Markdown
+  output refactoring, and broader workflow factoring remain explicitly deferred beyond 1.0, while
+  the presentation styling backend has now been migrated from `yachalk` to `rich` behind the
+  existing semantic adapter and `rich-click` has been adopted for CLI help rendering.
 
 After the final 1.0 release, remaining work is no longer broad architectural redesign. It is limited
 to ecosystem observation, downstream compatibility checks, documentation clarifications, stable 1.x
@@ -295,8 +295,9 @@ The remaining work after `1.0.0` is intentionally narrow and governance-oriented
 - preserving documentation and output-contract consistency;
 - monitoring the finalized CI/release metadata and uv-cache ownership model across ongoing workflow
   runs;
-- planning a possible `rich-click` migration and generated command-help documentation workflow now
-  that the presentation layer itself uses `rich` behind the existing semantic styling adapter;
+- planning generated command-help documentation and help-layout refinements now that the
+  presentation layer itself uses `rich` behind the existing semantic styling adapter and CLI help
+  uses `rich-click`;
 - planning the streaming pipeline architecture direction initiated while fixing issue #52;
 - and maintaining explicit post-1.0 scope boundaries.
 
@@ -437,11 +438,16 @@ Human output:
 - and keeps semantic styling routed through the current `rich`-backed presentation adapter.
 
 The `yachalk` replacement has now been completed by routing semantic styling through a `rich`-backed
-presentation adapter while preserving the existing styling roles and output boundaries. Remaining
-post-1.0 presentation planning may evaluate adopting `rich-click` for command help rendering,
-auto-generating command help pages instead of fully hand-curating `docs/usage/cli.md` and
-`docs/usage/commands/`, and refactoring Markdown output only where that naturally follows from a
-richer presentation backend.
+presentation adapter while preserving the existing styling roles and output boundaries. The first
+`rich-click` adoption phase has also been completed for CLI help rendering only: command/group help
+uses Rich Click formatting, while Click remains the authoritative runtime, validation, state, and
+context layer. Internal command code continues to prefer `click.get_current_context()`;
+`rich_click.get_current_context()` is intentionally not used.
+
+Remaining post-1.0 presentation planning may evaluate auto-generating command help pages instead of
+fully hand-curating `docs/usage/cli.md` and `docs/usage/commands/`, improving long-option help
+layout, and refactoring Markdown output only where that naturally follows from a richer presentation
+backend.
 
 Remaining work is limited to compatibility validation, wording consistency, and downstream consumer
 verification.
@@ -455,8 +461,10 @@ Potential future work includes:
 - maintaining the completed `yachalk` to `rich` migration behind the existing semantic styling
   adapter while preserving semantic styling roles, `NO_COLOR` behavior, non-TTY behavior, and
   deterministic test output;
-- adopting `rich-click` for richer command help output while preserving Click-compatible command
-  semantics;
+- maintaining the completed first `rich-click` adoption phase for CLI help rendering only while
+  preserving Click-compatible command semantics, validation, state, and context handling;
+- improving help layout for very long option names, aliases, and boolean flag pairs where Rich Click
+  table wrapping remains awkward;
 - evaluating whether command help pages can be generated from the CLI instead of fully hand-curating
   `docs/usage/cli.md` and `docs/usage/commands/`;
 - refactoring Markdown output if the presentation backend changes make the current implementation
@@ -593,8 +601,9 @@ required by a concrete release blocker:
 - [x] verbosity and quiet semantics stabilized
 - [x] warning/error wording reviewed for consistency
 - [x] command-page structure conventions harmonized
-- [x] Rich / `rich-click` migration and generated command-help documentation explicitly deferred
-  beyond 1.0
+- [x] `yachalk` → `rich` migration completed behind the semantic styling adapter
+- [x] initial `rich-click` adoption completed for CLI help rendering
+- [x] generated command-help documentation explicitly deferred beyond 1.0
 
 #### Machine-readable output
 
@@ -669,6 +678,6 @@ terminology stability, and cross-platform installation behavior.
 The stable 1.x maintenance path is now limited to preserving compatibility, validating published
 artifacts after release, monitoring the CI coverage signal, observing the finalized CI/release
 metadata and cache-ownership model across real workflow runs, and applying focused compatibility or
-correctness fixes only. New broad scope, architectural churn, `rich-click` adoption, streaming
-pipeline redesign, generated command-help documentation, and output-contract redesign remain out of
+correctness fixes only. New broad scope, architectural churn, streaming pipeline redesign, generated
+command-help documentation, Markdown-output redesign, and output-contract redesign remain out of
 scope unless required by a concrete stable 1.x issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ dependencies = [
   "pathspec>=1.1.0,<1.2.0",
   # Rich rendering on the terminal (ANSI, Markdown, tables...):
   "rich>=15.0.0,<16.0.0",
+  # Format click help output nicely with rich:
+  "rich-click>=1.9.7,<2.0.0",
   # TOML configuration file manipulation:
   "tomlkit>=0.15.0,<0.16.0",
   # Add typing extensions and deprecation annotations:

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.api.runtime import ensure_config_valid
 from topmark.api.runtime import select_pipeline
@@ -62,6 +63,8 @@ from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
 from topmark.cli.cmd_common import maybe_route_console_to_stderr
 from topmark.cli.emitters.machine import emit_processing_results_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.io import plan_cli_inputs
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
@@ -139,20 +142,28 @@ if TYPE_CHECKING:
 logger: TopmarkLogger = get_logger(__name__)
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.CHECK,
     context_settings=PATH_COMMAND_CONTEXT_SETTINGS,
     help=f"Inspect TopMark headers (dry-run), or add/update them with {CliOpt.APPLY_CHANGES}.",
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Preview which files would change (dry-run)\n"
-        f"  topmark {CliCmd.CHECK} src\n"
-        "  # Apply header updates in place\n"
-        f"  topmark {CliCmd.CHECK} {CliOpt.APPLY_CHANGES} .\n"
-        "  # Restrict check/apply to adding missing headers only\n"
-        f"  topmark {CliCmd.CHECK} "
-        f"{CliOpt.POLICY_HEADER_MUTATION_MODE}={HeaderMutationMode.ADD_ONLY.value} src\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Preview which files would change (dry-run)",
+                command_line=f"topmark {CliCmd.CHECK} src",
+            ),
+            HelpExample(
+                summary="Apply header updates in place",
+                command_line=f"topmark {CliCmd.CHECK} {CliOpt.APPLY_CHANGES} .",
+            ),
+            HelpExample(
+                summary="Restrict check/apply to adding missing headers only",
+                command_line=(
+                    f"topmark {CliCmd.CHECK} "
+                    f"{CliOpt.POLICY_HEADER_MUTATION_MODE}={HeaderMutationMode.ADD_ONLY.value} src"
+                ),
+            ),
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/config.py
+++ b/src/topmark/cli/commands/config.py
@@ -21,31 +21,42 @@ configuration:
 
 from __future__ import annotations
 
-import click
+import rich_click
 
 from topmark.cli.commands.config_check import config_check_command
 from topmark.cli.commands.config_defaults import config_defaults_command
 from topmark.cli.commands.config_dump import config_dump_command
 from topmark.cli.commands.config_init import config_init_command
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
 
 
-@click.group(
+@rich_click.group(
+    cls=rich_click.RichGroup,
     name=CliCmd.CONFIG,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help="Validate, inspect, and scaffold TopMark configuration.",
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Validate the effective runtime configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_CHECK}\n"
-        "  # Print the effective runtime configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP}\n"
-        "  # Print the built-in default configuration reference\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DEFAULTS}\n"
-        "  # Create a starter configuration file for projects\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} > topmark.toml\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Validate the effective runtime configuration",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_CHECK}",
+            ),
+            HelpExample(
+                summary="Print the effective runtime configuration",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP}",
+            ),
+            HelpExample(
+                summary="Print the built-in default configuration reference",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DEFAULTS}",
+            ),
+            HelpExample(
+                summary="Create a starter configuration file for projects",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} > topmark.toml",
+            ),
+        ),
     ),
 )
 def config_command() -> None:

--- a/src/topmark/cli/commands/config_check.py
+++ b/src/topmark/cli/commands/config_check.py
@@ -30,10 +30,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.api.runtime import is_config_valid
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.emitters.machine import emit_config_check_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
@@ -69,7 +72,7 @@ if TYPE_CHECKING:
 logger: TopmarkLogger = get_logger(__name__)
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.CONFIG_CHECK,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help=(
@@ -80,24 +83,31 @@ logger: TopmarkLogger = get_logger(__name__)
         f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}/{OutputFormat.NDJSON.value} "
         "for machine-readable output."
     ),
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Validate the effective runtime configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_CHECK}\n"
-        "  # Fail on warnings (strict mode)\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_CHECK} {CliOpt.STRICT}\n"
-        "  # Emit machine-readable diagnostics\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_CHECK} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "\n"
-        "\b\n"
-        "Notes:\n"
-        "  • Configuration is built from defaults, discovered files, "
-        f"explicit {CliOpt.CONFIG_FILES} files, and CLI overrides.\n"
-        "  • Exit status is non-zero on validation failure "
-        f"(errors, or warnings with {CliOpt.STRICT}).\n"
-        "  • NDJSON emits a sequence of structured records.\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Validate the effective runtime configuration",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_CHECK}",
+            ),
+            HelpExample(
+                summary="Fail on warnings (strict mode)",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_CHECK} {CliOpt.STRICT}",
+            ),
+            HelpExample(
+                summary="Emit machine-readable diagnostics",
+                command_line=(
+                    f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_CHECK} "
+                    f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+        ),
+        notes=(
+            "Configuration is built from defaults, discovered files, "
+            f"explicit {CliOpt.CONFIG_FILES} files, and CLI overrides.",
+            "Exit status is non-zero on validation failure "
+            f"(errors, or warnings with {CliOpt.STRICT}).",
+            "NDJSON emits a sequence of structured records.",
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/config_defaults.py
+++ b/src/topmark/cli/commands/config_defaults.py
@@ -22,9 +22,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.emitters.machine import emit_config_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
@@ -53,7 +56,7 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import MetaPayload
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.CONFIG_DEFAULTS,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help=(
@@ -63,21 +66,31 @@ if TYPE_CHECKING:
         f"Use {CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}/{OutputFormat.NDJSON.value} "
         "for machine-readable output."
     ),
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Print built-in default configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DEFAULTS}\n"
-        "  # Print the built-in default configuration reference for pyproject.toml\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DEFAULTS} {CliOpt.CONFIG_FOR_PYPROJECT}\n"
-        "  # Emit machine-readable configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DEFAULTS} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "\n"
-        "\b\n"
-        "Notes:\n"
-        "  • Human formats render a clean TOML view of defaults (no comments).\n"
-        "  • Machine-readable formats emit a minimal Config snapshot without diagnostics.\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Print built-in default configuration",
+                command_line=(f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DEFAULTS}"),
+            ),
+            HelpExample(
+                summary="Print the built-in default configuration reference for pyproject.toml",
+                command_line=(
+                    f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DEFAULTS} "
+                    f"{CliOpt.CONFIG_FOR_PYPROJECT}"
+                ),
+            ),
+            HelpExample(
+                summary="Emit machine-readable configuration",
+                command_line=(
+                    f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DEFAULTS} "
+                    f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+        ),
+        notes=(
+            "Human formats render a clean TOML view of defaults (no comments).",
+            "Machine-readable formats emit a minimal Config snapshot without diagnostics.",
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/config_dump.py
+++ b/src/topmark/cli/commands/config_dump.py
@@ -29,12 +29,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.cli.cmd_common import build_resolved_toml_sources_and_config_for_plan
 from topmark.cli.cmd_common import build_run_options
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_route_console_to_stderr
 from topmark.cli.emitters.machine import emit_config_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.io import plan_cli_inputs
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
@@ -82,7 +85,7 @@ if TYPE_CHECKING:
 logger: TopmarkLogger = get_logger(__name__)
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.CONFIG_DUMP,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help=(
@@ -92,26 +95,39 @@ logger: TopmarkLogger = get_logger(__name__)
         f"Use {CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}/{OutputFormat.NDJSON.value} "
         "for machine-readable output."
     ),
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Print the effective runtime configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP}\n"
-        "  # Include configuration provenance layers\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP} {CliOpt.SHOW_CONFIG_LAYERS}\n"
-        "  # Read include patterns from STDIN\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP} {CliOpt.INCLUDE_FROM} -\n"
-        "  # Emit machine-readable configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "\n"
-        "\b\n"
-        "Notes:\n"
-        "  • File lists are inputs, not configuration; "
-        "listed paths do not affect this command's output.\n"
-        "  • Pattern sources are configuration and are included in the dump.\n"
-        "  • Human output may include TOML block markers when verbosity is enabled.\n"
-        "  • Machine-readable formats emit a Config snapshot and optional provenance records.\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Print the effective runtime configuration",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP}",
+            ),
+            HelpExample(
+                summary="Include configuration provenance layers",
+                command_line=(
+                    f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP} {CliOpt.SHOW_CONFIG_LAYERS}"
+                ),
+            ),
+            HelpExample(
+                summary="Read include patterns from STDIN",
+                command_line=(
+                    f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP} {CliOpt.INCLUDE_FROM} -"
+                ),
+            ),
+            HelpExample(
+                summary="Emit machine-readable configuration",
+                command_line=(
+                    f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_DUMP} "
+                    f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+        ),
+        notes=(
+            "File lists are inputs, not configuration; "
+            "listed paths do not affect this command's output.",
+            "Pattern sources are configuration and are included in the dump.",
+            "Human output may include TOML block markers when verbosity is enabled.",
+            "Machine-readable formats emit a Config snapshot and optional provenance records.",
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/config_init.py
+++ b/src/topmark/cli/commands/config_init.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.emitters.machine import emit_config_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
@@ -50,7 +53,7 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import MetaPayload
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.CONFIG_INIT,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help=(
@@ -60,24 +63,35 @@ if TYPE_CHECKING:
         f"Use {CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}/{OutputFormat.NDJSON.value} "
         "for machine-readable output."
     ),
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Print a starter topmark.toml configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT}\n"
-        "  # Print a starter pyproject.toml configuration section\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} {CliOpt.CONFIG_FOR_PYPROJECT}\n"
-        "  # Write a starter configuration file\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} > topmark.toml\n"
-        "  # Emit machine-readable configuration\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "\n"
-        "\b\n"
-        "Notes:\n"
-        "  • Human formats use the annotated, commented template bundled with TopMark.\n"
-        "  • Machine-readable formats emit a minimal Config snapshot "
-        "without comments or diagnostics.\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Print a starter topmark.toml configuration",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT}",
+            ),
+            HelpExample(
+                summary="Print a starter pyproject.toml configuration section",
+                command_line=(
+                    f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} {CliOpt.CONFIG_FOR_PYPROJECT}"
+                ),
+            ),
+            HelpExample(
+                summary="Write a starter configuration file",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} > topmark.toml",
+            ),
+            HelpExample(
+                summary="Emit machine-readable configuration",
+                command_line=(
+                    f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} "
+                    f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+        ),
+        notes=(
+            "Human formats use the annotated, commented template bundled with TopMark.",
+            "Machine-readable formats emit a minimal Config snapshot "
+            "without comments or diagnostics.",
+        ),
     ),
 )
 # Common option decorators

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.api.runtime import ensure_config_valid
 from topmark.cli.cmd_common import PreparedCliConfig
@@ -57,6 +58,8 @@ from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
 from topmark.cli.cmd_common import maybe_route_console_to_stderr
 from topmark.cli.emitters.machine import emit_probe_results_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.io import plan_cli_inputs
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
@@ -122,17 +125,21 @@ if TYPE_CHECKING:
 logger: TopmarkLogger = get_logger(__name__)
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.PROBE,
     context_settings=PATH_COMMAND_CONTEXT_SETTINGS,
     help="Probe file type and processor resolution.",
-    epilog=(
-        f"\b\nExamples:\n"
-        f"  # Explain how files resolve to file types and processors\n"
-        f"  topmark {CliCmd.PROBE} src\n"
-        f"\n"
-        f"  # Show candidate scores and match signals\n"
-        f"  topmark {CliCmd.PROBE} README.md -vv\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Explain how files resolve to file types and processors",
+                command_line=f"topmark {CliCmd.PROBE} src",
+            ),
+            HelpExample(
+                summary="Show candidate scores and match signals",
+                command_line=f"topmark {CliCmd.PROBE} README.md -vv",
+            ),
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/registry.py
+++ b/src/topmark/cli/commands/registry.py
@@ -21,11 +21,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import click
+import rich_click
 
 from topmark.cli.commands.registry_bindings import registry_bindings_command
 from topmark.cli.commands.registry_filetypes import registry_filetypes_command
 from topmark.cli.commands.registry_processors import registry_processors_command
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
 from topmark.core.logging import get_logger
@@ -37,19 +39,26 @@ if TYPE_CHECKING:
 logger: TopmarkLogger = get_logger(__name__)
 
 
-@click.group(
+@rich_click.group(
+    cls=rich_click.RichGroup,
     name=CliCmd.REGISTRY,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help="Inspect TopMark registry metadata.",
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Inspect registered file types\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES}\n"
-        "  # Inspect registered header processors\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_PROCESSORS}\n"
-        "  # Inspect file-type-to-processor bindings\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_BINDINGS}\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Inspect registered file types",
+                command_line=f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES}",
+            ),
+            HelpExample(
+                summary="Inspect registered header processors",
+                command_line=f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_PROCESSORS}",
+            ),
+            HelpExample(
+                summary="Inspect file-type-to-processor bindings",
+                command_line=f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_BINDINGS}",
+            ),
+        ),
     ),
 )
 def registry_command() -> None:

--- a/src/topmark/cli/commands/registry_bindings.py
+++ b/src/topmark/cli/commands/registry_bindings.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.emitters.machine import emit_bindings_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
@@ -47,24 +50,34 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import DetailedMetaPayload
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.REGISTRY_BINDINGS,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help="Inspect TopMark file-type-to-processor bindings.",
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Inspect file-type-to-processor bindings\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_BINDINGS}\n"
-        "  # Show extended binding metadata\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_BINDINGS} {CliOpt.SHOW_DETAILS}\n"
-        "  # Emit machine-readable binding metadata\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_BINDINGS} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "\b\n"
-        "Notes:\n"
-        "  • Bindings show which header processor handles each file type.\n"
-        "  • Machine-readable formats emit registry metadata without human formatting.\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Inspect file-type-to-processor bindings",
+                command_line=f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_BINDINGS}",
+            ),
+            HelpExample(
+                summary="Show extended binding metadata",
+                command_line=(
+                    f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_BINDINGS} {CliOpt.SHOW_DETAILS}"
+                ),
+            ),
+            HelpExample(
+                summary="Emit machine-readable binding metadata",
+                command_line=(
+                    f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_BINDINGS} "
+                    f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+        ),
+        notes=(
+            "Bindings show which header processor handles each file type.",
+            "Machine-readable formats emit registry metadata without human formatting.",
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/registry_filetypes.py
+++ b/src/topmark/cli/commands/registry_filetypes.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.emitters.machine import emit_filetypes_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
@@ -46,24 +49,34 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import DetailedMetaPayload
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.REGISTRY_FILETYPES,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help="Inspect registered TopMark file types.",
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Inspect registered file types\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES}\n"
-        "  # Show extended file type metadata\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES} {CliOpt.SHOW_DETAILS}\n"
-        "  # Emit machine-readable file type metadata\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "\b\n"
-        "Notes:\n"
-        "  • Use file type identifiers in configuration filters.\n"
-        "  • Machine-readable formats emit registry metadata without human formatting.\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Inspect registered file types",
+                command_line=f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES}",
+            ),
+            HelpExample(
+                summary="Show extended file type metadata",
+                command_line=(
+                    f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES} {CliOpt.SHOW_DETAILS}"
+                ),
+            ),
+            HelpExample(
+                summary="Emit machine-readable file type metadata",
+                command_line=(
+                    f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES} "
+                    f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+        ),
+        notes=(
+            "Use file type identifiers in configuration filters.",
+            "Machine-readable formats emit registry metadata without human formatting.",
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/registry_processors.py
+++ b/src/topmark/cli/commands/registry_processors.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.emitters.machine import emit_processors_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
@@ -46,24 +49,34 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import DetailedMetaPayload
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.REGISTRY_PROCESSORS,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help="Inspect registered TopMark header processors.",
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Inspect registered header processors\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_PROCESSORS}\n"
-        "  # Show extended processor metadata\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_PROCESSORS} {CliOpt.SHOW_DETAILS}\n"
-        "  # Emit machine-readable processor metadata\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_PROCESSORS} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "\b\n"
-        "Notes:\n"
-        "  • Processors define how TopMark detects and renders headers for file types.\n"
-        "  • Machine-readable formats emit registry metadata without human formatting.\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Inspect registered header processors",
+                command_line=f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_PROCESSORS}",
+            ),
+            HelpExample(
+                summary="Show extended processor metadata",
+                command_line=(
+                    f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_PROCESSORS} {CliOpt.SHOW_DETAILS}"
+                ),
+            ),
+            HelpExample(
+                summary="Emit machine-readable processor metadata",
+                command_line=(
+                    f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_PROCESSORS} "
+                    f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+        ),
+        notes=(
+            "Processors define how TopMark detects and renders headers for file types.",
+            "Machine-readable formats emit registry metadata without human formatting.\n",
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.api.runtime import ensure_config_valid
 from topmark.api.runtime import select_pipeline
@@ -58,6 +59,8 @@ from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
 from topmark.cli.cmd_common import maybe_route_console_to_stderr
 from topmark.cli.emitters.machine import emit_processing_results_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.io import plan_cli_inputs
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
@@ -131,19 +134,23 @@ if TYPE_CHECKING:
 logger: TopmarkLogger = get_logger(__name__)
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.STRIP,
     context_settings=PATH_COMMAND_CONTEXT_SETTINGS,
     help=(
         f"Preview header removal (dry-run), or remove TopMark headers with {CliOpt.APPLY_CHANGES}."
     ),
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Preview which files would change (dry-run)\n"
-        f"  topmark {CliCmd.STRIP} src\n"
-        "  # Remove headers in-place (apply):\n"
-        f"  topmark {CliCmd.STRIP} {CliOpt.APPLY_CHANGES} .\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Preview which files would change (dry-run)",
+                command_line=f"topmark {CliCmd.STRIP} src",
+            ),
+            HelpExample(
+                summary="Remove headers in-place (apply):",
+                command_line=f"topmark {CliCmd.STRIP} {CliOpt.APPLY_CHANGES} .",
+            ),
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/commands/version.py
+++ b/src/topmark/cli/commands/version.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.emitters.machine import emit_machine
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
@@ -48,23 +51,31 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import MetaPayload
 
 
-@click.command(
+@rich_click.command(
     name=CliCmd.VERSION,
     context_settings=GROUP_CONTEXT_SETTINGS,
     help="Print the installed TopMark version.",
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Print the installed TopMark version\n"
-        f"  topmark {CliCmd.VERSION}\n"
-        "  # Print the version in SemVer form when possible\n"
-        f"  topmark {CliCmd.VERSION} {CliOpt.SEMVER_VERSION}\n"
-        "  # Emit machine-readable version metadata\n"
-        f"  topmark {CliCmd.VERSION} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "Notes:\n"
-        "  • Default output uses the installed package version.\n"
-        "  • Machine-readable formats emit structured version metadata.\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Print the installed TopMark version",
+                command_line=f"topmark {CliCmd.VERSION}",
+            ),
+            HelpExample(
+                summary="Print the version in SemVer form when possible",
+                command_line=f"topmark {CliCmd.VERSION} {CliOpt.SEMVER_VERSION}",
+            ),
+            HelpExample(
+                summary="Emit machine-readable version metadata",
+                command_line=(
+                    f"topmark {CliCmd.VERSION} {CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+        ),
+        notes=(
+            "Default output uses the installed package version.",
+            "Machine-readable formats emit structured version metadata.",
+        ),
     ),
 )
 @common_color_options

--- a/src/topmark/cli/help.py
+++ b/src/topmark/cli/help.py
@@ -1,0 +1,81 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : help.py
+#   file_relpath : src/topmark/cli/help.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Shared helpers for Rich Click command help epilogs.
+
+This module builds small Rich renderables used by `rich-click` help output.
+It keeps command epilog formatting consistent while preserving plain Click for
+command execution, context handling, validation, and shell completion.
+
+The helpers are intentionally limited to human-facing command help. They should
+not be used for machine-readable output, runtime reports, or pipeline rendering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class HelpExample:
+    """Command-help example shown in a Rich Click epilog.
+
+    Attributes:
+        summary: Short human-readable explanation of the command.
+        command_line: CLI command line to show below the description.
+    """
+
+    summary: str
+    command_line: str
+
+
+def render_examples_epilog(
+    examples: Sequence[HelpExample],
+    *,
+    notes: Sequence[str] | None = None,
+) -> Text:
+    """Build a styled Rich Click epilog for examples and optional notes.
+
+    Args:
+        examples: Command examples to render in order.
+        notes: Optional note lines rendered after the examples section.
+
+    Returns:
+        A Rich `Text` renderable suitable for use as a `rich-click` command
+        epilog.
+    """
+    epilog = Text()
+
+    if examples:
+        epilog.append("Examples:\n", style="bold")
+        for example in examples:
+            epilog.append("  # ", style="dim")
+            epilog.append(example.summary, style="dim")
+            epilog.append("\n")
+            epilog.append("  ")
+            epilog.append(example.command_line, style="cyan")
+            epilog.append("\n")
+
+    if notes:
+        if examples:
+            epilog.append("\n")
+        epilog.append("Notes:\n", style="bold")
+        for note in notes:
+            epilog.append("  • ", style="dim")
+            epilog.append(note)
+            epilog.append("\n")
+
+    return epilog

--- a/src/topmark/cli/main.py
+++ b/src/topmark/cli/main.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import click
+import rich_click
 
 from topmark.cli.commands.check import check_command
 from topmark.cli.commands.config import config_command
@@ -32,6 +33,8 @@ from topmark.cli.commands.probe import probe_command
 from topmark.cli.commands.registry import registry_command
 from topmark.cli.commands.strip import strip_command
 from topmark.cli.commands.version import version_command
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.options import GROUP_CONTEXT_SETTINGS
@@ -44,27 +47,41 @@ if TYPE_CHECKING:
     from topmark.cli.console.protocols import ConsoleProtocol
 
 
-@click.group(
-    cls=click.Group,
+@rich_click.group(
+    cls=rich_click.RichGroup,
     context_settings=GROUP_CONTEXT_SETTINGS,
     invoke_without_command=True,  # Always invoke the cli() function
     help="Inspect, validate, and manage TopMark headers and configuration.",
-    epilog=(
-        "\b\n"
-        "Examples:\n"
-        "  # Validate headers in a project (dry-run)\n"
-        f"  topmark {CliCmd.CHECK} src\n"
-        "  # Apply header updates in place\n"
-        f"  topmark {CliCmd.CHECK} --apply .\n"
-        "  # Write a starter configuration file\n"
-        f"  topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} > topmark.toml\n"
-        "  # Validate the merged configuration\n"
-        f"  topmark {CliCmd.CONFIG} check\n"
-        "  # Inspect file types (machine-readable output)\n"
-        f"  topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES} "
-        f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}\n"
-        "  # Print the installed TopMark version\n"
-        f"  topmark {CliCmd.VERSION}\n"
+    epilog=render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Validate headers in a project (dry-run)",
+                command_line=f"topmark {CliCmd.CHECK} src",
+            ),
+            HelpExample(
+                summary="Apply header updates in place",
+                command_line=f"topmark {CliCmd.CHECK} --apply .",
+            ),
+            HelpExample(
+                summary="Write a starter configuration file",
+                command_line=f"topmark {CliCmd.CONFIG} {CliCmd.CONFIG_INIT} > topmark.toml",
+            ),
+            HelpExample(
+                summary="Validate the merged configuration",
+                command_line=f"topmark {CliCmd.CONFIG} check",
+            ),
+            HelpExample(
+                summary="Inspect file types (machine-readable output)",
+                command_line=(
+                    f"topmark {CliCmd.REGISTRY} {CliCmd.REGISTRY_FILETYPES} "
+                    f"{CliOpt.OUTPUT_FORMAT}={OutputFormat.JSON.value}"
+                ),
+            ),
+            HelpExample(
+                summary="Print the installed TopMark version",
+                command_line=f"topmark {CliCmd.VERSION}",
+            ),
+        ),
     ),
 )
 @click.pass_context

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -20,11 +20,14 @@ matching TopMark's resolver contract that disallows absolute patterns.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import IO
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Final
 
+import click
 from click.testing import CliRunner
 from click.testing import Result
 
@@ -246,3 +249,109 @@ def assert_FILE_NOT_FOUND(result: Result) -> None:
         result: The Result object returned by `run_cli` or `run_cli_in`.
     """
     assert result.exit_code == ExitCode.FILE_NOT_FOUND, result.output
+
+
+def normalize_rich_cli_output(output: str) -> str:
+    """Normalize Rich-rendered CLI output for semantic substring assertions.
+
+    Rich panels and tables may wrap messages across lines and surround content
+    with border glyphs. Long option names may also soft-wrap after hyphens inside
+    Rich table cells. These tests validate command behavior, not exact terminal
+    layout, so this helper removes panel borders, collapses whitespace, and joins
+    soft-wrapped hyphenated option tokens while preserving the rendered text
+    content.
+    """
+    content_lines: list[str] = []
+    for line in output.splitlines():
+        stripped: str = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(("╭", "╰")):
+            continue
+        if stripped.startswith("│") and stripped.endswith("│"):
+            stripped = stripped[1:-1].strip()
+        elif stripped.startswith("│"):
+            stripped = stripped[1:].strip()
+        content_lines.append(stripped)
+
+    normalized: str = " ".join(" ".join(content_lines).split())
+    return re.sub(r"(?<=-)\s+(?=[A-Za-z0-9])", "", normalized)
+
+
+def assert_rich_output_contains(
+    output: str,
+    *,
+    expected: str,
+) -> None:
+    """Assert text appears in Rich-rendered CLI output.
+
+    The comparison ignores Rich panel borders and line wrapping so tests remain
+    focused on emitted diagnostic content.
+    """
+    normalized_output: str = normalize_rich_cli_output(output)
+    normalized_expected: str = " ".join(expected.split())
+    assert normalized_expected in normalized_output
+
+
+def assert_rich_output_does_not_contain(
+    output: str,
+    *,
+    expected: str,
+) -> None:
+    """Assert text does not appear in Rich-rendered CLI output.
+
+    The comparison ignores Rich panel borders and line wrapping so tests remain
+    focused on emitted diagnostic content.
+    """
+    normalized_output: str = normalize_rich_cli_output(output)
+    normalized_expected: str = " ".join(expected.split())
+    assert normalized_expected not in normalized_output
+
+
+CLICK_USAGE_ERROR_EXIT_CODE: Final[int] = 2
+"""Exit code used by Click for reporting a usage error."""
+
+
+def assert_rich_output_no_such_option(
+    result: Result,
+    *,
+    option_name: str,
+) -> None:
+    """Assert that Rich Click reported an unknown CLI option.
+
+    Click reports parser-level usage errors with exit code 2 before TopMark can
+    normalize them to `ExitCode.USAGE_ERROR`. That numeric code overlaps with
+    `ExitCode.WOULD_CHANGE`, so this helper also asserts the rendered
+    `No such option` diagnostic.
+    """
+    # Click handles the parser error and `CliRunner` captures the resulting
+    # `SystemExit(2)`, not the original `click.NoSuchOption` instance. The
+    # rendered diagnostic disambiguates this parser-level failure from
+    # TopMark's normal `ExitCode.WOULD_CHANGE` outcome, which also uses code 2.
+    assert result.exit_code == CLICK_USAGE_ERROR_EXIT_CODE, result.output
+
+    # Use the message format used by `rich-click`:
+    assert_rich_output_contains(
+        result.output,
+        expected=f"No such option '{option_name}'.",
+    )
+
+
+def command_option_names(command_name: str) -> set[str]:
+    """Return all option declarations exposed by a CLI subcommand.
+
+    Rich Click may wrap long option names inside rendered help tables, so tests
+    that validate option exposure should inspect the Click command model instead
+    of asserting on terminal layout. The helper creates a lightweight Click
+    context explicitly because no global current context exists after
+    `CliRunner.invoke` has returned.
+    """
+    ctx = click.Context(cli, info_name="topmark")
+    command: click.Command | None = cli.get_command(ctx, cmd_name=command_name)
+    assert command is not None
+
+    option_names: set[str] = set()
+    for parameter in command.params:
+        option_names.update(parameter.opts)
+        option_names.update(parameter.secondary_opts)
+    return option_names

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -251,18 +251,24 @@ def assert_FILE_NOT_FOUND(result: Result) -> None:
     assert result.exit_code == ExitCode.FILE_NOT_FOUND, result.output
 
 
+ANSI_ESCAPE_RE: Final[re.Pattern[str]] = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+"""ANSI control-sequence matcher used to normalize Rich-rendered test output."""
+
+
 def normalize_rich_cli_output(output: str) -> str:
     """Normalize Rich-rendered CLI output for semantic substring assertions.
 
-    Rich panels and tables may wrap messages across lines and surround content
-    with border glyphs. Long option names may also soft-wrap after hyphens inside
-    Rich table cells. These tests validate command behavior, not exact terminal
-    layout, so this helper removes panel borders, collapses whitespace, and joins
-    soft-wrapped hyphenated option tokens while preserving the rendered text
-    content.
+    Rich panels and tables may wrap messages across lines, surround content with
+    border glyphs, and emit ANSI control sequences depending on the terminal
+    environment. Long option names may also soft-wrap after hyphens inside Rich
+    table cells. These tests validate command behavior, not exact terminal
+    layout, so this helper removes ANSI sequences and panel borders, collapses
+    whitespace, and joins soft-wrapped hyphenated option tokens while preserving
+    the rendered text content.
     """
+    plain_output: str = ANSI_ESCAPE_RE.sub("", output)
     content_lines: list[str] = []
-    for line in output.splitlines():
+    for line in plain_output.splitlines():
         stripped: str = line.strip()
         if not stripped:
             continue

--- a/tests/cli/machine/test_version_machine.py
+++ b/tests/cli/machine/test_version_machine.py
@@ -19,6 +19,7 @@ import pytest
 from packaging.version import InvalidVersion
 from packaging.version import Version
 
+from tests.cli.conftest import assert_rich_output_no_such_option
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
 from tests.helpers.json import parse_json_object
@@ -97,9 +98,10 @@ def test_version_rejects_quiet_option_with_json_output() -> None:
         ]
     )
 
-    assert result.exit_code != 0
-    assert "No such option" in result.output
-    assert CliOpt.QUIET in result.output
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.QUIET,
+    )
 
 
 def test_version_verbose_does_not_change_json_output() -> None:
@@ -188,9 +190,10 @@ def test_version_rejects_quiet_option_with_ndjson_output() -> None:
         ]
     )
 
-    assert result.exit_code != 0
-    assert "No such option" in result.output
-    assert CliOpt.QUIET in result.output
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.QUIET,
+    )
 
 
 def test_version_verbose_does_not_change_ndjson_output() -> None:

--- a/tests/cli/test_command_applicability.py
+++ b/tests/cli/test_command_applicability.py
@@ -16,7 +16,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.cli.conftest import assert_FILE_NOT_FOUND
+from tests.cli.conftest import assert_rich_output_contains
+from tests.cli.conftest import assert_rich_output_does_not_contain
 from tests.cli.conftest import assert_USAGE_ERROR
+from tests.cli.conftest import assert_WOULD_CHANGE
 from tests.cli.conftest import run_cli
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
@@ -60,9 +64,18 @@ def test_probe_rejects_inapplicable_path_command_options(
     result: Result = run_cli(argv)
 
     assert_USAGE_ERROR(result)
-    assert f"Option '{option}' is not supported for" in result.output
-    assert CliCmd.PROBE in result.output
-    assert reason in result.output
+    assert_rich_output_contains(
+        result.output,
+        expected=f"Option '{option}' is not supported for",
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=CliCmd.PROBE,
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=reason,
+    )
 
 
 def test_probe_rejects_inapplicable_option_assignment_form() -> None:
@@ -75,9 +88,18 @@ def test_probe_rejects_inapplicable_option_assignment_form() -> None:
     )
 
     assert_USAGE_ERROR(result)
-    assert f"Option '{CliOpt.WRITE_MODE}' is not supported for" in result.output
-    assert CliCmd.PROBE in result.output
-    assert _CHECK_STRIP_REASON in result.output
+    assert_rich_output_contains(
+        result.output,
+        expected=f"Option '{CliOpt.WRITE_MODE}' is not supported for",
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=CliCmd.PROBE,
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=_CHECK_STRIP_REASON,
+    )
 
 
 @pytest.mark.parametrize(
@@ -103,9 +125,18 @@ def test_strip_rejects_generated_header_options(
     result: Result = run_cli(argv)
 
     assert_USAGE_ERROR(result)
-    assert f"Option '{option}' is not supported for" in result.output
-    assert CliCmd.STRIP in result.output
-    assert _CHECK_ONLY_REASON in result.output
+    assert_rich_output_contains(
+        result.output,
+        expected=f"Option '{option}' is not supported for",
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=CliCmd.STRIP,
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=_CHECK_ONLY_REASON,
+    )
 
 
 @pytest.mark.parametrize(
@@ -128,9 +159,18 @@ def test_path_commands_reject_stdin_flag(command: str) -> None:
     )
 
     assert_USAGE_ERROR(result)
-    assert f"Option '{_STDIN_FLAG}' is not supported for" in result.output
-    assert command in result.output
-    assert _STDIN_GUIDANCE in result.output
+    assert_rich_output_contains(
+        result.output,
+        expected=f"Option '{_STDIN_FLAG}' is not supported for",
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=command,
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=_STDIN_GUIDANCE,
+    )
 
 
 @pytest.mark.parametrize(
@@ -153,9 +193,18 @@ def test_path_commands_reject_stdin_flag_assignment_form(command: str) -> None:
     )
 
     assert_USAGE_ERROR(result)
-    assert f"Option '{_STDIN_FLAG}' is not supported for" in result.output
-    assert command in result.output
-    assert _STDIN_GUIDANCE in result.output
+    assert_rich_output_contains(
+        result.output,
+        expected=f"Option '{_STDIN_FLAG}' is not supported for",
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=command,
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=_STDIN_GUIDANCE,
+    )
 
 
 def test_probe_rejects_first_inapplicable_option_when_multiple_are_present() -> None:
@@ -170,9 +219,18 @@ def test_probe_rejects_first_inapplicable_option_when_multiple_are_present() -> 
     )
 
     assert_USAGE_ERROR(result)
-    assert f"Option '{CliOpt.RENDER_DIFF}' is not supported for" in result.output
-    assert CliCmd.PROBE in result.output
-    assert _CHECK_STRIP_REASON in result.output
+    assert_rich_output_contains(
+        result.output,
+        expected=f"Option '{CliOpt.RENDER_DIFF}' is not supported for",
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=CliCmd.PROBE,
+    )
+    assert_rich_output_contains(
+        result.output,
+        expected=_CHECK_STRIP_REASON,
+    )
 
 
 def test_check_accepts_content_stdin_sentinel() -> None:
@@ -187,8 +245,15 @@ def test_check_accepts_content_stdin_sentinel() -> None:
         input_text="print('hello')\n",
     )
 
-    assert "Usage:" not in result.output
-    assert f"Option '{_STDIN_FLAG}' is not supported" not in result.output
+    assert_WOULD_CHANGE(result)
+    assert_rich_output_does_not_contain(
+        result.output,
+        expected="Usage:",
+    )
+    assert_rich_output_does_not_contain(
+        result.output,
+        expected=f"Option '{_STDIN_FLAG}' is not supported for",
+    )
 
 
 @pytest.mark.parametrize(
@@ -208,4 +273,8 @@ def test_path_commands_do_not_reject_literal_stdin_named_path(command: str) -> N
         ]
     )
 
-    assert f"Option '{_STDIN_FLAG}' is not supported" not in result.output
+    assert_FILE_NOT_FOUND(result)
+    assert_rich_output_does_not_contain(
+        result.output,
+        expected=f"Option '{_STDIN_FLAG}' is not supported for",
+    )

--- a/tests/cli/test_config_human_output.py
+++ b/tests/cli/test_config_human_output.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 import pytest
 from click.testing import Result
 
+from tests.cli.conftest import assert_rich_output_no_such_option
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
 from topmark.cli.keys import CliCmd
@@ -80,9 +81,10 @@ def test_config_content_commands_reject_text_quiet_option(cmd: str) -> None:
         ]
     )
 
-    assert result.exit_code != 0
-    assert "No such option" in result.output
-    assert CliOpt.QUIET in result.output
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.QUIET,
+    )
 
 
 # --- Quiet mode: Markdown output ---
@@ -130,9 +132,10 @@ def test_config_content_commands_reject_quiet_option_with_markdown_output(cmd: s
         ]
     )
 
-    assert result.exit_code != 0
-    assert "No such option" in result.output
-    assert CliOpt.QUIET in result.output
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.QUIET,
+    )
 
 
 # --- Verbosity: Markdown output ---

--- a/tests/cli/test_help_all.py
+++ b/tests/cli/test_help_all.py
@@ -19,9 +19,11 @@ These tests are broad command-surface smoke tests, not detailed content checks.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import Final
 
 from click.testing import Result
 
+from tests.cli.conftest import assert_rich_output_contains
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
 from topmark.cli.keys import CliCmd
@@ -30,7 +32,7 @@ from topmark.cli.keys import CliOpt
 if TYPE_CHECKING:
     from click.testing import Result
 
-PUBLIC_COMMAND_PATHS: list[tuple[str, ...]] = [
+PUBLIC_HELP_COMMAND_PATHS: Final[tuple[tuple[str, ...], ...]] = (
     (CliCmd.PROBE,),
     (CliCmd.CHECK,),
     (CliCmd.STRIP,),
@@ -65,12 +67,7 @@ PUBLIC_COMMAND_PATHS: list[tuple[str, ...]] = [
         CliCmd.REGISTRY_BINDINGS,
     ),
     (CliCmd.VERSION,),
-]
-
-
-def _collapse_help_whitespace(text: str) -> str:
-    """Normalize Click help wrapping for stable substring assertions."""
-    return " ".join(text.split())
+)
 
 
 # --- Top-level help ---
@@ -83,7 +80,10 @@ def test_top_level_help_exits_success() -> None:
     )
 
     assert_SUCCESS(result)
-    assert "usage" in result.output.lower()
+    assert_rich_output_contains(
+        result.output,
+        expected="Usage:",
+    )
 
 
 # --- Public command help pages ---
@@ -91,13 +91,16 @@ def test_top_level_help_exits_success() -> None:
 
 def test_each_public_command_path_has_help() -> None:
     """Every public command path should expose a working `--help` page."""
-    for command_path in PUBLIC_COMMAND_PATHS:
+    for command_path in PUBLIC_HELP_COMMAND_PATHS:
         result: Result = run_cli(
             command_path + (CliOpt.HELP,),
         )
 
         assert_SUCCESS(result)
-        assert "usage" in result.output.lower()
+        assert_rich_output_contains(
+            result.output,
+            expected="Usage:",
+        )
 
 
 def test_config_dump_help_listed_paths_noop() -> None:
@@ -109,6 +112,8 @@ def test_config_dump_help_listed_paths_noop() -> None:
             CliOpt.HELP,
         ]
     )
-    output: str = _collapse_help_whitespace(result.output)
 
-    assert "Listed paths do not affect the dumped configuration." in output
+    assert_rich_output_contains(
+        result.output,
+        expected="Listed paths do not affect the dumped configuration.",
+    )

--- a/tests/cli/test_help_epilog.py
+++ b/tests/cli/test_help_epilog.py
@@ -1,0 +1,80 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_help_epilog.py
+#   file_relpath : tests/cli/test_help_epilog.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for Rich Click help epilog rendering helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+
+from topmark.cli.help import HelpExample
+from topmark.cli.help import render_examples_epilog
+
+if TYPE_CHECKING:
+    from rich.text import Text
+
+
+def test_render_examples_epilog_renders_examples_without_notes() -> None:
+    """Render examples and omit the notes section when no notes are provided."""
+    epilog: Text = render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Run a dry-run check",
+                command_line="topmark check src",
+            ),
+        ),
+    )
+
+    assert epilog.plain == ("Examples:\n  # Run a dry-run check\n  topmark check src\n")
+
+
+def test_render_examples_epilog_renders_examples_and_notes() -> None:
+    """Render examples followed by notes when both sections are provided."""
+    epilog: Text = render_examples_epilog(
+        examples=(
+            HelpExample(
+                summary="Print the installed version",
+                command_line="topmark version",
+            ),
+        ),
+        notes=(
+            "Default output is human-readable.",
+            "Machine-readable formats emit structured metadata.",
+        ),
+    )
+
+    assert epilog.plain == (
+        "Examples:\n"
+        "  # Print the installed version\n"
+        "  topmark version\n"
+        "\n"
+        "Notes:\n"
+        "  • Default output is human-readable.\n"
+        "  • Machine-readable formats emit structured metadata.\n"
+    )
+
+
+def test_render_examples_epilog_renders_notes_without_examples() -> None:
+    """Render notes without an examples heading when examples are empty."""
+    epilog: Text = render_examples_epilog(
+        examples=(),
+        notes=("Use this output for command help only.",),
+    )
+
+    assert epilog.plain == ("Notes:\n  • Use this output for command help only.\n")
+
+
+def test_render_examples_epilog_renders_empty_text_for_no_content() -> None:
+    """Render an empty Rich Text object when no examples or notes are provided."""
+    epilog: Text = render_examples_epilog(examples=())
+
+    assert epilog.plain == ""

--- a/tests/cli/test_logging_flags.py
+++ b/tests/cli/test_logging_flags.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.cli.conftest import assert_rich_output_contains
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_USAGE_ERROR
 from tests.cli.conftest import run_cli
@@ -63,4 +64,7 @@ def test_config_check_rejects_combined_verbose_and_quiet_flags() -> None:
     for args in conflicting_invocations:
         result: Result = run_cli(args)
         assert_USAGE_ERROR(result)
-        assert "--verbose and --quiet are mutually exclusive" in result.output
+        assert_rich_output_contains(
+            result.output,
+            expected="--verbose and --quiet are mutually exclusive",
+        )

--- a/tests/cli/test_policy_options.py
+++ b/tests/cli/test_policy_options.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_USAGE_ERROR
+from tests.cli.conftest import command_option_names
 from tests.cli.conftest import run_cli
 from tests.cli.conftest import run_cli_in
 from topmark.cli.keys import CliCmd
@@ -60,12 +61,14 @@ def test_check_help_lists_check_only_and_shared_policy_options() -> None:
     )
     assert_SUCCESS(result)
 
-    assert CliOpt.POLICY_HEADER_MUTATION_MODE in result.output
-    assert CliOpt.POLICY_ALLOW_HEADER_IN_EMPTY_FILES in result.output
-    assert CliOpt.POLICY_EMPTY_INSERT_MODE in result.output
-    assert CliOpt.POLICY_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS in result.output
-    assert CliOpt.POLICY_ALLOW_REFLOW in result.output
-    assert CliOpt.POLICY_ALLOW_CONTENT_PROBE in result.output
+    option_names: set[str] = command_option_names(CliCmd.CHECK)
+
+    assert CliOpt.POLICY_HEADER_MUTATION_MODE in option_names
+    assert CliOpt.POLICY_ALLOW_HEADER_IN_EMPTY_FILES in option_names
+    assert CliOpt.POLICY_EMPTY_INSERT_MODE in option_names
+    assert CliOpt.POLICY_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS in option_names
+    assert CliOpt.POLICY_ALLOW_REFLOW in option_names
+    assert CliOpt.POLICY_ALLOW_CONTENT_PROBE in option_names
 
 
 def test_strip_help_lists_only_shared_policy_options() -> None:
@@ -78,12 +81,14 @@ def test_strip_help_lists_only_shared_policy_options() -> None:
     )
     assert_SUCCESS(result)
 
-    assert CliOpt.POLICY_ALLOW_CONTENT_PROBE in result.output
-    assert CliOpt.POLICY_HEADER_MUTATION_MODE not in result.output
-    assert CliOpt.POLICY_ALLOW_HEADER_IN_EMPTY_FILES not in result.output
-    assert CliOpt.POLICY_EMPTY_INSERT_MODE not in result.output
-    assert CliOpt.POLICY_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS not in result.output
-    assert CliOpt.POLICY_ALLOW_REFLOW not in result.output
+    option_names: set[str] = command_option_names(CliCmd.STRIP)
+
+    assert CliOpt.POLICY_ALLOW_CONTENT_PROBE in option_names
+    assert CliOpt.POLICY_HEADER_MUTATION_MODE not in option_names
+    assert CliOpt.POLICY_ALLOW_HEADER_IN_EMPTY_FILES not in option_names
+    assert CliOpt.POLICY_EMPTY_INSERT_MODE not in option_names
+    assert CliOpt.POLICY_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS not in option_names
+    assert CliOpt.POLICY_ALLOW_REFLOW not in option_names
 
 
 # --- Check behavior: header mutation mode ---

--- a/tests/cli/test_registry_human_output.py
+++ b/tests/cli/test_registry_human_output.py
@@ -27,6 +27,7 @@ from typing import ClassVar
 
 import pytest
 
+from tests.cli.conftest import assert_rich_output_no_such_option
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
 from tests.helpers.registry import make_file_type
@@ -187,9 +188,10 @@ def test_registry_commands_reject_quiet_option_for_text_output(
         ]
     )
 
-    assert result.exit_code != 0
-    assert "No such option" in result.output
-    assert CliOpt.QUIET in result.output
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.QUIET,
+    )
 
 
 # --- Markdown output: filetypes ---
@@ -239,9 +241,10 @@ def test_registry_filetypes_markdown_rejects_quiet_option(
         ]
     )
 
-    assert result.exit_code != 0
-    assert "No such option" in result.output
-    assert CliOpt.QUIET in result.output
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.QUIET,
+    )
 
 
 def test_registry_filetypes_markdown_long_shows_details(

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -28,6 +28,7 @@ import pytest
 from packaging.version import InvalidVersion
 from packaging.version import Version
 
+from tests.cli.conftest import assert_rich_output_no_such_option
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
 from tests.helpers.version import SEMVER_RE
@@ -100,9 +101,10 @@ def test_version_rejects_quiet_option_for_text_output() -> None:
         ]
     )
 
-    assert result.exit_code != 0
-    assert "No such option" in result.output
-    assert CliOpt.QUIET in result.output
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.QUIET,
+    )
 
 
 def test_version_rejects_quiet_option_with_markdown_output() -> None:
@@ -117,9 +119,10 @@ def test_version_rejects_quiet_option_with_markdown_output() -> None:
         ]
     )
 
-    assert result.exit_code != 0
-    assert "No such option" in result.output
-    assert CliOpt.QUIET in result.output
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.QUIET,
+    )
 
 
 # --- Markdown output ---

--- a/uv.lock
+++ b/uv.lock
@@ -1509,6 +1509,21 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-click"
+version = "1.9.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/27/091e140ea834272188e63f8dd6faac1f5c687582b687197b3e0ec3c78ebf/rich_click-1.9.7.tar.gz", hash = "sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc", size = 74838, upload-time = "2026-01-31T04:29:27.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl", hash = "sha256:2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b", size = 71491, upload-time = "2026-01-31T04:29:26.777Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.14"
 source = { registry = "https://pypi.org/simple" }
@@ -1658,6 +1673,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "rich" },
+    { name = "rich-click" },
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
@@ -1736,6 +1752,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.8.0,<4.0.0" },
     { name = "rich", specifier = ">=15.0.0,<16.0.0" },
     { name = "rich", marker = "extra == 'docs'", specifier = ">=15.0.0,<16.0.0" },
+    { name = "rich-click", specifier = ">=1.9.7,<2.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.5,<0.16.0" },
     { name = "ruff", marker = "extra == 'docs'", specifier = ">=0.14.5,<0.16.0" },
     { name = "taplo", marker = "extra == 'dev'", specifier = ">=0.9.3,<0.10.0" },


### PR DESCRIPTION
## Summary

Adopt `rich-click` for CLI help rendering while preserving standard Click
as the authoritative runtime, validation, state, and context layer.

This PR intentionally scopes `rich-click` usage to human-facing help
formatting only. Runtime behavior, machine-readable output contracts,
validators, CLI state handling, shell completion, and pipeline behavior
remain unchanged.

Fixes #61.

## Highlights

- adopt `rich-click` for command/group help rendering;
- preserve existing Click runtime/context/state behavior;
- keep `click.get_current_context()` as the preferred internal API;
- avoid introducing `rich_click.get_current_context()`;
- introduce shared Rich-backed help epilog helpers in:
  - `src/topmark/cli/help.py`;
- improve rendering of examples and notes in command help epilogs;
- migrate CLI help tests to Rich-aware semantic assertions;
- add focused tests for help epilog rendering behavior;
- update roadmap documentation for completed `rich-click` adoption work.

## Architectural notes

This PR intentionally preserves the existing CLI/runtime architecture:

- Click remains the authoritative runtime/validation/context layer;
- `rich-click` is currently limited to presentation/help formatting;
- machine-readable JSON/NDJSON output behavior remains unchanged;
- CLI applicability, exit-code behavior, and validators remain unchanged;
- shell completion behavior remains unchanged.

The migration also preserves:
- semantic styling isolation;
- `NO_COLOR` behavior;
- non-TTY behavior;
- deterministic CI/test behavior.

## Follow-up work (deferred)

This PR intentionally does not include:
- generated command-help documentation;
- Markdown-output redesign;
- custom Rich table rendering;
- replacement of Click runtime APIs;
- broader CLI architecture changes.

Future follow-up work may evaluate:
- help-layout improvements for very long option names and boolean flag pairs;
- command-help documentation generation from CLI output;
- possible Rich Click panel/group tuning for policy-heavy commands.