### PR TITLE
cleanup(tooling): remove stale tox references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,9 +279,9 @@ ______________________________________________________________________
 TopMark maintains a stable public 1.x API across Python 3.10-3.14.
 
 ```bash
-make api-snapshot-dev         # quick local check
-make api-snapshot             # tox matrix check
-make api-snapshot-update      # regenerate snapshot (interactive)
+make api-snapshot-dev           # quick local check
+make api-snapshot               # API snapshot (nox matrix check)
+make api-snapshot-update        # regenerate snapshot (interactive)
 make api-snapshot-ensure-clean  # fail if snapshot differs from Git index
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ typeCheckingMode = "strict"
 # Editor-only integration:
 # The settings below help your **editor** (VS Code Pyright extension) resolve imports
 # from a local convenience environment (e.g. `.venv`). They are **not** used by CI,
-# because our actual type checks run inside tox-managed environments where Pyright
+# because our actual type checks run inside nox-managed environments where Pyright
 # is invoked with an explicit `--pythonversion` per env.
 # If you don't maintain a local `.venv`, you can remove these two lines.
 venvPath                           = "."

--- a/tools/docs/check_code_hygiene.py
+++ b/tools/docs/check_code_hygiene.py
@@ -36,10 +36,11 @@ EXCLUDED_DIR_NAMES: Final[frozenset[str]] = frozenset(
     {
         ".git",
         ".nox",
-        ".tox",
+        ".pytest_cache",
+        ".tox",  # defensive exclusion for legacy/local environments
+        ".uv-release-test-env",
         ".venv",
         ".venv-docs",
-        ".uv-release-test-env",
         "__pycache__",
         "build",
         "dist",


### PR DESCRIPTION
## Summary

Clean up stale tox-era references after TopMark's migration to nox.

This PR updates remaining contributor-facing comments and developer
documentation that still referred to tox-managed workflows while keeping
historically accurate CHANGELOG migration entries intact.

Fixes #68.

## Changes

- update Pyright integration comments in `pyproject.toml`;
- update contributor workflow wording in `CONTRIBUTING.md`;
- clarify defensive exclusion handling in
  `tools/docs/check_code_hygiene.py`;
- keep historical tox → nox migration references in `CHANGELOG.md`
  unchanged.

## Notes

This is a documentation/tooling cleanup only.

No behavioral CI, nox, packaging, or runtime changes are introduced.