### PR TITLE
Refactor CLI option metadata for diagnostics

### DIFF
--- a/src/topmark/cli/option_meta.py
+++ b/src/topmark/cli/option_meta.py
@@ -1,0 +1,107 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : option_meta.py
+#   file_relpath : src/topmark/cli/option_meta.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""CLI option metadata helpers.
+
+This module contains small, parser-adjacent metadata used by TopMark-owned
+validation and diagnostic rendering. Click option declarations remain in
+`topmark.cli.options`; this module must not become a second parser model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from topmark.cli.keys import CliOpt
+from topmark.cli.keys import CliShortOpt
+
+
+@dataclass(frozen=True, slots=True)
+class CliOptionMeta:
+    """Human-facing metadata for one CLI option spelling.
+
+    Attributes:
+        long: Canonical long option spelling.
+        short: Optional short alias spelling.
+        hidden_aliases: Compatibility aliases accepted by Click but hidden from help.
+    """
+
+    long: str
+    short: str | None = None
+    hidden_aliases: tuple[str, ...] = ()
+
+    def label(self) -> str:
+        """Return the option label used in human-facing diagnostics.
+
+        Returns:
+            The canonical long spelling, followed by the short alias when available.
+        """
+        if self.short is None:
+            return self.long
+        return f"{self.long} ({self.short})"
+
+
+CLI_OPTION_META_BY_LONG: Final[dict[str, CliOptionMeta]] = {
+    CliOpt.INCLUDE_FILE_TYPES: CliOptionMeta(
+        long=CliOpt.INCLUDE_FILE_TYPES,
+        short=CliShortOpt.INCLUDE_FILE_TYPES,
+        hidden_aliases=(CliOpt.INCLUDE_FILE_TYPE,),
+    ),
+    CliOpt.EXCLUDE_FILE_TYPES: CliOptionMeta(
+        long=CliOpt.EXCLUDE_FILE_TYPES,
+        short=CliShortOpt.EXCLUDE_FILE_TYPES,
+        hidden_aliases=(CliOpt.EXCLUDE_FILE_TYPE,),
+    ),
+    CliOpt.VERBOSE: CliOptionMeta(
+        long=CliOpt.VERBOSE,
+        short=CliShortOpt.VERBOSE,
+    ),
+    CliOpt.QUIET: CliOptionMeta(
+        long=CliOpt.QUIET,
+        short=CliShortOpt.QUIET,
+    ),
+}
+"""Known CLI option metadata keyed by canonical long spelling."""
+
+
+CLI_HIDDEN_ALIAS_TARGETS: Final[dict[str, str]] = {
+    alias: meta.long for meta in CLI_OPTION_META_BY_LONG.values() for alias in meta.hidden_aliases
+}
+"""Hidden compatibility aliases keyed by alias spelling."""
+
+
+def format_option_label(option: str) -> str:
+    """Return a user-facing option label, including a short alias when known.
+
+    Args:
+        option: Option spelling to render. Hidden aliases are resolved to their
+            canonical long spelling before rendering.
+
+    Returns:
+        Human-facing option label for diagnostics.
+    """
+    canonical: str = CLI_HIDDEN_ALIAS_TARGETS.get(option, option)
+    meta: CliOptionMeta | None = CLI_OPTION_META_BY_LONG.get(canonical)
+    if meta is None:
+        return canonical
+    return meta.label()
+
+
+def format_option_labels(options: list[str]) -> list[str]:
+    """Return user-facing option labels for a list of option spellings.
+
+    Args:
+        options: Option spellings to render.
+
+    Returns:
+        Rendered labels in the same order as the provided option spellings.
+    """
+    return [format_option_label(option) for option in options]

--- a/src/topmark/cli/validators.py
+++ b/src/topmark/cli/validators.py
@@ -36,7 +36,8 @@ import click
 from topmark.cli.console.color import ColorMode
 from topmark.cli.errors import TopmarkCliUsageError
 from topmark.cli.keys import CliOpt
-from topmark.cli.keys import CliShortOpt
+from topmark.cli.option_meta import format_option_label
+from topmark.cli.option_meta import format_option_labels
 from topmark.cli.state import get_cli_state
 from topmark.core.formats import OutputFormat
 from topmark.core.formats import is_machine_format
