### PR TITLE
Improve CLI validation diagnostic formatting

### DIFF
--- a/src/topmark/cli/validators.py
+++ b/src/topmark/cli/validators.py
@@ -36,6 +36,7 @@ import click
 from topmark.cli.console.color import ColorMode
 from topmark.cli.errors import TopmarkCliUsageError
 from topmark.cli.keys import CliOpt
+from topmark.cli.keys import CliShortOpt
 from topmark.cli.state import get_cli_state
 from topmark.core.formats import OutputFormat
 from topmark.core.formats import is_machine_format
@@ -72,15 +73,34 @@ LOG_LEVELS: dict[str, int] = {
 # ---- Reusable validators ----
 
 
+_OPTION_SHORT_ALIASES: dict[str, str] = {
+    CliOpt.VERBOSE: CliShortOpt.VERBOSE,
+    CliOpt.QUIET: CliShortOpt.QUIET,
+}
+
+
+def _format_option_label(option: str) -> str:
+    """Return a user-facing option label, including a short alias when known."""
+    short_alias: str | None = _OPTION_SHORT_ALIASES.get(option)
+    if short_alias is None:
+        return option
+    return f"{option} ({short_alias})"
+
+
+def _format_option_labels(options: list[str]) -> list[str]:
+    """Return user-facing option labels for a list of option spellings."""
+    return [_format_option_label(option) for option in options]
+
+
 def _join_option_list(options: list[str]) -> str:
-    """Return option names joined for a human-readable diagnostic message."""
+    """Return option labels joined for a human-readable diagnostic message."""
     if len(options) == 1:
         return options[0]
     if len(options) == 2:
         return " and ".join(options)
 
     opts: str = ", ".join(options[:-1])
-    return f"{opts} and {options[-1]}"
+    return f"{opts}, and {options[-1]}"
 
 
 def _extra_arg_matches_option(arg: str, opt: str) -> bool:
@@ -127,8 +147,9 @@ def validate_common_forbidden_path_command_options_in_extra_args(
     extra_args: list[str] = list(ctx.args)
     for opt, reason in _FORBIDDEN_PATH_COMMAND_OPTS_IN_EXTRA_ARGS.items():
         if any(_extra_arg_matches_option(arg, opt) for arg in extra_args):
+            opt_label: str = _format_option_label(opt)
             raise TopmarkCliUsageError(
-                f"Option '{opt}' is not supported for '{ctx.command_path}'. {reason}"
+                f"{ctx.command_path}: option {opt_label} is not supported. {reason}"
             )
 
 
@@ -146,8 +167,9 @@ def validate_forbidden_options_in_extra_args(
     extra_args: list[str] = list(ctx.args)
     for opt, reason in forbidden_opts.items():
         if any(_extra_arg_matches_option(arg, opt) for arg in extra_args):
+            opt_label: str = _format_option_label(opt)
             raise TopmarkCliUsageError(
-                f"Option '{opt}' is not supported for '{ctx.command_path}'. {reason}"
+                f"{ctx.command_path}: option {opt_label} is not supported. {reason}"
             )
 
 
@@ -178,8 +200,7 @@ def validate_mutually_exclusive(
 
     cmd: str = ctx.command_path
     if message is None:
-        # Keep message stable and easy to read.
-        joined: str = _join_option_list(enabled)
+        joined: str = _join_option_list(_format_option_labels(enabled))
         message = f"{cmd}: {joined} are mutually exclusive."
 
     raise TopmarkCliUsageError(message)
@@ -216,7 +237,7 @@ def validate_machine_format_forbids_flags(
         return
 
     cmd: str = ctx.command_path
-    opts: str = _join_option_list(enabled)
+    opts: str = _join_option_list(_format_option_labels(enabled))
 
     raise TopmarkCliUsageError(f"{cmd}: {CliOpt.OUTPUT_FORMAT}={fmt.value}: {opts} {reason}")
 
@@ -481,7 +502,7 @@ def validate_output_verbosity_policy(
 
             logger.debug(
                 "Ignoring TEXT-only CLI options: %s",
-                _join_option_list(ignored),
+                _join_option_list(_format_option_labels(ignored)),
             )
         return
 

--- a/tests/cli/test_command_applicability.py
+++ b/tests/cli/test_command_applicability.py
@@ -66,7 +66,7 @@ def test_probe_rejects_inapplicable_path_command_options(
     assert_USAGE_ERROR(result)
     assert_rich_output_contains(
         result.output,
-        expected=f"Option '{option}' is not supported for",
+        expected=f"option {option} is not supported.",
     )
     assert_rich_output_contains(
         result.output,
@@ -90,7 +90,7 @@ def test_probe_rejects_inapplicable_option_assignment_form() -> None:
     assert_USAGE_ERROR(result)
     assert_rich_output_contains(
         result.output,
-        expected=f"Option '{CliOpt.WRITE_MODE}' is not supported for",
+        expected=f"option {CliOpt.WRITE_MODE} is not supported.",
     )
     assert_rich_output_contains(
         result.output,
@@ -127,7 +127,7 @@ def test_strip_rejects_generated_header_options(
     assert_USAGE_ERROR(result)
     assert_rich_output_contains(
         result.output,
-        expected=f"Option '{option}' is not supported for",
+        expected=f"option {option} is not supported.",
     )
     assert_rich_output_contains(
         result.output,
@@ -161,7 +161,7 @@ def test_path_commands_reject_stdin_flag(command: str) -> None:
     assert_USAGE_ERROR(result)
     assert_rich_output_contains(
         result.output,
-        expected=f"Option '{_STDIN_FLAG}' is not supported for",
+        expected=f"option {_STDIN_FLAG} is not supported.",
     )
     assert_rich_output_contains(
         result.output,
@@ -195,7 +195,7 @@ def test_path_commands_reject_stdin_flag_assignment_form(command: str) -> None:
     assert_USAGE_ERROR(result)
     assert_rich_output_contains(
         result.output,
-        expected=f"Option '{_STDIN_FLAG}' is not supported for",
+        expected=f"option {_STDIN_FLAG} is not supported.",
     )
     assert_rich_output_contains(
         result.output,
@@ -221,7 +221,7 @@ def test_probe_rejects_first_inapplicable_option_when_multiple_are_present() -> 
     assert_USAGE_ERROR(result)
     assert_rich_output_contains(
         result.output,
-        expected=f"Option '{CliOpt.RENDER_DIFF}' is not supported for",
+        expected=f"option {CliOpt.RENDER_DIFF} is not supported.",
     )
     assert_rich_output_contains(
         result.output,
@@ -252,7 +252,7 @@ def test_check_accepts_content_stdin_sentinel() -> None:
     )
     assert_rich_output_does_not_contain(
         result.output,
-        expected=f"Option '{_STDIN_FLAG}' is not supported for",
+        expected=f"option {_STDIN_FLAG} is not supported.",
     )
 
 
@@ -276,5 +276,5 @@ def test_path_commands_do_not_reject_literal_stdin_named_path(command: str) -> N
     assert_FILE_NOT_FOUND(result)
     assert_rich_output_does_not_contain(
         result.output,
-        expected=f"Option '{_STDIN_FLAG}' is not supported for",
+        expected=f"option {_STDIN_FLAG} is not supported.",
     )

--- a/tests/cli/test_logging_flags.py
+++ b/tests/cli/test_logging_flags.py
@@ -66,5 +66,5 @@ def test_config_check_rejects_combined_verbose_and_quiet_flags() -> None:
         assert_USAGE_ERROR(result)
         assert_rich_output_contains(
             result.output,
-            expected="--verbose and --quiet are mutually exclusive",
+            expected="--verbose (-v) and --quiet (-q) are mutually exclusive",
         )

--- a/tests/cli/test_options_helpers.py
+++ b/tests/cli/test_options_helpers.py
@@ -98,7 +98,7 @@ def test_validate_mutually_exclusive_joins_three_options() -> None:
 
     with pytest.raises(
         TopmarkCliUsageError,
-        match="--one, --two and --three are mutually exclusive",
+        match="--one, --two, and --three are mutually exclusive",
     ):
         validate_mutually_exclusive(
             ctx,

--- a/tests/cli/test_validators.py
+++ b/tests/cli/test_validators.py
@@ -118,7 +118,7 @@ def test_validate_common_forbidden_path_options_rejects_stdin(arg: str) -> None:
 
     with pytest.raises(
         TopmarkCliUsageError,
-        match=r"Option '--stdin' is not supported for 'topmark-test'",
+        match=r"topmark-test: option --stdin is not supported.",
     ):
         validate_common_forbidden_path_command_options_in_extra_args(ctx)
 
@@ -129,7 +129,7 @@ def test_validate_forbidden_options_in_extra_args_rejects_custom_option() -> Non
 
     with pytest.raises(
         TopmarkCliUsageError,
-        match=r"Option '--unsafe' is not supported for 'topmark-test'. not allowed",
+        match=r"topmark-test: option --unsafe is not supported. not allowed",
     ):
         validate_forbidden_options_in_extra_args(
             ctx,
@@ -405,7 +405,7 @@ def test_validate_output_verbosity_policy_rejects_text_verbose_and_quiet() -> No
 
     with pytest.raises(
         TopmarkCliUsageError,
-        match=r"topmark-test: --verbose and --quiet are mutually exclusive.",
+        match=r"topmark-test: --verbose \(-v\) and --quiet \(-q\) are mutually exclusive.",
     ):
         validate_output_verbosity_policy(
             ctx,


### PR DESCRIPTION
## Summary

Fixes #66.

This PR improves selected TopMark-owned CLI validation diagnostics while preserving CLI semantics, parser behavior, machine-readable output, and exit-code behavior.

Changes include:

- add private option-label/list formatting helpers in `cli/validators.py`;
- render known short aliases in diagnostics, e.g. `--verbose (-v)` and `--quiet (-q)`;
- standardize unsupported-option diagnostics to the command-prefixed form:
  - `topmark probe: option --diff is not supported. ...`
- use Oxford-comma formatting for longer option lists;
- update CLI validation tests to assert the new human-facing diagnostics.

## Notes

This PR intentionally does not address #67. Click/parser usage-error exit-code normalization remains separate follow-up work.