### PR TITLE
fix(cli): trap underscored option spellings consistently

### DIFF
--- a/src/topmark/cli/options.py
+++ b/src/topmark/cli/options.py
@@ -344,7 +344,7 @@ def _trap_underscored_option(ctx: click.Context, param: click.Option, _value: ob
 
     bad: str = param.opts[0] if param.opts else "--?"
     suggestion: str = bad.replace("_", "-")
-    raise click.UsageError(f"Unknown option: {bad}. Did you mean {suggestion}?")
+    raise click.UsageError(f"Unknown option: '{bad}'. Did you mean '{suggestion}'?")
 
 
 def option_with_underscore_traps(
@@ -354,11 +354,15 @@ def option_with_underscore_traps(
     """Like `click.option`, but also traps underscored spellings.
 
     For each canonical long option declaration of the form `--foo-bar`, this helper
-    also registers a hidden eager option `--foo_bar` that raises a helpful error
+    also registers a hidden eager flag `--foo_bar` that raises a helpful error
     suggesting the hyphenated spelling.
 
     The trap is attached alongside the real option so call sites don't need to
     remember to register traps separately.
+
+    Trap options are always flags, even when the canonical option takes a value.
+    This ensures underscored spellings are rejected immediately instead of being
+    parsed as value-taking options.
 
     Args:
         *param_decls: Click option declarations (e.g. `"--verbose"`, `"-v"`).
@@ -392,7 +396,7 @@ def option_with_underscore_traps(
         hidden=True,
         expose_value=False,
         is_eager=True,
-        multiple=True,
+        is_flag=True,
         callback=_trap_underscored_option,
     )
 
@@ -443,7 +447,9 @@ def enum_value_help_text(
         raw_value: str = str(member.value)
         rendered_value: str = raw_value.replace("_", "-")
         if raw_value == default_value:
-            rendered_value = f"{rendered_value} (default)"
+            rendered_value = f"'{rendered_value}' (default)"
+        else:
+            rendered_value = f"'{rendered_value}'"
         rendered_values.append(rendered_value)
         if "_" in raw_value:
             underscore_values.append(raw_value)

--- a/src/topmark/cli/validators.py
+++ b/src/topmark/cli/validators.py
@@ -72,6 +72,17 @@ LOG_LEVELS: dict[str, int] = {
 # ---- Reusable validators ----
 
 
+def _join_option_list(options: list[str]) -> str:
+    """Return option names joined for a human-readable diagnostic message."""
+    if len(options) == 1:
+        return options[0]
+    if len(options) == 2:
+        return " and ".join(options)
+
+    opts: str = ", ".join(options[:-1])
+    return f"{opts} and {options[-1]}"
+
+
 def _extra_arg_matches_option(arg: str, opt: str) -> bool:
     """Return whether an extra argument is the given option spelling.
 
@@ -168,7 +179,7 @@ def validate_mutually_exclusive(
     cmd: str = ctx.command_path
     if message is None:
         # Keep message stable and easy to read.
-        joined: str = " and ".join(enabled) if len(enabled) == 2 else ", ".join(enabled)
+        joined: str = _join_option_list(enabled)
         message = f"{cmd}: {joined} are mutually exclusive."
 
     raise TopmarkCliUsageError(message)
@@ -205,12 +216,7 @@ def validate_machine_format_forbids_flags(
         return
 
     cmd: str = ctx.command_path
-    if len(enabled) == 1:
-        opts: str = enabled[0]
-    elif len(enabled) == 2:
-        opts = " and ".join(enabled)
-    else:
-        opts = ", ".join(enabled)
+    opts: str = _join_option_list(enabled)
 
     raise TopmarkCliUsageError(f"{cmd}: {CliOpt.OUTPUT_FORMAT}={fmt.value}: {opts} {reason}")
 
@@ -473,7 +479,10 @@ def validate_output_verbosity_policy(
                 ignored.append(CliOpt.QUIET)
                 state.quiet = False
 
-            logger.debug("Ignoring TEXT-only CLI options: %s", ", ".join(ignored))
+            logger.debug(
+                "Ignoring TEXT-only CLI options: %s",
+                _join_option_list(ignored),
+            )
         return
 
     validate_mutually_exclusive(

--- a/tests/cli/test_options_helpers.py
+++ b/tests/cli/test_options_helpers.py
@@ -1,0 +1,110 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_options_helpers.py
+#   file_relpath : tests/cli/test_options_helpers.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for reusable CLI option parsing and validation helpers."""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from topmark.cli.errors import TopmarkCliUsageError
+from topmark.cli.options import FromOptionStdinText
+from topmark.cli.options import FromOptionValues
+from topmark.cli.options import extend_with_stdin_lines
+from topmark.cli.options import extract_stdin_for_from_options
+from topmark.cli.options import split_nonempty_lines
+from topmark.cli.options import strip_dash_sentinels
+from topmark.cli.validators import validate_mutually_exclusive
+
+
+def test_split_nonempty_lines_ignores_blank_and_comment_lines() -> None:
+    """Split helper should ignore blank lines and comment-only lines."""
+    assert split_nonempty_lines("one\n\n# comment\n two \n") == ["one", "two"]
+
+
+def test_extend_with_stdin_lines_extends_existing_target() -> None:
+    """STDIN line helper should append parsed lines to the existing list."""
+    target: list[str] = ["existing"]
+
+    result: list[str] = extend_with_stdin_lines(target, "one\n# comment\ntwo\n")
+
+    assert result is target
+    assert target == ["existing", "one", "two"]
+
+
+def test_strip_dash_sentinels_removes_stdin_markers() -> None:
+    """Dash sentinels should be removed from all --*-from values."""
+    result: FromOptionValues = strip_dash_sentinels(
+        files_from=("files.txt", "-"),
+        include_from=("-", "src/**"),
+        exclude_from=("build/**", "-"),
+    )
+
+    assert result.files_from == ["files.txt"]
+    assert result.include_from == ["src/**"]
+    assert result.exclude_from == ["build/**"]
+
+
+def test_extract_stdin_for_from_options_routes_files_from_stdin_text() -> None:
+    """A single --files-from dash should receive the provided STDIN text."""
+    result: FromOptionStdinText = extract_stdin_for_from_options(
+        files_from=("-",),
+        include_from=(),
+        exclude_from=(),
+        stdin_text="README.md\n",
+    )
+
+    assert result.files_from == "README.md\n"
+    assert result.include_from is None
+    assert result.exclude_from is None
+
+
+def test_extract_stdin_for_from_options_rejects_multiple_stdin_consumers() -> None:
+    """Only one --*-from option may consume STDIN."""
+    with pytest.raises(TopmarkCliUsageError, match="Only one of"):
+        extract_stdin_for_from_options(
+            files_from=("-",),
+            include_from=("-",),
+            exclude_from=(),
+            stdin_text="README.md\n",
+        )
+
+
+def test_validate_mutually_exclusive_joins_two_options() -> None:
+    """Mutual-exclusion diagnostics should join two enabled options with 'and'."""
+    ctx = click.Context(click.Command("check"), info_name="topmark check")
+
+    with pytest.raises(TopmarkCliUsageError, match="--one and --two are mutually exclusive"):
+        validate_mutually_exclusive(
+            ctx,
+            flags={
+                "--one": True,
+                "--two": True,
+            },
+        )
+
+
+def test_validate_mutually_exclusive_joins_three_options() -> None:
+    """Mutual-exclusion diagnostics should join three enabled options readably."""
+    ctx = click.Context(click.Command("check"), info_name="topmark check")
+
+    with pytest.raises(
+        TopmarkCliUsageError,
+        match="--one, --two and --three are mutually exclusive",
+    ):
+        validate_mutually_exclusive(
+            ctx,
+            flags={
+                "--one": True,
+                "--two": True,
+                "--three": True,
+            },
+        )


### PR DESCRIPTION
## Summary

Fix underscored option trap handling so invalid spellings such as
`--no_color` now produce the intended helpful diagnostic:

```text
Unknown option: '--no_color'. Did you mean '--no-color'?
```

instead of the misleading Click parser error:

```text
Option '--no_color' requires an argument.
```

## Changes

- register underscored trap options as eager flags;
- preserve existing hyphenated-option suggestions;
- add regression coverage for underscored option traps;
- add focused coverage for reusable CLI option helpers;
- add validation-message coverage for option-list formatting.

## Scope

This is a narrow CLI bugfix for issue #63.

It does not change command semantics, rich-click help rendering, exit-code behavior, or broader validation policy.