@@ -71,25 +72,6 @@ LOG_LEVELS: dict[str, int] = {
 }
 
 # ---- Reusable validators ----
-
-
-_OPTION_SHORT_ALIASES: dict[str, str] = {
-    CliOpt.VERBOSE: CliShortOpt.VERBOSE,
-    CliOpt.QUIET: CliShortOpt.QUIET,
-}
-
-
-def _format_option_label(option: str) -> str:
-    """Return a user-facing option label, including a short alias when known."""
-    short_alias: str | None = _OPTION_SHORT_ALIASES.get(option)
-    if short_alias is None:
-        return option
-    return f"{option} ({short_alias})"
-
-
-def _format_option_labels(options: list[str]) -> list[str]:
-    """Return user-facing option labels for a list of option spellings."""
-    return [_format_option_label(option) for option in options]
 
 
 def _join_option_list(options: list[str]) -> str:
@@ -147,7 +129,7 @@ def validate_common_forbidden_path_command_options_in_extra_args(
     extra_args: list[str] = list(ctx.args)
     for opt, reason in _FORBIDDEN_PATH_COMMAND_OPTS_IN_EXTRA_ARGS.items():
         if any(_extra_arg_matches_option(arg, opt) for arg in extra_args):
-            opt_label: str = _format_option_label(opt)
+            opt_label: str = format_option_label(opt)
             raise TopmarkCliUsageError(
                 f"{ctx.command_path}: option {opt_label} is not supported. {reason}"
             )
@@ -167,7 +149,7 @@ def validate_forbidden_options_in_extra_args(
     extra_args: list[str] = list(ctx.args)
     for opt, reason in forbidden_opts.items():
         if any(_extra_arg_matches_option(arg, opt) for arg in extra_args):
-            opt_label: str = _format_option_label(opt)
+            opt_label: str = format_option_label(opt)
             raise TopmarkCliUsageError(
                 f"{ctx.command_path}: option {opt_label} is not supported. {reason}"
             )
@@ -200,7 +182,7 @@ def validate_mutually_exclusive(
 
     cmd: str = ctx.command_path
     if message is None:
-        joined: str = _join_option_list(_format_option_labels(enabled))
+        joined: str = _join_option_list(format_option_labels(enabled))
         message = f"{cmd}: {joined} are mutually exclusive."
 
     raise TopmarkCliUsageError(message)
@@ -237,7 +219,7 @@ def validate_machine_format_forbids_flags(
         return
 
     cmd: str = ctx.command_path
-    opts: str = _join_option_list(_format_option_labels(enabled))
+    opts: str = _join_option_list(format_option_labels(enabled))
 
     raise TopmarkCliUsageError(f"{cmd}: {CliOpt.OUTPUT_FORMAT}={fmt.value}: {opts} {reason}")
 
@@ -502,7 +484,7 @@ def validate_output_verbosity_policy(
 
             logger.debug(
                 "Ignoring TEXT-only CLI options: %s",
-                _join_option_list(_format_option_labels(ignored)),
+                _join_option_list(format_option_labels(ignored)),
             )
         return
 

--- a/tests/cli/test_file_type_and_skip_flags.py
+++ b/tests/cli/test_file_type_and_skip_flags.py
@@ -26,7 +26,6 @@ rather than exact phrases to tolerate minor wording tweaks.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -190,3 +189,91 @@ def test_report_actionable_hides_unsupported_per_file_but_summary_counts_it(tmp_
 
     assert_SUCCESS(result_summary)
     assert ResolveStatus.UNSUPPORTED.value in result_summary.output.lower()
+
+
+# ---- Test hidden singular option aliases ----
+
+
+@pytest.mark.parametrize(
+    ("include_opt", "exclude_opt"),
+    [
+        (CliOpt.INCLUDE_FILE_TYPES, CliOpt.EXCLUDE_FILE_TYPES),
+        (CliOpt.INCLUDE_FILE_TYPE, CliOpt.EXCLUDE_FILE_TYPE),
+        (CliOpt.INCLUDE_FILE_TYPES, CliOpt.EXCLUDE_FILE_TYPE),
+        (CliOpt.INCLUDE_FILE_TYPE, CliOpt.EXCLUDE_FILE_TYPES),
+    ],
+)
+def test_file_type_filter_accepts_plural_and_hidden_singular_aliases(
+    tmp_path: Path,
+    include_opt: str,
+    exclude_opt: str,
+) -> None:
+    """File type filter accepts plural and hidden singular aliases.
+
+    This tests:
+    - plural options;
+    - hidden singular aliases;
+    - mixed canonical/hidden spelling combinations;
+    - CSV parsing;
+    - actual filter semantics.
+    """
+    py: Path = tmp_path / "a.py"
+    md: Path = tmp_path / "a.md"
+    java: Path = tmp_path / "A.java"
+    toml: Path = tmp_path / "settings.toml"
+
+    py.write_text("print('x')\n", "utf-8")
+    md.write_text("# Title\n", "utf-8")
+    java.write_text("class A {}\n", "utf-8")
+    toml.write_text("[project]\nname = 'x'\n", "utf-8")
+
+    result: Result = run_cli(
+        [
+            CliCmd.CHECK,
+            include_opt,
+            "python,markdown,javascript,toml",
+            exclude_opt,
+            "java",
+            CliOpt.APPLY_CHANGES,
+            str(tmp_path),
+        ],
+    )
+
+    assert_SUCCESS(result)
+    assert TOPMARK_START_MARKER in py.read_text("utf-8")
+    assert TOPMARK_START_MARKER in md.read_text("utf-8")
+    assert TOPMARK_START_MARKER not in java.read_text("utf-8")
+    assert TOPMARK_START_MARKER in toml.read_text("utf-8")
+
+
+@pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP, CliCmd.PROBE])
+def test_file_type_filter_merges_repeated_plural_and_hidden_singular_aliases(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Repeated plural and hidden singular aliases are accepted and merged.
+
+    This test intentionally runs in dry-run mode against one selected file. It
+    verifies the CLI parsing and file-type filter accumulation contract without
+    depending on command-specific mutation behavior or directory probe reporting.
+    """
+    md: Path = tmp_path / "a.md"
+
+    md.write_text("# Title\n", "utf-8")
+
+    result: Result = run_cli(
+        [
+            command,
+            CliOpt.INCLUDE_FILE_TYPE,
+            "python",
+            CliOpt.INCLUDE_FILE_TYPES,
+            "javascript,markdown,toml",
+            CliOpt.EXCLUDE_FILE_TYPE,
+            "html",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "css,xml,svg",
+            str(md),
+        ],
+    )
+
+    assert_SUCCESS_or_WOULD_CHANGE(result)

--- a/tests/cli/test_help_all.py
+++ b/tests/cli/test_help_all.py
@@ -18,13 +18,13 @@ These tests are broad command-surface smoke tests, not detailed content checks.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 from typing import Final
 
-from click.testing import Result
-
 from tests.cli.conftest import assert_rich_output_contains
 from tests.cli.conftest import assert_SUCCESS
+from tests.cli.conftest import normalize_rich_cli_output
 from tests.cli.conftest import run_cli
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
@@ -116,4 +116,35 @@ def test_config_dump_help_listed_paths_noop() -> None:
     assert_rich_output_contains(
         result.output,
         expected="Listed paths do not affect the dumped configuration.",
+    )
+
+
+# ---- Test hidden aliases ----
+
+
+def test_file_type_hidden_singular_aliases_are_not_shown_in_help() -> None:
+    """Hidden singular file type filter aliases are not shown in help."""
+    result: Result = run_cli([CliCmd.CHECK, CliOpt.HELP])
+
+    assert_SUCCESS(result)
+    assert_rich_output_contains(result.output, expected=CliOpt.INCLUDE_FILE_TYPES)
+    assert_rich_output_contains(result.output, expected=CliOpt.EXCLUDE_FILE_TYPES)
+
+    # We cannot use `assert_rich_output_does_not_contain()` here since the hidden singular alias
+    # is a substring of the canonical plural option name. We normalize the rich output by hand and
+    # use a regular expression instead:
+    normalized_output: str = normalize_rich_cli_output(result.output)
+    assert (
+        re.search(
+            rf"{re.escape(CliOpt.INCLUDE_FILE_TYPE)}(?!s)(?:\s|,)",
+            normalized_output,
+        )
+        is None
+    )
+    assert (
+        re.search(
+            rf"{re.escape(CliOpt.EXCLUDE_FILE_TYPE)}(?!s)(?:\s|,)",
+            normalized_output,
+        )
+        is None
     )

--- a/tests/cli/test_option_meta.py
+++ b/tests/cli/test_option_meta.py
@@ -1,0 +1,67 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_option_meta.py
+#   file_relpath : tests/cli/test_option_meta.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for CLI option metadata helpers."""
+
+from __future__ import annotations
+
+from topmark.cli.keys import CliOpt
+from topmark.cli.option_meta import CLI_HIDDEN_ALIAS_TARGETS
+from topmark.cli.option_meta import CLI_OPTION_META_BY_LONG
+from topmark.cli.option_meta import format_option_label
+from topmark.cli.option_meta import format_option_labels
+
+
+def test_format_option_label_returns_long_option_for_unknown_option() -> None:
+    """Unknown options should render unchanged."""
+    assert format_option_label("--unknown") == "--unknown"
+
+
+def test_format_option_label_includes_known_short_alias() -> None:
+    """Known options with short aliases should render both spellings."""
+    assert format_option_label(CliOpt.VERBOSE) == "--verbose (-v)"
+
+
+def test_format_option_label_resolves_hidden_alias_to_canonical_label() -> None:
+    """Hidden compatibility aliases should render using the canonical option."""
+    assert format_option_label(CliOpt.INCLUDE_FILE_TYPE) == ("--include-file-types (-t)")
+
+
+def test_format_option_labels_preserves_order() -> None:
+    """Multiple option labels should render in the original order."""
+    assert format_option_labels(
+        [
+            CliOpt.QUIET,
+            "--unknown",
+            CliOpt.INCLUDE_FILE_TYPE,
+        ]
+    ) == [
+        "--quiet (-q)",
+        "--unknown",
+        "--include-file-types (-t)",
+    ]
+
+
+def test_hidden_alias_targets_map_aliases_to_canonical_options() -> None:
+    """Hidden alias lookup should point to canonical long option spellings."""
+    assert CLI_HIDDEN_ALIAS_TARGETS == {
+        CliOpt.INCLUDE_FILE_TYPE: CliOpt.INCLUDE_FILE_TYPES,
+        CliOpt.EXCLUDE_FILE_TYPE: CliOpt.EXCLUDE_FILE_TYPES,
+    }
+
+
+def test_cli_option_meta_registry_contains_expected_known_options() -> None:
+    """Known metadata registry should expose stable canonical option keys."""
+    assert set(CLI_OPTION_META_BY_LONG) >= {
+        CliOpt.INCLUDE_FILE_TYPES,
+        CliOpt.EXCLUDE_FILE_TYPES,
+        CliOpt.VERBOSE,
+        CliOpt.QUIET,
+    }


### PR DESCRIPTION
## Summary

This PR introduces a small CLI option metadata helper used for human-facing
diagnostic rendering.

It adds metadata for:

- canonical long option spellings;
- short aliases used in diagnostics;
- hidden compatibility aliases for singular file-type filter options.

Validators now use this metadata instead of maintaining local short-alias
mappings.

## Scope

This is the first low-risk implementation slice for #72.

It intentionally preserves:

- Click as the authoritative parser/runtime layer;
- existing option declarations in `cli/options.py`;
- stable 1.x CLI option spellings;
- hidden singular compatibility aliases;
- validation semantics;
- machine-readable output behavior;
- exit-code behavior.

This PR does not introduce a full option registry and does not migrate command
applicability rules.

## Tests

Added coverage for:

- CLI option metadata label rendering;
- hidden alias canonicalization;
- hidden singular file-type aliases remaining hidden from help output;
- canonical plural and hidden singular file-type filter options being accepted;
- repeated singular/plural file-type filter options being accumulated correctly.

## Related issues

Refs #72.

This PR does not address #73, #74, or #75, which were identified separately
while exercising related CLI behavior.