### PR TITLE
Fix misleading synthetic probe results for explicit inputs

### DIFF
--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -330,7 +330,8 @@ Common NDJSON kinds include:
 - `config_diagnostics` (counts-only in NDJSON prefix records)
 - `diagnostic` (one diagnostic per record; see "Diagnostics" below)
 - `result` (per-file result)
-- `probe` (per-path resolution probe, including filtered explicit inputs)
+- `probe` (per-path resolution probe, including filtered explicit file inputs and missing explicit
+  inputs that could not produce a normal resolution probe)
 - `summary` (one aggregated `(outcome, reason)` summary entry)
 - `version`
 - registry-specific kinds:
@@ -472,8 +473,9 @@ quiet mode.
 Probe output reports canonical file type identities after identifier normalization and file-type
 filtering.
 
-Filtered probe results use machine-friendly reasons to explain why a path did not reach probing.
-These include:
+Filtered probe results use machine-friendly reasons to explain why an explicit file input did not
+reach probing. Missing explicit inputs use `probe_missing` with `no_resolution_probe_result` when no
+normal resolution probe payload could be recorded. These include:
 
 - `excluded_by_path_filter` - excluded by path-based include/exclude rules
 - `excluded_by_file_type_filter` - excluded by file-type include/exclude rules after identifier
@@ -486,10 +488,12 @@ Refer to the machine schema reference for the per-path probe payload:
 
 Note:
 
-- Explicit missing literal inputs are surfaced via the CLI exit code (`FILE_NOT_FOUND (66)`), not as
-  a distinct probe status.
-- In mixed-input runs, probe payloads may still include filtered or unsupported entries, but
-  exit-code precedence is resolved outside the payload.
+- Explicit missing literal inputs are represented as `probe_missing` probe payloads and still fail
+  the CLI invocation with `FILE_NOT_FOUND (66)`.
+- Explicit directories that successfully expand to selected child files are treated as discovery
+  sources and are not emitted as separate filtered probe payloads.
+- In mixed-input runs, probe payloads may still include filtered, missing, or unsupported entries,
+  but exit-code precedence is resolved outside the payload.
 
 ______________________________________________________________________
 

