### PR TITLE
Centralize CLI option applicability groups

### DIFF
--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -62,7 +62,7 @@ from topmark.cli.help import HelpExample
 from topmark.cli.help import render_examples_epilog
 from topmark.cli.io import plan_cli_inputs
 from topmark.cli.keys import CliCmd
-from topmark.cli.keys import CliOpt
+from topmark.cli.option_groups import PROBE_FORBIDDEN_OPTIONS
 from topmark.cli.options import PATH_COMMAND_CONTEXT_SETTINGS
 from topmark.cli.options import common_color_options
 from topmark.cli.options import common_config_resolution_options
@@ -251,30 +251,9 @@ def probe_command(
     # pipeline reporting, or generated-header rendering. `probe` shares input
     # and filtering semantics with `check`/`strip`, but remains read-only and
     # diagnostic-only.
-    _check_strip_reason: str = "Use this only with `topmark check` or `topmark strip`."
-    _check_reason: str = "Use this only with `topmark check`."
     validate_forbidden_options_in_extra_args(
         ctx,
-        forbidden_opts={
-            CliOpt.APPLY_CHANGES: _check_strip_reason,
-            CliOpt.WRITE_MODE: _check_strip_reason,
-            CliOpt.RENDER_DIFF: _check_strip_reason,
-            CliOpt.RESULTS_SUMMARY_MODE: _check_strip_reason,
-            CliOpt.REPORT: _check_strip_reason,
-            CliOpt.POLICY_HEADER_MUTATION_MODE: _check_reason,
-            CliOpt.POLICY_ALLOW_HEADER_IN_EMPTY_FILES: _check_reason,
-            CliOpt.POLICY_NO_ALLOW_HEADER_IN_EMPTY_FILES: _check_reason,
-            CliOpt.POLICY_EMPTY_INSERT_MODE: _check_reason,
-            CliOpt.POLICY_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS: _check_reason,
-            CliOpt.POLICY_NO_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS: _check_reason,
-            CliOpt.POLICY_ALLOW_REFLOW: _check_reason,
-            CliOpt.POLICY_NO_ALLOW_REFLOW: _check_reason,
-            CliOpt.HEADER_FIELDS: _check_reason,
-            CliOpt.FIELD_VALUES: _check_reason,
-            CliOpt.ALIGN_FIELDS: _check_reason,
-            CliOpt.NO_ALIGN_FIELDS: _check_reason,
-            CliOpt.RELATIVE_TO: _check_reason,
-        },
+        forbidden_opts=PROBE_FORBIDDEN_OPTIONS,
     )
 
     # Reject common unsupported option spellings that permissive path parsing

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -64,6 +64,7 @@ from topmark.cli.help import render_examples_epilog
 from topmark.cli.io import plan_cli_inputs
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
+from topmark.cli.option_groups import STRIP_FORBIDDEN_OPTIONS
 from topmark.cli.options import PATH_COMMAND_CONTEXT_SETTINGS
 from topmark.cli.options import common_apply_and_write_options
 from topmark.cli.options import common_color_options
@@ -282,24 +283,9 @@ def strip_command(
     # Reject options that belong to header generation/update. `strip` shares
     # input, reporting, diff, and write semantics with `check`, but it is a
     # removal-only command and must not accept generated-header controls.
-    _check_reason: str = "Use this only with `topmark check`."
     validate_forbidden_options_in_extra_args(
         ctx,
-        forbidden_opts={
-            CliOpt.POLICY_HEADER_MUTATION_MODE: _check_reason,
-            CliOpt.POLICY_ALLOW_HEADER_IN_EMPTY_FILES: _check_reason,
-            CliOpt.POLICY_NO_ALLOW_HEADER_IN_EMPTY_FILES: _check_reason,
-            CliOpt.POLICY_EMPTY_INSERT_MODE: _check_reason,
-            CliOpt.POLICY_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS: _check_reason,
-            CliOpt.POLICY_NO_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS: _check_reason,
-            CliOpt.POLICY_ALLOW_REFLOW: _check_reason,
-            CliOpt.POLICY_NO_ALLOW_REFLOW: _check_reason,
-            CliOpt.HEADER_FIELDS: _check_reason,
-            CliOpt.FIELD_VALUES: _check_reason,
-            CliOpt.ALIGN_FIELDS: _check_reason,
-            CliOpt.NO_ALIGN_FIELDS: _check_reason,
-            CliOpt.RELATIVE_TO: _check_reason,
-        },
+        forbidden_opts=STRIP_FORBIDDEN_OPTIONS,
     )
 
     # Reject common unsupported option spellings that permissive path parsing

--- a/src/topmark/cli/option_groups.py
+++ b/src/topmark/cli/option_groups.py
@@ -1,0 +1,95 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : option_groups.py
+#   file_relpath : src/topmark/cli/option_groups.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Command applicability groups for CLI options.
+
+This module is a narrow metadata layer for TopMark-owned applicability
+validation. It groups already-declared option spellings by the path-oriented
+commands that may accept them.
+
+Click option declarations remain in `topmark.cli.options`; this module must not
+become a generated parser model or a replacement for Click decorators.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from topmark.cli.keys import CliOpt
+
+CHECK_ONLY_OPTION_REASON: Final[str] = "Use this only with `topmark check`."
+"""Reason shown when a check-only option is used with another command."""
+
+CHECK_OR_STRIP_ONLY_OPTION_REASON: Final[str] = (
+    "Use this only with `topmark check` or `topmark strip`."
+)
+"""Reason shown when a check-or-strip-only option is used with another command."""
+
+CHECK_ONLY_GENERATED_HEADER_OPTIONS: Final[tuple[str, ...]] = (
+    CliOpt.POLICY_HEADER_MUTATION_MODE,
+    CliOpt.POLICY_ALLOW_HEADER_IN_EMPTY_FILES,
+    CliOpt.POLICY_NO_ALLOW_HEADER_IN_EMPTY_FILES,
+    CliOpt.POLICY_EMPTY_INSERT_MODE,
+    CliOpt.POLICY_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS,
+    CliOpt.POLICY_NO_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS,
+    CliOpt.POLICY_ALLOW_REFLOW,
+    CliOpt.POLICY_NO_ALLOW_REFLOW,
+    CliOpt.HEADER_FIELDS,
+    CliOpt.FIELD_VALUES,
+    CliOpt.ALIGN_FIELDS,
+    CliOpt.NO_ALIGN_FIELDS,
+    CliOpt.RELATIVE_TO,
+)
+"""Header generation/update controls accepted only by `topmark check`.
+
+These options configure generated header content or update policy. They are not
+meaningful for `topmark strip`, which removes headers, or `topmark probe`, which
+only reports file resolution and type support.
+"""
+
+CHECK_OR_STRIP_ONLY_PIPELINE_OPTIONS: Final[tuple[str, ...]] = (
+    CliOpt.APPLY_CHANGES,
+    CliOpt.WRITE_MODE,
+    CliOpt.RENDER_DIFF,
+    CliOpt.RESULTS_SUMMARY_MODE,
+    CliOpt.REPORT,
+)
+"""Pipeline mutation/reporting controls accepted by `check` and `strip`.
+
+These options either control writes, patch/diff previews, or report scope. They
+are intentionally rejected by `topmark probe`, which remains read-only and
+focused on discovery diagnostics.
+"""
+
+PROBE_FORBIDDEN_OPTIONS: Final[dict[str, str]] = {
+    **dict.fromkeys(
+        CHECK_OR_STRIP_ONLY_PIPELINE_OPTIONS,
+        CHECK_OR_STRIP_ONLY_OPTION_REASON,
+    ),
+    **dict.fromkeys(
+        CHECK_ONLY_GENERATED_HEADER_OPTIONS,
+        CHECK_ONLY_OPTION_REASON,
+    ),
+}
+"""Options accepted by permissive parsing but rejected by `topmark probe`.
+
+The values are human-facing reason strings used by command applicability
+validation.
+"""
+
+STRIP_FORBIDDEN_OPTIONS: Final[dict[str, str]] = dict.fromkeys(
+    CHECK_ONLY_GENERATED_HEADER_OPTIONS,
+    CHECK_ONLY_OPTION_REASON,
+)
+"""Options accepted by permissive parsing but rejected by `topmark strip`.
+
+The values are human-facing reason strings used by command applicability
+validation.
+"""

--- a/tests/cli/test_command_applicability.py
+++ b/tests/cli/test_command_applicability.py
@@ -8,7 +8,12 @@
 #
 # topmark:header:end
 
-"""CLI command-specific option applicability tests."""
+"""CLI command-specific option applicability tests.
+
+These tests intentionally import the production applicability groups so every
+centralized forbidden option remains covered. Argument values stay local to the
+test module because they are test fixtures, not CLI metadata.
+"""
 
 from __future__ import annotations
 
@@ -24,6 +29,10 @@ from tests.cli.conftest import assert_WOULD_CHANGE
 from tests.cli.conftest import run_cli
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
+from topmark.cli.option_groups import CHECK_ONLY_OPTION_REASON
+from topmark.cli.option_groups import CHECK_OR_STRIP_ONLY_OPTION_REASON
+from topmark.cli.option_groups import PROBE_FORBIDDEN_OPTIONS
+from topmark.cli.option_groups import STRIP_FORBIDDEN_OPTIONS
 
 if TYPE_CHECKING:
     from click.testing import Result
@@ -31,24 +40,38 @@ if TYPE_CHECKING:
 _STDIN_FLAG: str = "--stdin"
 _STDIN_FILENAME: str = CliOpt.STDIN_FILENAME
 _STDIN_GUIDANCE: str = "Use '-' with '--stdin-filename' to read one file's content from STDIN."
-_CHECK_ONLY_REASON: str = "Use this only with `topmark check`."
-_CHECK_STRIP_REASON: str = "Use this only with `topmark check` or `topmark strip`."
+
+
+# Values used when exercising option spellings that require an argument. Keep
+# these local to the tests: production applicability metadata should describe
+# whether an option applies to a command, not how a test should invoke it.
+_OPTION_VALUES: dict[str, str | None] = {
+    CliOpt.APPLY_CHANGES: None,
+    CliOpt.WRITE_MODE: "stdout",
+    CliOpt.RENDER_DIFF: None,
+    CliOpt.RESULTS_SUMMARY_MODE: "compact",
+    CliOpt.REPORT: "all",
+    CliOpt.POLICY_HEADER_MUTATION_MODE: "replace",
+    CliOpt.POLICY_ALLOW_HEADER_IN_EMPTY_FILES: None,
+    CliOpt.POLICY_NO_ALLOW_HEADER_IN_EMPTY_FILES: None,
+    CliOpt.POLICY_EMPTY_INSERT_MODE: "ignore",
+    CliOpt.POLICY_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS: None,
+    CliOpt.POLICY_NO_RENDER_EMPTY_HEADER_WHEN_NO_FIELDS: None,
+    CliOpt.POLICY_ALLOW_REFLOW: None,
+    CliOpt.POLICY_NO_ALLOW_REFLOW: None,
+    CliOpt.HEADER_FIELDS: "project,file",
+    CliOpt.FIELD_VALUES: "project=TopMark",
+    CliOpt.ALIGN_FIELDS: None,
+    CliOpt.NO_ALIGN_FIELDS: None,
+    CliOpt.RELATIVE_TO: "cwd",
+}
 
 
 @pytest.mark.parametrize(
     ("option", "value", "reason"),
     [
-        (CliOpt.APPLY_CHANGES, None, _CHECK_STRIP_REASON),
-        (CliOpt.WRITE_MODE, "stdout", _CHECK_STRIP_REASON),
-        (CliOpt.RENDER_DIFF, None, _CHECK_STRIP_REASON),
-        (CliOpt.RESULTS_SUMMARY_MODE, "compact", _CHECK_STRIP_REASON),
-        (CliOpt.REPORT, "all", _CHECK_STRIP_REASON),
-        (CliOpt.POLICY_HEADER_MUTATION_MODE, "replace", _CHECK_ONLY_REASON),
-        (CliOpt.HEADER_FIELDS, "project,file", _CHECK_ONLY_REASON),
-        (CliOpt.FIELD_VALUES, "project=TopMark", _CHECK_ONLY_REASON),
-        (CliOpt.ALIGN_FIELDS, None, _CHECK_ONLY_REASON),
-        (CliOpt.NO_ALIGN_FIELDS, None, _CHECK_ONLY_REASON),
-        (CliOpt.RELATIVE_TO, "cwd", _CHECK_ONLY_REASON),
+        (option, _OPTION_VALUES[option], reason)
+        for option, reason in PROBE_FORBIDDEN_OPTIONS.items()
     ],
 )
 def test_probe_rejects_inapplicable_path_command_options(
@@ -56,7 +79,7 @@ def test_probe_rejects_inapplicable_path_command_options(
     value: str | None,
     reason: str,
 ) -> None:
-    """`probe` must reject known check/strip options before input planning."""
+    """`probe` rejects every centralized check/strip-only option."""
     argv: list[str] = [CliCmd.PROBE, option]
     if value is not None:
         argv.append(value)
@@ -98,26 +121,19 @@ def test_probe_rejects_inapplicable_option_assignment_form() -> None:
     )
     assert_rich_output_contains(
         result.output,
-        expected=_CHECK_STRIP_REASON,
+        expected=CHECK_OR_STRIP_ONLY_OPTION_REASON,
     )
 
 
 @pytest.mark.parametrize(
     ("option", "value"),
-    [
-        (CliOpt.POLICY_HEADER_MUTATION_MODE, "replace"),
-        (CliOpt.HEADER_FIELDS, "project,file"),
-        (CliOpt.FIELD_VALUES, "project=TopMark"),
-        (CliOpt.ALIGN_FIELDS, None),
-        (CliOpt.NO_ALIGN_FIELDS, None),
-        (CliOpt.RELATIVE_TO, "cwd"),
-    ],
+    [(option, _OPTION_VALUES[option]) for option in STRIP_FORBIDDEN_OPTIONS],
 )
 def test_strip_rejects_generated_header_options(
     option: str,
     value: str | None,
 ) -> None:
-    """`strip` must reject check-only generated-header controls."""
+    """`strip` rejects every centralized check-only generated-header option."""
     argv: list[str] = [CliCmd.STRIP, option]
     if value is not None:
         argv.append(value)
@@ -135,7 +151,7 @@ def test_strip_rejects_generated_header_options(
     )
     assert_rich_output_contains(
         result.output,
-        expected=_CHECK_ONLY_REASON,
+        expected=CHECK_ONLY_OPTION_REASON,
     )
 
 
@@ -229,7 +245,7 @@ def test_probe_rejects_first_inapplicable_option_when_multiple_are_present() -> 
     )
     assert_rich_output_contains(
         result.output,
-        expected=_CHECK_STRIP_REASON,
+        expected=CHECK_OR_STRIP_ONLY_OPTION_REASON,
     )
 
 


### PR DESCRIPTION
## Summary

This PR adds a narrow CLI option applicability metadata layer.

It centralizes the option groups used to reject command-inapplicable options for:

- `topmark probe`
- `topmark strip`

The command modules now import these groups instead of maintaining inline
forbidden-option dictionaries.

## Scope

This completes the second low-risk slice of #72, following #76.

This PR intentionally preserves:

- Click as the authoritative parser/runtime layer;
- existing option declarations in `cli/options.py`;
- existing validation behavior;
- existing diagnostic wording;
- existing exit-code behavior;
- existing machine-readable output behavior.

It does not introduce registry-driven Click decorators or a generated parser
model.

## Tests

Updated command applicability tests so they import the production applicability
groups directly. This ensures every centralized forbidden option is covered
automatically while keeping test-only invocation values local to the test module.

Validated with:

```bash
make verify
```

## Related issues

Closes #72.