--- a/docs/usage/commands/probe.md
+++ b/docs/usage/commands/probe.md
@@ -103,8 +103,12 @@ working directory; path-based filters run before file-type filters, and exclude 
 precedence. See [Filtering](../filtering.md#path-based-filtering) for the full path discovery
 contract.
 
-Unlike processing commands, `probe` may report explicitly requested paths as filtered diagnostic
+Unlike processing commands, `probe` may report explicitly requested files as filtered diagnostic
 results instead of silently omitting them.
+
+Explicit directories that successfully expand to selected files are treated as discovery inputs and
+are not reported as separate filtered probe results. Explicit missing paths are reported as missing
+input errors rather than filtered probe results.
 
 ### File type filters
 
@@ -244,7 +248,11 @@ ______________________________________________________________________
 }
 ```
 
-Filtered explicit inputs are also represented as semantic probe payloads
+Only explicit inputs that actually fail selection are represented as filtered probe payloads.
+
+Directories that successfully expand to selected files are not emitted as additional filtered probe
+results. Explicit missing paths are represented as missing-input probe results rather than filtered
+probe results.
 
 ```jsonc
 {
@@ -392,4 +400,5 @@ ______________________________________________________________________
 - **`--stdin` is rejected**: Use `-` as the PATH sentinel together with `--stdin-filename NAME` when
   reading one virtual file from STDIN content.
 - **Missing file error**: A literal path such as `fubar.py` is treated as an explicit input and
-  fails with `FILE_NOT_FOUND (66)` when it does not exist.
+  fails with `FILE_NOT_FOUND (66)` when it does not exist. Missing explicit inputs are reported as
+  missing-input probe results rather than filtered probe results.

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -232,7 +232,8 @@ formats expose the same resolution evidence used by the human-facing probe rende
 - probe status and reason
 - all scored candidate file types
 - candidate match signals
-- explicit inputs filtered during discovery before file-type probing
+- explicit file inputs filtered during discovery before file-type probing
+- explicit missing inputs that could not produce a normal resolution probe
 
 ### JSON schema
 
@@ -252,8 +253,9 @@ formats expose the same resolution evidence used by the human-facing probe rende
   policy.
 - `config_diagnostics`: full diagnostics payload including counts and the list of config
   diagnostics.
-- `probes`: one resolution probe payload per probed path, including explicit inputs filtered before
-  file-type probing.
+- `probes`: one resolution probe payload per probed path, including explicit file inputs filtered
+  before file-type probing and explicit missing inputs that could not produce a normal resolution
+  probe.
 
 ### NDJSON schema
 
@@ -292,7 +294,9 @@ ______________________________________________________________________
 
 Each element of the JSON `probes` array and each NDJSON `probe` record contains a **per-path
 resolution probe payload**. Most probe payloads correspond to files that reached file-type probing,
-but explicit inputs filtered during discovery are also represented as probe payloads.
+but explicit file inputs filtered during discovery are also represented as probe payloads. Explicit
+missing inputs are represented as `probe_missing` payloads when no normal resolution probe could be
+recorded.
 
 High-level shape:
 
@@ -346,9 +350,26 @@ Filtered explicit input shape:
 }
 ```
 
-Filtered probe payloads are emitted only for paths explicitly supplied to
+Missing explicit input shape:
+
+```jsonc
+{
+  "path": "topmark-does-not-exist",
+  "status": "probe_missing",
+  "reason": "no_resolution_probe_result",
+  "selected_file_type": null,
+  "selected_processor": null,
+  "candidates": []
+}
+```
+
+Filtered probe payloads are emitted only for explicit file inputs supplied to
 [`topmark probe`](../usage/commands/probe.md) (including paths loaded via `--files-from`). TopMark
 does not enumerate every recursively discovered file that was ignored by discovery filters.
+
+Explicit directories that successfully expand to selected child files are treated as discovery
+sources and are not emitted as separate filtered probe payloads. Explicit missing inputs are emitted
+as `probe_missing` payloads rather than filtered payloads.
 
 Filtered probe payloads may use one of these reasons:
 
@@ -359,15 +380,15 @@ Filtered probe payloads may use one of these reasons:
 
 Fields:
 
-- `path`: probed or explicitly requested filesystem path. For filtered explicit inputs, this is the
-  path supplied to the command.
+- `path`: probed or explicitly requested filesystem path. For filtered and missing explicit inputs,
+  this is the path supplied to the command.
 - `status`: probe status, currently one of:
   - `resolved` - a file type and processor were selected.
   - `unsupported` - no file type candidate matched.
   - `no_processor` - a file type was selected, but no processor binding was available.
-  - `filtered` - an explicitly requested input was filtered during discovery before file-type
+  - `filtered` - an explicitly requested file input was filtered during discovery before file-type
     probing.
-  - `probe_missing` - internal fallback used only if a pipeline result lacks a probe payload.
+  - `probe_missing` - an explicit input could not produce a normal resolution probe payload.
 - `reason`: machine-friendly explanation for the status and selection, for example:
   - `selected_highest_score`
   - `selected_by_tie_break`
@@ -378,11 +399,11 @@ Fields:
   - `excluded_by_discovery_filter`
   - `no_resolution_probe_result`
 - `selected_file_type`: selected canonical file type identity and score, or `null` when unresolved,
-  unbound, or filtered.
-- `selected_processor`: selected processor identity, or `null` when unresolved, unbound, or
-  filtered.
+  unbound, filtered, or missing.
+- `selected_processor`: selected processor identity, or `null` when unresolved, unbound, filtered,
+  or missing.
 - `candidates`: scored candidate file types in deterministic resolution order. Empty for filtered
-  explicit inputs and for unsupported paths with no candidates.
+  explicit inputs, missing explicit inputs, and unsupported paths with no candidates.
 
 Candidate fields:
 
@@ -411,10 +432,10 @@ Candidate fields:
 
 Note:
 
-- Explicit missing literal inputs are not represented as a dedicated probe status; they are reported
-  via CLI exit codes (`FILE_NOT_FOUND (66)`).
-- Synthetic probe entries may still appear for explicitly requested paths that were filtered during
-  discovery, but exit-code precedence is resolved at the CLI layer.
+- Explicit missing literal inputs are represented as `probe_missing` probe payloads and still fail
+  the CLI invocation with `FILE_NOT_FOUND (66)`.
+- Synthetic filtered probe entries may still appear for explicitly requested files that were
+  filtered during discovery, but exit-code precedence is resolved at the CLI layer.
 
 ______________________________________________________________________
 

--- a/src/topmark/api/runtime.py
+++ b/src/topmark/api/runtime.py
@@ -833,16 +833,8 @@ def run_probe_pipeline(
         else probe_explicit_file_selection(
             prepared.effective_cfg,
             selected_files=prepared.file_list,
+            missing_literals=prepared.file_resolution.missing_literals,
         )
-    )
-
-    # Missing explicit literals get hard error contexts below. Do not also emit a
-    # semantic filtered probe context for the same path.
-    missing_literal_paths: frozenset[Path] = frozenset(prepared.file_resolution.missing_literals)
-    filtered_selection_results = tuple(
-        selection
-        for selection in filtered_selection_results
-        if selection.path not in missing_literal_paths
     )
 
     execution: PipelineExecution = _execute_pipeline_for_file_list(

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -388,6 +388,7 @@ def probe_command(
         filtered_selection_results = probe_explicit_file_selection(
             config,
             selected_files=file_list,
+            missing_literals=file_resolution.missing_literals,
         )
 
     if (

--- a/src/topmark/resolution/files.py
+++ b/src/topmark/resolution/files.py
@@ -258,6 +258,25 @@ def _explicit_input_paths(config: FrozenConfig) -> list[Path]:
     return paths
 
 
+def _real_paths(paths: Sequence[Path]) -> set[Path]:
+    """Return normalized real paths for filesystem entries.
+
+    Args:
+        paths: Filesystem paths to normalize.
+
+    Returns:
+        Set of resolved paths. Paths that cannot be resolved are kept as
+        provided so comparison remains best-effort and non-fatal.
+    """
+    resolved: set[Path] = set()
+    for path in paths:
+        try:
+            resolved.add(path.resolve())
+        except OSError:
+            resolved.add(path)
+    return resolved
+
+
 def _selected_real_paths(selected_files: Sequence[Path]) -> set[Path]:
     """Return normalized real paths for selected file-list entries.
 
@@ -268,13 +287,40 @@ def _selected_real_paths(selected_files: Sequence[Path]) -> set[Path]:
         Set of resolved selected paths. Paths that cannot be resolved are kept
         as provided so comparison remains best-effort and non-fatal.
     """
-    selected: set[Path] = set()
-    for path in selected_files:
+    return _real_paths(selected_files)
+
+
+# --- Explicit-input selection helpers ---
+
+
+def _has_selected_descendant(
+    directory: Path,
+    selected_real: set[Path],
+) -> bool:
+    """Return whether `directory` contains at least one selected file.
+
+    Args:
+        directory: Explicit directory input to check.
+        selected_real: Resolved selected file paths returned by
+            [_selected_real_paths][topmark.resolution.files._selected_real_paths].
+
+    Returns:
+        True if at least one selected file is below `directory`.
+    """
+    try:
+        directory_real: Path = directory.resolve()
+    except OSError:
+        directory_real = directory
+
+    for selected in selected_real:
         try:
-            selected.add(path.resolve())
-        except OSError:
-            selected.add(path)
-    return selected
+            selected.relative_to(directory_real)
+        except ValueError:
+            continue
+        else:
+            return True
+
+    return False
 
 
 # --- Discovery filter explanation helpers ---
@@ -369,6 +415,7 @@ def probe_explicit_file_selection(
     config: FrozenConfig,
     *,
     selected_files: Sequence[Path],
+    missing_literals: Sequence[Path] = (),
 ) -> tuple[FileSelectionProbeResult, ...]:
     """Explain explicit inputs that were not selected for file-type probing.
 
@@ -380,12 +427,16 @@ def probe_explicit_file_selection(
     Args:
         config: Effective layered configuration used for file discovery.
         selected_files: Files selected by `resolve_file_list()`.
+        missing_literals: Literal input paths already reported by file-list
+            resolution as missing. These paths are skipped so probe does not
+            emit duplicate missing and filtered synthetic results.
 
     Returns:
         Discovery-level probe results for explicit inputs that did not reach
         file-type probing.
     """
     selected_real: set[Path] = _selected_real_paths(selected_files)
+    missing_real: set[Path] = _real_paths(missing_literals)
     results: list[FileSelectionProbeResult] = []
 
     for explicit in _explicit_input_paths(config):
@@ -394,7 +445,7 @@ def probe_explicit_file_selection(
         except OSError:
             real = explicit
 
-        if real in selected_real:
+        if real in selected_real or real in missing_real:
             continue
 
         if not explicit.exists():
@@ -408,6 +459,9 @@ def probe_explicit_file_selection(
             continue
 
         if not explicit.is_file():
+            if explicit.is_dir() and _has_selected_descendant(explicit, selected_real):
+                continue
+
             results.append(
                 FileSelectionProbeResult(
                     path=explicit,

--- a/tests/api/test_api_probe.py
+++ b/tests/api/test_api_probe.py
@@ -60,7 +60,10 @@ def test_probe_python_file_resolves_with_stable_candidate_shape(tmp_path: Path) 
     assert isinstance(file_result, api.ProbeFileResult)
     assert file_result.path == target
     assert file_result.status == "resolved"
-    assert file_result.reason in {"selected_highest_score", "selected_by_tie_break"}
+    assert file_result.reason in {
+        "selected_highest_score",
+        "selected_by_tie_break",
+    }
     assert file_result.selected_file_type == "python"
     assert file_result.selected_processor is not None
     assert file_result.candidates
@@ -93,7 +96,10 @@ def test_probe_unsupported_explicit_file_uses_public_strings(tmp_path: Path) -> 
 
     file_result: api.ProbeFileResult = result.files[0]
     assert file_result.path == target
-    assert file_result.status in {"unsupported", "filtered"}
+    assert file_result.status in {
+        "unsupported",
+        "filtered",
+    }
     assert isinstance(file_result.reason, str)
     assert file_result.selected_file_type is None
     assert file_result.selected_processor is None
@@ -113,6 +119,11 @@ def test_probe_missing_explicit_path_reports_error(tmp_path: Path) -> None:
 
     file_result: api.ProbeFileResult = result.files[0]
     assert file_result.path == missing
+
+    assert file_result.status == "error"
+    assert file_result.reason == "not found"
+    assert len(result.files) == 1
+
     assert file_result.selected_file_type is None
     assert file_result.selected_processor is None
     assert file_result.candidates == ()
@@ -141,3 +152,44 @@ def test_probe_explicit_input_filtered_by_file_type_is_reported(tmp_path: Path) 
     assert by_path[toml_file].reason == "excluded_by_file_type_filter"
     assert by_path[toml_file].candidates == ()
     assert result.summary.get("filtered", 0) >= 1
+
+
+# Directories that expand to selected files are not probe results.
+def test_probe_directory_with_selected_children_omits_directory_result(
+    tmp_path: Path,
+) -> None:
+    """Directories that expand to selected files are not probe results."""
+    directory: Path = tmp_path / "project"
+    directory.mkdir()
+
+    python_file: Path = directory / "example.py"
+    python_file.write_text("print('hello')\n", encoding="utf-8")
+
+    markdown_file: Path = directory / "README.md"
+    markdown_file.write_text("# Example\n", encoding="utf-8")
+
+    html_file: Path = directory / "index.html"
+    html_file.write_text("<h1>Example</h1>\n", encoding="utf-8")
+
+    result: api.ProbeRunResult = api.probe(
+        [directory],
+        include_file_types=[
+            "python",
+            "markdown",
+            "toml",
+        ],
+        exclude_file_types=[
+            "html",
+        ],
+    )
+
+    assert result.had_errors is False
+
+    by_path: dict[Path, api.ProbeFileResult] = {
+        file_result.path: file_result for file_result in result.files
+    }
+    assert set(by_path) == {python_file, markdown_file}
+    assert by_path[python_file].status == "resolved"
+    assert by_path[markdown_file].status == "resolved"
+    assert directory not in by_path
+    assert result.summary == {"resolved": 2}

--- a/tests/cli/machine/test_probe_machine.py
+++ b/tests/cli/machine/test_probe_machine.py
@@ -19,15 +19,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
-from click.testing import Result
 
+from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
 from tests.helpers.json import parse_json_object
 from tests.helpers.ndjson import parse_ndjson_records
 from tests.helpers.ndjson import record_kinds
 from tests.helpers.ndjson import record_payload
 from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
 from topmark.cli.main import cli
+from topmark.core.formats import OutputFormat
 from topmark.core.typing_guards import as_object_dict
 from topmark.core.typing_guards import is_any_list
 from topmark.core.typing_guards import is_mapping
@@ -35,6 +37,7 @@ from topmark.core.typing_guards import is_mapping
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from click.testing import Result
     from pytest import MonkeyPatch
 
 
@@ -49,12 +52,12 @@ def test_probe_json_output_shape(tmp_path: Path) -> None:
         [
             CliCmd.PROBE,
             str(file),
-            "--output-format",
-            "json",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
         ],
     )
 
-    assert result.exit_code == 0
+    assert_SUCCESS(result)
 
     payload: dict[str, object] = parse_json_object(result.output)
 
@@ -90,12 +93,12 @@ def test_probe_json_candidate_structure(tmp_path: Path) -> None:
         [
             CliCmd.PROBE,
             str(file),
-            "--output-format",
-            "json",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
         ],
     )
 
-    assert result.exit_code == 0
+    assert_SUCCESS(result)
 
     payload: dict[str, object] = parse_json_object(result.output)
     probes_obj: object = payload["probes"]
@@ -152,11 +155,11 @@ def test_probe_json_reports_explicit_filtered_input(
         cli,
         [
             CliCmd.PROBE,
-            "--exclude",
+            CliOpt.EXCLUDE_PATTERNS,
             "__pycache__/",
             input_path,
-            "--output-format",
-            "json",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
         ],
     )
 
@@ -186,6 +189,61 @@ def test_probe_json_reports_explicit_filtered_input(
     assert "match" not in probe
 
 
+def test_probe_json_omits_directory_filtered_result_when_children_selected(
+    tmp_path: Path,
+) -> None:
+    """JSON output should omit expanded directory synthetic filtered results."""
+    directory: Path = tmp_path / "project"
+    directory.mkdir()
+
+    python_file: Path = directory / "example.py"
+    python_file.write_text("print('hello')\n", encoding="utf-8")
+
+    markdown_file: Path = directory / "README.md"
+    markdown_file.write_text("# Example\n", encoding="utf-8")
+
+    html_file: Path = directory / "index.html"
+    html_file.write_text("<h1>Example</h1>\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            CliOpt.INCLUDE_FILE_TYPES,
+            "python",
+            CliOpt.INCLUDE_FILE_TYPES,
+            "markdown,toml",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "html",
+            str(directory),
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+        ],
+    )
+
+    assert_SUCCESS(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    probes_obj: object = payload["probes"]
+    assert is_any_list(probes_obj)
+    probes: list[object] = probes_obj
+    assert len(probes) == 2
+
+    probe_payloads: list[dict[str, object]] = []
+    for probe_obj in probes:
+        assert is_mapping(probe_obj)
+        probe_payloads.append(as_object_dict(probe_obj))
+
+    paths: set[object] = {probe["path"] for probe in probe_payloads}
+    assert str(python_file) in paths
+    assert str(markdown_file) in paths
+    assert str(directory) not in paths
+
+    statuses: set[object] = {probe["status"] for probe in probe_payloads}
+    assert statuses == {"resolved"}
+
+
 def test_probe_ndjson_output_shape(tmp_path: Path) -> None:
     """NDJSON output should contain probe records with correct structure."""
     file: Path = tmp_path / "example.py"
@@ -197,12 +255,12 @@ def test_probe_ndjson_output_shape(tmp_path: Path) -> None:
         [
             CliCmd.PROBE,
             str(file),
-            "--output-format",
-            "ndjson",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
         ],
     )
 
-    assert result.exit_code == 0
+    assert_SUCCESS(result)
 
     records: list[dict[str, object]] = parse_ndjson_records(result.output)
     kinds: list[str] = record_kinds(records)
@@ -238,11 +296,11 @@ def test_probe_ndjson_reports_explicit_filtered_input(
         cli,
         [
             CliCmd.PROBE,
-            "--exclude",
+            CliOpt.EXCLUDE_PATTERNS,
             "__pycache__/",
             input_path,
-            "--output-format",
-            "ndjson",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
         ],
     )
 
@@ -267,6 +325,33 @@ def test_probe_ndjson_reports_explicit_filtered_input(
     assert "match" not in payload
 
 
+def test_probe_ndjson_reports_missing_input_only_once(tmp_path: Path) -> None:
+    """NDJSON output should not duplicate missing inputs as filtered."""
+    missing: Path = tmp_path / "topmark-does-not-exist"
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            str(missing),
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
+        ],
+    )
+
+    assert result.exit_code != 0
+
+    records: list[dict[str, object]] = parse_ndjson_records(result.output)
+    probe_records: list[dict[str, object]] = [r for r in records if r["kind"] == "probe"]
+    assert len(probe_records) == 1
+
+    payload: dict[str, object] = record_payload(probe_records[0])
+    assert payload["path"] == str(missing)
+    assert payload["status"] == "probe_missing"
+    assert payload["reason"] == "no_resolution_probe_result"
+
+
 def test_probe_ndjson_multiple_files(tmp_path: Path) -> None:
     """NDJSON should emit one probe record per file."""
     file1: Path = tmp_path / "a.py"
@@ -276,18 +361,18 @@ def test_probe_ndjson_multiple_files(tmp_path: Path) -> None:
     file2.write_text("print('b')\n", encoding="utf-8")
 
     runner = CliRunner()
-    result = runner.invoke(
+    result: Result = runner.invoke(
         cli,
         [
             CliCmd.PROBE,
             str(file1),
             str(file2),
-            "--output-format",
-            "ndjson",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
         ],
     )
 
-    assert result.exit_code == 0
+    assert_SUCCESS(result)
 
     records: list[dict[str, object]] = parse_ndjson_records(result.output)
 

--- a/tests/cli/test_probe_exit_codes.py
+++ b/tests/cli/test_probe_exit_codes.py
@@ -28,6 +28,7 @@ from tests.cli.conftest import assert_FILE_NOT_FOUND
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
 from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
 from topmark.cli.main import cli
 
 if TYPE_CHECKING:
@@ -51,6 +52,37 @@ def test_probe_exit_code_success_for_supported_file(tmp_path: Path) -> None:
             str(file),
         ],
     )
+    assert_SUCCESS(result)
+
+
+def test_probe_exit_code_success_for_filtered_directory_with_selected_files(
+    tmp_path: Path,
+) -> None:
+    """Directory inputs with selected children should exit SUCCESS."""
+    directory: Path = tmp_path / "project"
+    directory.mkdir()
+    python_file: Path = directory / "example.py"
+    python_file.write_text("print('hello')\n", encoding="utf-8")
+    markdown_file: Path = directory / "README.md"
+    markdown_file.write_text("# Example\n", encoding="utf-8")
+    html_file: Path = directory / "index.html"
+    html_file.write_text("<h1>Example</h1>\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            CliOpt.INCLUDE_FILE_TYPES,
+            "python",
+            CliOpt.INCLUDE_FILE_TYPES,
+            "markdown,toml",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "html",
+            str(directory),
+        ],
+    )
+
     assert_SUCCESS(result)
 
 

--- a/tests/cli/test_probe_human_output.py
+++ b/tests/cli/test_probe_human_output.py
@@ -28,7 +28,9 @@ from click.testing import Result
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
 from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
 from topmark.cli.main import cli
+from topmark.core.formats import OutputFormat
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -56,7 +58,7 @@ def test_probe_text_output_progressively_expands_with_verbosity(tmp_path: Path) 
         [
             CliCmd.PROBE,
             str(file),
-            "-v",
+            CliOpt.VERBOSE,
         ],
     )
     result_vv: Result = runner.invoke(
@@ -64,7 +66,8 @@ def test_probe_text_output_progressively_expands_with_verbosity(tmp_path: Path) 
         [
             CliCmd.PROBE,
             str(file),
-            "-vv",
+            CliOpt.VERBOSE,
+            CliOpt.VERBOSE,
         ],
     )
 
@@ -90,6 +93,8 @@ def test_probe_text_output_progressively_expands_with_verbosity(tmp_path: Path) 
 
 
 # --- TEXT output: filtered explicit inputs ---
+
+
 def test_probe_text_output_reports_explicitly_filtered_input(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -107,7 +112,7 @@ def test_probe_text_output_reports_explicitly_filtered_input(
         cli,
         [
             CliCmd.PROBE,
-            "--exclude",
+            CliOpt.EXCLUDE_PATTERNS,
             "__pycache__/",
             input_path,
         ],
@@ -119,7 +124,68 @@ def test_probe_text_output_reports_explicitly_filtered_input(
     assert "filtered: excluded_by_path_filter" in result.output
 
 
+def test_probe_text_output_omits_directory_filtered_result_when_children_selected(
+    tmp_path: Path,
+) -> None:
+    """Expanded directories should not be reported as filtered inputs."""
+    directory: Path = tmp_path / "project"
+    directory.mkdir()
+
+    python_file: Path = directory / "example.py"
+    python_file.write_text("print('hello')\n", encoding="utf-8")
+
+    markdown_file: Path = directory / "README.md"
+    markdown_file.write_text("# Example\n", encoding="utf-8")
+
+    html_file: Path = directory / "index.html"
+    html_file.write_text("<h1>Example</h1>\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            CliOpt.INCLUDE_FILE_TYPES,
+            "python",
+            CliOpt.INCLUDE_FILE_TYPES,
+            "markdown,toml",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "html",
+            str(directory),
+        ],
+    )
+
+    assert_SUCCESS(result)
+
+    assert "example.py" in result.output
+    assert "README.md" in result.output
+    assert "<filtered>" not in result.output
+
+
+def test_probe_text_output_reports_missing_input_only_once(
+    tmp_path: Path,
+) -> None:
+    """Missing explicit inputs should not also appear as filtered."""
+    missing_directory: Path = tmp_path / "topmark-does-not-exist"
+    runner = CliRunner()
+
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            str(missing_directory),
+        ],
+    )
+
+    assert result.exit_code != 0
+
+    assert "probe-missing" in result.output
+    assert "<filtered>" not in result.output
+
+
 # --- Markdown output: verbosity and quiet controls ---
+
+
 def test_probe_markdown_output_ignores_text_verbosity(tmp_path: Path) -> None:
     """Markdown probe output should ignore TEXT-only verbosity flags."""
     file: Path = tmp_path / "example.py"
@@ -132,8 +198,8 @@ def test_probe_markdown_output_ignores_text_verbosity(tmp_path: Path) -> None:
         [
             CliCmd.PROBE,
             str(file),
-            "--output-format",
-            "markdown",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
         ],
     )
     result_v: Result = runner.invoke(
@@ -141,9 +207,9 @@ def test_probe_markdown_output_ignores_text_verbosity(tmp_path: Path) -> None:
         [
             CliCmd.PROBE,
             str(file),
-            "--output-format",
-            "markdown",
-            "-v",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            CliOpt.VERBOSE,
         ],
     )
 
@@ -171,9 +237,9 @@ def test_probe_markdown_output_ignores_text_quiet(tmp_path: Path) -> None:
         [
             CliCmd.PROBE,
             str(file),
-            "--output-format",
-            "markdown",
-            "--quiet",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            CliOpt.QUIET,
         ],
     )
 

--- a/tests/resolver/test_discovery.py
+++ b/tests/resolver/test_discovery.py
@@ -147,6 +147,22 @@ def test_probe_explicit_file_selection_reports_missing_file(tmp_path: Path) -> N
     assert result.reason == FileSelectionReason.NOT_FOUND
 
 
+def test_probe_explicit_file_selection_skips_reported_missing_literal(
+    tmp_path: Path,
+) -> None:
+    """Missing explicit inputs already reported by resolution should be skipped."""
+    file: Path = tmp_path / "missing.py"
+    cfg: FrozenConfig = make_frozen_config(files=[str(file)])
+
+    results: tuple[FileSelectionProbeResult, ...] = probe_explicit_file_selection(
+        cfg,
+        selected_files=[],
+        missing_literals=[file],
+    )
+
+    assert results == ()
+
+
 def test_probe_explicit_file_selection_reports_directory(tmp_path: Path) -> None:
     """Explicit directories omitted from selected files should be reported as not files."""
     directory: Path = tmp_path / "data"
@@ -163,3 +179,21 @@ def test_probe_explicit_file_selection_reports_directory(tmp_path: Path) -> None
     assert result.path == directory
     assert result.status == FileSelectionStatus.FILTERED
     assert result.reason == FileSelectionReason.NOT_A_FILE
+
+
+def test_probe_explicit_file_selection_omits_directory_with_selected_descendant(
+    tmp_path: Path,
+) -> None:
+    """Explicit directories with selected descendants are expansion sources."""
+    directory: Path = tmp_path / "data"
+    directory.mkdir()
+    file: Path = directory / "example.py"
+    file.write_text("print('hello')\n", encoding="utf-8")
+    cfg: FrozenConfig = make_frozen_config(files=[str(directory)])
+
+    results: tuple[FileSelectionProbeResult, ...] = probe_explicit_file_selection(
+        cfg,
+        selected_files=[file],
+    )
+
+    assert results == ()


### PR DESCRIPTION
## Summary

Fixes probe result classification for explicit inputs that do not directly become normal file-type probe targets.

This PR addresses two related probe issues:

- Closes #74
- Closes #81

## Changes

- Treat explicit directories that successfully expand to selected child files as discovery sources, not as separate filtered probe results.
- Skip synthetic filtered results for missing explicit inputs that were already reported by file-list resolution.
- Pass `missing_literals` into `probe_explicit_file_selection()` from both CLI and API probe paths.
- Keep filtered probe payloads for explicitly requested files that are genuinely excluded by discovery or file-type filters.
- Update probe machine-output documentation to describe:
  - filtered explicit file inputs;
  - `probe_missing` payloads for missing explicit inputs;
  - expanded directories not being emitted as duplicate filtered probe payloads.

## Tests

Added or updated coverage for:

- resolver-level explicit input classification;
- CLI probe exit-code behavior;
- human-readable probe output;
- JSON and NDJSON probe output;
- public API probe behavior.

## Validation

- All tests are green.
- Manual reproduction for #74 now exits successfully without a synthetic filtered directory result.
- Manual reproduction for #81 now reports one `probe-missing` result without a duplicate `<filtered>` result.