### PR TITLE
fix(cli): preserve config diagnostics on strict validation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,55 @@ sections **Added**, **Changed**, **Removed**, and **Fixed**.
 
 ______________________________________________________________________
 
+## [Unreleased]
+
+### Changed - Unreleased
+
+- Replaced the CLI presentation backend with Rich.
+- Adopted `rich-click` for CLI help rendering while preserving Click runtime semantics.
+- Centralized CLI option metadata and command-applicability groups used by diagnostics.
+- Hid singular file-type compatibility aliases from help output while preserving them as accepted
+  hidden aliases.
+
+### Fixed - Unreleased
+
+- Fixed post-1.0.1 documentation hygiene violations.
+- Trapped underscored option spellings consistently and suggested hyphenated alternatives.
+- Improved CLI validation diagnostic formatting.
+- Fixed misleading synthetic `probe` results for explicit directories that successfully expand to
+  selected child files.
+- Fixed duplicate `probe` records for missing explicit inputs.
+- Fixed strict config-validation failures so the triggering diagnostics remain visible in
+  human-readable output.
+- Preserved valid JSON/NDJSON config diagnostics when strict config validation stops command
+  execution.
+
+### Documentation - Unreleased
+
+- Updated probe and machine-output documentation for corrected explicit-input probe behavior.
+- Clarified strict configuration-validation diagnostics in shared configuration strictness
+  documentation.
+- Documented machine-readable output behavior when strict config validation stops commands before
+  probing or processing.
+
+### Internal - Unreleased
+
+- Removed stale tox references.
+- Updated pre-commit dependencies, including TopMark itself.
+- Refreshed locked dependencies including Ruff, Hypothesis, and uv.
+
+### Notes - Unreleased
+
+- CLI help output and selected human-facing validation diagnostics now use Rich / `rich-click`
+  presentation. Runtime behavior and machine-readable JSON/NDJSON contracts are unchanged, but
+  consumers or tests that assert exact human-readable terminal formatting may need to update
+  formatting-sensitive expectations.
+- Strict configuration-validation failures now preserve machine-readable JSON/NDJSON output. This
+  fixes invalid machine output in error paths, but consumers that previously treated such failures
+  as unparseable plain text may need to adjust their error handling.
+
+______________________________________________________________________
+
 ## [1.0.1] - 2026-05-26
 
 This first TopMark 1.0 patch release focuses on post-1.0 correctness fixes, documentation

--- a/docs/_snippets/config-strictness.md
+++ b/docs/_snippets/config-strictness.md
@@ -21,4 +21,7 @@ topmark:header:end
 > - merged-config diagnostics;
 > - runtime applicability diagnostics.
 >
+> When strict validation fails, TopMark exits with `CONFIG_ERROR`. The diagnostics that triggered
+> the failure remain visible in human-readable and machine-readable output formats.
+>
 > `strict` is resolved during TOML loading and does not become a layered configuration field.

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -85,6 +85,11 @@ Consumers must:
 - inspect the process exit code for success or failure semantics,
 - parse machine-readable output for detailed diagnostics and results.
 
+When strict configuration validation stops a command before probing or processing begins, TopMark
+still emits valid machine-readable configuration diagnostics. In that case, JSON output may contain
+a configuration-diagnostics envelope without normal `probes`, `results`, or `summary` payloads, and
+NDJSON output may contain only the configuration-diagnostics prefix records.
+
 This design ensures a clean separation between:
 
 - **process status** (exit code), and
@@ -257,6 +262,9 @@ formats expose the same resolution evidence used by the human-facing probe rende
   before file-type probing and explicit missing inputs that could not produce a normal resolution
   probe.
 
+If strict configuration validation stops `probe` before resolution begins, JSON output contains the
+same `meta` and `config_diagnostics` structure but may omit the normal `probes` payload.
+
 ### NDJSON schema
 
 NDJSON output follows the same stable config prefix used by processing commands, then emits one
@@ -278,6 +286,9 @@ NDJSON rules for `probe`:
   1. `config_diagnostics` (**counts-only**)
   1. zero or more `diagnostic` records (each with `domain="config"`)
 - Then one `probe` record is emitted per probe result.
+
+If strict configuration validation stops `probe` before resolution begins, the stream may end after
+the `config_diagnostics` and `diagnostic` records, before any `probe` records are emitted.
 
 The JSON `probes` key and NDJSON `probe` kind are defined in
 \[`topmark.pipeline.machine.schemas.PipelineKey`\][topmark.pipeline.machine.schemas.PipelineKey] and
@@ -470,6 +481,10 @@ Detail mode corresponds to `summary_mode = false`.
   \[`topmark.config.machine.payloads.build_config_diagnostics_payload`\][topmark.config.machine.payloads.build_config_diagnostics_payload].
 - `results`: one entry per processed file (see **Per-file result payload** below).
 
+If strict configuration validation stops a processing command before file discovery or pipeline
+execution begins, JSON output contains the same `meta` and `config_diagnostics` structure but may
+omit the normal `results` or `summary` payload.
+
 ### JSON schema (summary mode)
 
 Summary mode corresponds to `summary_mode = true`.
@@ -546,6 +561,10 @@ NDJSON rules for processing commands:
 - Then either:
   - detail mode: one `result` record per file
   - summary mode: one `summary` record per `(outcome, reason)` bucket
+
+If strict configuration validation stops a processing command before file discovery or pipeline
+execution begins, the stream may end after the `config_diagnostics` and `diagnostic` records, before
+any `result` or `summary` records are emitted.
 
 The NDJSON record stream is produced by:
 

--- a/src/topmark/cli/cmd_common.py
+++ b/src/topmark/cli/cmd_common.py
@@ -25,11 +25,13 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import NoReturn
 
 import click
 
 from topmark.cli.console.click_console import Console
 from topmark.cli.console.color import resolve_color_mode
+from topmark.cli.emitters.machine import emit_config_diagnostics_machine
 from topmark.cli.options import ColorMode
 from topmark.cli.options import normalize_verbosity
 from topmark.cli.presentation import TextStyler
@@ -45,9 +47,13 @@ from topmark.config.resolution.bridge import resolve_toml_sources_and_build_muta
 from topmark.config.types import FileWriteStrategy
 from topmark.config.types import OutputTarget
 from topmark.core.constants import CLI_OVERRIDE_STR
+from topmark.core.exit_codes import ExitCode
+from topmark.core.formats import OutputFormat
 from topmark.core.logging import resolve_env_log_level
 from topmark.core.logging import setup_logging
 from topmark.core.presentation import StyleRole
+from topmark.presentation.markdown.diagnostic import render_diagnostics_markdown
+from topmark.presentation.text.diagnostic import render_diagnostics_text
 from topmark.resolution.files import FileListResolution
 from topmark.resolution.files import resolve_file_list_with_diagnostics
 from topmark.runtime.model import RunOptions
@@ -62,8 +68,9 @@ if TYPE_CHECKING:
     from topmark.config.model import MutableConfig
     from topmark.config.policy import MutablePolicy
     from topmark.config.resolution.bridge import ResolvedConfigDraft
-    from topmark.core.exit_codes import ExitCode
-    from topmark.core.formats import OutputFormat
+    from topmark.core.errors import ConfigValidationError
+    from topmark.core.machine.schemas import MetaPayload
+    from topmark.diagnostic.model import FrozenDiagnosticLog
     from topmark.toml.resolution import ResolvedTopmarkTomlSources
 
 
@@ -332,6 +339,69 @@ class PreparedCliConfig:
 
     resolved_toml: ResolvedTopmarkTomlSources
     draft: MutableConfig
+
+
+def exit_for_config_validation_error(
+    *,
+    ctx: click.Context,
+    console: ConsoleProtocol,
+    exc: ConfigValidationError,
+    config: FrozenConfig,
+    fmt: OutputFormat,
+    meta: MetaPayload,
+    verbosity_level: int,
+    quiet: bool,
+    color: bool,
+) -> NoReturn:
+    """Render config diagnostics for a validation failure and exit.
+
+    Strict config validation may stop a command before normal probe or
+    processing output exists. This helper preserves the existing `CONFIG_ERROR`
+    exit contract while ensuring the diagnostics that caused the failure remain
+    visible in the active output format.
+
+    Args:
+        ctx: Active Click context used to exit with `CONFIG_ERROR`.
+        console: Console used for command output.
+        exc: Validation exception raised by config validation.
+        config: Effective frozen configuration carrying validation logs.
+        fmt: Active output format.
+        meta: Machine-output metadata for JSON and NDJSON diagnostics.
+        verbosity_level: Effective TEXT verbosity level.
+        quiet: Whether TEXT quiet mode is enabled.
+        color: Whether TEXT output should use color.
+    """
+    if fmt in (OutputFormat.JSON, OutputFormat.NDJSON):
+        emit_config_diagnostics_machine(
+            console=console,
+            meta=meta,
+            config=config,
+            fmt=fmt,
+        )
+        ctx.exit(ExitCode.CONFIG_ERROR)
+
+    flattened_diagnostics: FrozenDiagnosticLog = config.validation_logs.flattened()
+
+    console.error(f"Processing stopped: {exc}")
+
+    if fmt == OutputFormat.MARKDOWN:
+        diagnostics_md: str = render_diagnostics_markdown(
+            diagnostics=flattened_diagnostics,
+        )
+        if diagnostics_md:
+            console.print(diagnostics_md)
+        ctx.exit(ExitCode.CONFIG_ERROR)
+
+    if not quiet:
+        diagnostics_text: str = render_diagnostics_text(
+            diagnostics=flattened_diagnostics,
+            verbosity_level=max(verbosity_level, 1),
+            color=color,
+        )
+        if diagnostics_text:
+            console.print(diagnostics_text)
+
+    ctx.exit(ExitCode.CONFIG_ERROR)
 
 
 def build_resolved_toml_sources_and_config_for_plan(

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -58,6 +58,7 @@ from topmark.api.runtime import select_pipeline
 from topmark.cli.cmd_common import build_file_resolution
 from topmark.cli.cmd_common import build_resolved_toml_sources_and_config_for_plan
 from topmark.cli.cmd_common import build_run_options
+from topmark.cli.cmd_common import exit_for_config_validation_error
 from topmark.cli.cmd_common import exit_if_no_files
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
@@ -422,8 +423,17 @@ def check_command(
             resolved=prepared_cli_config.resolved_toml,
         )
     except ConfigValidationError as exc:
-        console.error(f"Processing stopped: {exc}")
-        ctx.exit(ExitCode.CONFIG_ERROR)
+        exit_for_config_validation_error(
+            ctx=ctx,
+            console=console,
+            exc=exc,
+            config=config,
+            fmt=fmt,
+            meta=meta,
+            verbosity_level=verbosity_level,
+            quiet=state.quiet,
+            color=enable_color,
+        )
 
     # Display config validation diagnostics before resolving files.
     # TEXT keeps these behind -v; Markdown renders diagnostics whenever present.

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -53,6 +53,7 @@ from topmark.cli.cmd_common import PreparedCliConfig
 from topmark.cli.cmd_common import build_file_resolution
 from topmark.cli.cmd_common import build_resolved_toml_sources_and_config_for_plan
 from topmark.cli.cmd_common import build_run_options
+from topmark.cli.cmd_common import exit_for_config_validation_error
 from topmark.cli.cmd_common import exit_if_no_files
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
@@ -349,8 +350,17 @@ def probe_command(
             resolved=prepared_cli_config.resolved_toml,
         )
     except ConfigValidationError as exc:
-        console.error(f"Processing stopped: {exc}")
-        ctx.exit(ExitCode.CONFIG_ERROR)
+        exit_for_config_validation_error(
+            ctx=ctx,
+            console=console,
+            exc=exc,
+            config=config,
+            fmt=fmt,
+            meta=meta,
+            verbosity_level=verbosity_level,
+            quiet=state.quiet,
+            color=enable_color,
+        )
 
     # Display config validation diagnostics before resolving files.
     # TEXT keeps these behind -v; Markdown renders diagnostics whenever present.

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -54,6 +54,7 @@ from topmark.api.runtime import select_pipeline
 from topmark.cli.cmd_common import build_file_resolution
 from topmark.cli.cmd_common import build_resolved_toml_sources_and_config_for_plan
 from topmark.cli.cmd_common import build_run_options
+from topmark.cli.cmd_common import exit_for_config_validation_error
 from topmark.cli.cmd_common import exit_if_no_files
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
@@ -391,8 +392,17 @@ def strip_command(
             resolved=prepared_cli_config.resolved_toml,
         )
     except ConfigValidationError as exc:
-        console.error(f"Processing stopped: {exc}")
-        ctx.exit(ExitCode.CONFIG_ERROR)
+        exit_for_config_validation_error(
+            ctx=ctx,
+            console=console,
+            exc=exc,
+            config=config,
+            fmt=fmt,
+            meta=meta,
+            verbosity_level=verbosity_level,
+            quiet=state.quiet,
+            color=enable_color,
+        )
 
     # Display config validation diagnostics before resolving files.
     # TEXT keeps these behind -v; Markdown renders diagnostics whenever present.

--- a/src/topmark/config/model.py
+++ b/src/topmark/config/model.py
@@ -778,17 +778,18 @@ class MutableConfig:
             is_exclusion=True,
         )
 
-        # If a type appears in both include and exclude, prefer exclusion.
+        # If a type appears in both include and exclude, keep both selectors.
+        # Downstream filtering applies includes first and exclusions second, so
+        # exclusion still wins without collapsing an emptied include set into the
+        # default "include all file types" behavior.
         overlap: set[str] = self.include_file_types & self.exclude_file_types
         if overlap:
             overlap_str: str = ", ".join(sorted(overlap))
             msg: str = (
                 "File types specified in both include and exclude filters; "
-                f"exclusion wins (removed from include): {overlap_str}"
+                f"exclusion wins: {overlap_str}"
             )
             self.validation_logs.runtime_applicability.add_warning(msg)
-            # Remove overlaps (blacklisted wins from whitelisted):
-            self.include_file_types.difference_update(overlap)
 
         def _sanitize_policy_by_type() -> None:
             """Resolve per-type policy keys to canonical qualified file type keys.

--- a/tests/cli/machine/test_probe_machine.py
+++ b/tests/cli/machine/test_probe_machine.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from click.testing import CliRunner
 
+from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
+from tests.helpers.config_diagnostics import assert_config_diagnostics_warning_payload
+from tests.helpers.config_diagnostics import assert_overlap_warning_text
 from tests.helpers.json import parse_json_object
 from tests.helpers.ndjson import parse_ndjson_records
 from tests.helpers.ndjson import record_kinds
@@ -244,6 +248,60 @@ def test_probe_json_omits_directory_filtered_result_when_children_selected(
     assert statuses == {"resolved"}
 
 
+# Regression test: strict config warnings yield machine-readable diagnostics in JSON mode
+@pytest.mark.parametrize(
+    ("include_file_types", "exclude_file_types", "expected_removed_file_types"),
+    [
+        ("python", "python", ("topmark:python",)),
+        ("python", "topmark:python", ("topmark:python",)),
+        ("topmark:python", "python", ("topmark:python",)),
+        ("topmark:python", "topmark:python", ("topmark:python",)),
+        (
+            "topmark:python,topmark:markdown",
+            "python,markdown",
+            ("topmark:python", "topmark:markdown"),
+        ),
+    ],
+)
+def test_probe_json_strict_config_warning_emits_machine_diagnostics(
+    tmp_path: Path,
+    include_file_types: str,
+    exclude_file_types: str,
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """Strict config warnings should remain machine-readable in JSON mode.
+
+    When strict mode escalates a config warning to `CONFIG_ERROR`, probing stops
+    before file resolution. JSON output should still be a valid
+    config-diagnostics envelope instead of human-oriented error text.
+    """
+    file: Path = tmp_path / "example.py"
+    file.write_text("print('hello')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            include_file_types,
+            CliOpt.EXCLUDE_FILE_TYPES,
+            exclude_file_types,
+            str(file),
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
+    payload: dict[str, object] = parse_json_object(result.output)
+    assert_config_diagnostics_warning_payload(
+        payload,
+        expected_removed_file_types,
+    )
+
+
 def test_probe_ndjson_output_shape(tmp_path: Path) -> None:
     """NDJSON output should contain probe records with correct structure."""
     file: Path = tmp_path / "example.py"
@@ -378,3 +436,77 @@ def test_probe_ndjson_multiple_files(tmp_path: Path) -> None:
 
     probe_records: list[dict[str, object]] = [r for r in records if r["kind"] == "probe"]
     assert len(probe_records) == 2
+
+
+# Regression test: strict config warnings yield machine-readable diagnostics in NDJSON mode
+@pytest.mark.parametrize(
+    ("include_file_types", "exclude_file_types", "expected_removed_file_types"),
+    [
+        ("python", "python", ("topmark:python",)),
+        ("python", "topmark:python", ("topmark:python",)),
+        ("topmark:python", "python", ("topmark:python",)),
+        ("topmark:python", "topmark:python", ("topmark:python",)),
+        (
+            "topmark:python,topmark:markdown",
+            "python,markdown",
+            ("topmark:python", "topmark:markdown"),
+        ),
+    ],
+)
+def test_probe_ndjson_strict_config_warning_emits_machine_diagnostics(
+    tmp_path: Path,
+    include_file_types: str,
+    exclude_file_types: str,
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """Strict config warnings should remain machine-readable in NDJSON mode."""
+    file: Path = tmp_path / "example.py"
+    file.write_text("print('hello')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            include_file_types,
+            CliOpt.EXCLUDE_FILE_TYPES,
+            exclude_file_types,
+            str(file),
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
+    records: list[dict[str, object]] = parse_ndjson_records(result.output)
+    assert records
+
+    kinds: list[str] = record_kinds(records)
+    assert "config_diagnostics" in kinds
+    assert "diagnostic" in kinds
+
+    diagnostic_messages: list[str] = []
+    for record in records:
+        if record.get("kind") != "diagnostic":
+            continue
+
+        diagnostic_obj: object | None = record.get("diagnostic")
+        assert is_mapping(diagnostic_obj)
+        diagnostic: dict[str, object] = as_object_dict(diagnostic_obj)
+
+        domain_obj: object | None = diagnostic.get("domain")
+        level_obj: object | None = diagnostic.get("level")
+        message_obj: object | None = diagnostic.get("message")
+
+        assert domain_obj == "config"
+        assert level_obj == "warning"
+        assert isinstance(message_obj, str)
+        diagnostic_messages.append(message_obj)
+
+    assert diagnostic_messages
+    assert_overlap_warning_text(
+        "\n".join(diagnostic_messages),
+        expected_removed_file_types,
+    )

--- a/tests/cli/machine/test_processing_machine.py
+++ b/tests/cli/machine/test_processing_machine.py
@@ -40,14 +40,18 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
 from tests.cli.conftest import run_cli_in
+from tests.helpers.config_diagnostics import assert_config_diagnostics_warning_payload
+from tests.helpers.config_diagnostics import assert_overlap_warning_text
 from tests.helpers.json import parse_json_object
 from tests.helpers.ndjson import assert_ndjson_meta
 from tests.helpers.ndjson import parse_ndjson_records
 from tests.helpers.ndjson import record_kinds
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
+from topmark.core.formats import OutputFormat
 from topmark.core.typing_guards import as_object_dict
 from topmark.core.typing_guards import is_any_list
 from topmark.core.typing_guards import is_mapping
@@ -56,6 +60,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from click.testing import Result
+
 
 # ----- JSON -----
 
@@ -86,7 +91,7 @@ def test_processing_json_includes_meta(tmp_path: Path, command: str) -> None:
         [
             command,
             CliOpt.OUTPUT_FORMAT,
-            "json",
+            OutputFormat.JSON.value,
             ".",
         ],
     )
@@ -133,7 +138,7 @@ def test_processing_json_detail_shape(tmp_path: Path, command: str) -> None:
         [
             command,
             CliOpt.OUTPUT_FORMAT,
-            "json",
+            OutputFormat.JSON.value,
             ".",
         ],
     )
@@ -237,7 +242,7 @@ def test_processing_json_summary_shape(tmp_path: Path, command: str) -> None:
         [
             command,
             CliOpt.OUTPUT_FORMAT,
-            "json",
+            OutputFormat.JSON.value,
             CliOpt.RESULTS_SUMMARY_MODE,
             ".",
         ],
@@ -288,7 +293,7 @@ def test_processing_json_summary_rows_do_not_use_legacy_key_label_shape(
         [
             command,
             CliOpt.OUTPUT_FORMAT,
-            "json",
+            OutputFormat.JSON.value,
             CliOpt.RESULTS_SUMMARY_MODE,
             ".",
         ],
@@ -310,6 +315,43 @@ def test_processing_json_summary_rows_do_not_use_legacy_key_label_shape(
         assert "count" in row
         assert "key" not in row
         assert "label" not in row
+
+
+# Regression test: strict config warnings should remain machine-readable in JSON mode
+@pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP])
+def test_processing_json_strict_config_warning_emits_machine_diagnostics(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Strict config warnings should remain machine-readable in JSON mode.
+
+    When strict mode escalates a config warning to `CONFIG_ERROR`, processing
+    stops before file resolution. JSON output should still be a valid
+    config-diagnostics envelope instead of human-oriented error text.
+    """
+    (tmp_path / "example.py").write_text("print('hi')\n", encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            "topmark:python,topmark:markdown",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "python,markdown",
+            ".",
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
+    payload: dict[str, object] = parse_json_object(result.output)
+    assert_config_diagnostics_warning_payload(
+        payload,
+        ("topmark:python", "topmark:markdown"),
+    )
 
 
 # ----- NDJSON -----
@@ -342,7 +384,7 @@ def test_processing_ndjson_kinds_with_summary(tmp_path: Path, command: str) -> N
         [
             command,
             CliOpt.OUTPUT_FORMAT,
-            "ndjson",
+            OutputFormat.NDJSON.value,
             CliOpt.RESULTS_SUMMARY_MODE,
             ".",
         ],
@@ -397,7 +439,7 @@ def test_processing_ndjson_summary_rows_do_not_use_legacy_key_label_shape(
         [
             command,
             CliOpt.OUTPUT_FORMAT,
-            "ndjson",
+            OutputFormat.NDJSON.value,
             CliOpt.RESULTS_SUMMARY_MODE,
             ".",
         ],
@@ -427,3 +469,61 @@ def test_processing_ndjson_summary_rows_do_not_use_legacy_key_label_shape(
         assert "label" not in summary
 
     assert summary_records_found > 0
+
+
+# Regression test: strict config warnings should remain machine-readable in NDJSON mode
+@pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP])
+def test_processing_ndjson_strict_config_warning_emits_machine_diagnostics(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Strict config warnings should remain machine-readable in NDJSON mode."""
+    (tmp_path / "example.py").write_text("print('hi')\n", encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            "topmark:python,topmark:markdown",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "python,markdown",
+            ".",
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
+    records: list[dict[str, object]] = parse_ndjson_records(result.output)
+    assert records
+
+    kinds: list[str] = record_kinds(records)
+    assert "config_diagnostics" in kinds
+    assert "diagnostic" in kinds
+
+    diagnostic_messages: list[str] = []
+    for record in records:
+        assert_ndjson_meta(record.get("meta"), expected_detail_level="brief")
+        if record.get("kind") != "diagnostic":
+            continue
+
+        diagnostic_obj: object | None = record.get("diagnostic")
+        assert is_mapping(diagnostic_obj)
+        diagnostic: dict[str, object] = as_object_dict(diagnostic_obj)
+
+        domain_obj: object | None = diagnostic.get("domain")
+        level_obj: object | None = diagnostic.get("level")
+        message_obj: object | None = diagnostic.get("message")
+
+        assert domain_obj == "config"
+        assert level_obj == "warning"
+        assert isinstance(message_obj, str)
+        diagnostic_messages.append(message_obj)
+
+    assert diagnostic_messages
+    assert_overlap_warning_text(
+        "\n".join(diagnostic_messages),
+        ("topmark:python", "topmark:markdown"),
+    )

--- a/tests/cli/test_config_overrides.py
+++ b/tests/cli/test_config_overrides.py
@@ -159,7 +159,8 @@ def test_cli_write_mode_overrides_local_writer_option(
         [
             CliCmd.CHECK,
             CliOpt.APPLY_CHANGES,
-            "--write-mode=atomic",
+            CliOpt.WRITE_MODE,
+            "atomic",
             file_name,
         ],
     )
@@ -213,3 +214,40 @@ def test_invalid_topmark_toml_exits_config_error_in_strict_mode(
 
     # Strict config checking escalates config-resolution diagnostics to CONFIG_ERROR.
     assert_CONFIG_ERROR(result)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        CliCmd.CHECK,
+        CliCmd.STRIP,
+        CliCmd.PROBE,
+    ],
+)
+def test_strict_config_warning_renders_actionable_diagnostic_for_processing_commands(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Strict config failure should still render the warning that caused it."""
+    file_name = "x.py"
+    f: Path = tmp_path / file_name
+    f.write_text("print('ok')\n", "utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            "topmark:python",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "python",
+            file_name,
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
+    out: str = result.output.lower()
+    assert "file types specified in both include and exclude filters" in out
+    assert "exclusion wins" in out
+    assert "topmark:python" in out

--- a/tests/cli/test_file_type_and_skip_flags.py
+++ b/tests/cli/test_file_type_and_skip_flags.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
 from tests.cli.conftest import run_cli
@@ -244,6 +245,117 @@ def test_file_type_filter_accepts_plural_and_hidden_singular_aliases(
     assert TOPMARK_START_MARKER in md.read_text("utf-8")
     assert TOPMARK_START_MARKER not in java.read_text("utf-8")
     assert TOPMARK_START_MARKER in toml.read_text("utf-8")
+
+
+@pytest.mark.parametrize(
+    (
+        "include_file_types",
+        "exclude_file_types",
+        "expected_py_has_header",
+        "expected_md_has_header",
+        "expected_ts_has_header",
+    ),
+    [
+        ("topmark:python", "python", False, False, False),
+        ("python", "topmark:python", False, False, False),
+        ("topmark:python", "topmark:python", False, False, False),
+        ("topmark:python,topmark:markdown", "python", False, True, False),
+        ("topmark:python,topmark:markdown", "python,markdown", False, False, False),
+    ],
+)
+def test_file_type_filter_normalized_overlap_excludes_matching_types(
+    tmp_path: Path,
+    include_file_types: str,
+    exclude_file_types: str,
+    expected_py_has_header: bool,
+    expected_md_has_header: bool,
+    expected_ts_has_header: bool,
+) -> None:
+    """Overlapping include/exclude file-type filters are normalized before filtering.
+
+    Local identifiers such as `python` and qualified identifiers such as
+    `topmark:python` may resolve to the same canonical file type. When an
+    include and exclude entry overlap after normalization, exclusion wins for
+    the overlapping canonical type only. Non-overlapping include entries remain
+    selected and should still be processed.
+    """
+    py: Path = tmp_path / "a.py"
+    md: Path = tmp_path / "a.md"
+    ts: Path = tmp_path / "a.ts"
+
+    py.write_text("print('x')\n", "utf-8")
+    md.write_text("# Title\n", "utf-8")
+    ts.write_text("console.log(1);\n", "utf-8")
+
+    result: Result = run_cli(
+        [
+            CliCmd.CHECK,
+            CliOpt.INCLUDE_FILE_TYPES,
+            include_file_types,
+            CliOpt.EXCLUDE_FILE_TYPES,
+            exclude_file_types,
+            CliOpt.APPLY_CHANGES,
+            str(tmp_path),
+        ],
+    )
+
+    assert_SUCCESS(result)
+    assert (TOPMARK_START_MARKER in py.read_text("utf-8")) is expected_py_has_header
+    assert (TOPMARK_START_MARKER in md.read_text("utf-8")) is expected_md_has_header
+    assert (TOPMARK_START_MARKER in ts.read_text("utf-8")) is expected_ts_has_header
+
+
+@pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP, CliCmd.PROBE])
+@pytest.mark.parametrize(
+    ("include_file_types", "exclude_file_types", "expected_removed_file_types"),
+    [
+        ("python", "python", ("topmark:python",)),
+        ("python", "topmark:python", ("topmark:python",)),
+        ("topmark:python", "python", ("topmark:python",)),
+        ("topmark:python", "topmark:python", ("topmark:python",)),
+        (
+            "topmark:python,topmark:markdown",
+            "python,markdown",
+            ("topmark:python", "topmark:markdown"),
+        ),
+    ],
+)
+def test_strict_file_type_filter_overlap_reports_actionable_warning(
+    tmp_path: Path,
+    command: str,
+    include_file_types: str,
+    exclude_file_types: str,
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """Strict mode fails on normalized overlap warnings and renders their cause.
+
+    Overlapping include/exclude file-type filters are deterministic because
+    exclusion wins, but the overlap is still an actionable configuration
+    warning. Under strict mode, that warning should stop processing with
+    `CONFIG_ERROR` while preserving the diagnostic details that explain which
+    canonical file types were removed from the include set.
+    """
+    py: Path = tmp_path / "a.py"
+    py.write_text("print('x')\n", "utf-8")
+
+    result: Result = run_cli(
+        [
+            command,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            include_file_types,
+            CliOpt.EXCLUDE_FILE_TYPES,
+            exclude_file_types,
+            str(py),
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
+    out: str = result.output.lower()
+    assert "file types specified in both include and exclude filters" in out
+    assert "exclusion wins" in out
+    for expected_removed_file_type in expected_removed_file_types:
+        assert expected_removed_file_type in out
 
 
 @pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP, CliCmd.PROBE])

--- a/tests/cli/test_pipeline_human_output.py
+++ b/tests/cli/test_pipeline_human_output.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_WOULD_CHANGE
 from tests.cli.conftest import run_cli
@@ -34,6 +35,7 @@ from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.core.constants import TOPMARK_END_MARKER
 from topmark.core.constants import TOPMARK_START_MARKER
+from topmark.core.formats import OutputFormat
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -70,6 +72,98 @@ def _write_file_requiring_pipeline_change(tmp_path: Path, cmd: str) -> Path:
         _write_file_requiring_check_update(tmp_path)
         if cmd == CliCmd.CHECK
         else _write_file_requiring_strip(tmp_path)
+    )
+
+
+# --- Strict config diagnostics ---
+
+
+def _assert_strict_file_type_overlap_warning(
+    result: Result,
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """Assert strict file-type overlap output includes actionable diagnostics."""
+    assert_CONFIG_ERROR(result)
+    out: str = result.output.lower()
+    assert "file types specified in both include and exclude filters" in out
+    assert "exclusion wins" in out
+    for expected_removed_file_type in expected_removed_file_types:
+        assert expected_removed_file_type in out
+
+
+@pytest.mark.parametrize("cmd", [CliCmd.CHECK, CliCmd.STRIP])
+@pytest.mark.parametrize(
+    ("include_file_types", "exclude_file_types", "expected_removed_file_types"),
+    [
+        ("python", "python", ("topmark:python",)),
+        ("python", "topmark:python", ("topmark:python",)),
+        ("topmark:python", "python", ("topmark:python",)),
+        ("topmark:python", "topmark:python", ("topmark:python",)),
+        (
+            "topmark:python,topmark:markdown",
+            "python,markdown",
+            ("topmark:python", "topmark:markdown"),
+        ),
+    ],
+)
+def test_pipeline_text_output_reports_strict_file_type_overlap_warning(
+    tmp_path: Path,
+    cmd: str,
+    include_file_types: str,
+    exclude_file_types: str,
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """TEXT pipeline output should include config diagnostics on strict failure.
+
+    Strict mode escalates configuration warnings to `CONFIG_ERROR`, but the
+    warning remains the actionable explanation. Processing commands should
+    therefore render the normalized include/exclude overlap diagnostic instead
+    of showing only the aggregate validation failure.
+    """
+    path: Path = _write_file_requiring_pipeline_change(tmp_path, cmd)
+
+    result: Result = run_cli(
+        [
+            cmd,
+            CliOpt.NO_COLOR_MODE,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            include_file_types,
+            CliOpt.EXCLUDE_FILE_TYPES,
+            exclude_file_types,
+            str(path),
+        ]
+    )
+
+    _assert_strict_file_type_overlap_warning(result, expected_removed_file_types)
+
+
+@pytest.mark.parametrize("cmd", [CliCmd.CHECK, CliCmd.STRIP])
+def test_pipeline_markdown_output_reports_strict_file_type_overlap_warning(
+    tmp_path: Path,
+    cmd: str,
+) -> None:
+    """Markdown pipeline output should include config diagnostics on strict failure."""
+    path: Path = _write_file_requiring_pipeline_change(tmp_path, cmd)
+
+    result: Result = run_cli(
+        [
+            cmd,
+            CliOpt.NO_COLOR_MODE,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            "topmark:python,topmark:markdown",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "python,markdown",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            str(path),
+        ]
+    )
+
+    _assert_strict_file_type_overlap_warning(
+        result,
+        ("topmark:python", "topmark:markdown"),
     )
 
 
@@ -113,7 +207,7 @@ def test_pipeline_markdown_output_ignores_text_quiet(
             cmd,
             CliOpt.QUIET,
             CliOpt.OUTPUT_FORMAT,
-            "markdown",
+            OutputFormat.MARKDOWN.value,
             str(path),
         ]
     )
@@ -135,7 +229,7 @@ def test_pipeline_markdown_output_ignores_text_verbosity(
             cmd,
             CliOpt.NO_COLOR_MODE,
             CliOpt.OUTPUT_FORMAT,
-            "markdown",
+            OutputFormat.MARKDOWN.value,
             str(base_path),
         ]
     )
@@ -145,7 +239,7 @@ def test_pipeline_markdown_output_ignores_text_verbosity(
             CliOpt.NO_COLOR_MODE,
             CliOpt.VERBOSE,
             CliOpt.OUTPUT_FORMAT,
-            "markdown",
+            OutputFormat.MARKDOWN.value,
             str(base_path),
         ]
     )
@@ -168,7 +262,7 @@ def test_pipeline_markdown_output_always_renders_document_banner(
             cmd,
             CliOpt.NO_COLOR_MODE,
             CliOpt.OUTPUT_FORMAT,
-            "markdown",
+            OutputFormat.MARKDOWN.value,
             str(path),
         ]
     )
@@ -186,7 +280,7 @@ def test_check_markdown_output_shows_hints_without_text_verbosity(tmp_path: Path
             CliCmd.CHECK,
             CliOpt.NO_COLOR_MODE,
             CliOpt.OUTPUT_FORMAT,
-            "markdown",
+            OutputFormat.MARKDOWN.value,
             str(path),
         ]
     )

--- a/tests/cli/test_probe_exit_codes.py
+++ b/tests/cli/test_probe_exit_codes.py
@@ -24,6 +24,7 @@ import pytest
 from click.testing import CliRunner
 from click.testing import Result
 
+from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_FILE_NOT_FOUND
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
@@ -84,6 +85,42 @@ def test_probe_exit_code_success_for_filtered_directory_with_selected_files(
     )
 
     assert_SUCCESS(result)
+
+
+# --- Config validation failures ---
+@pytest.mark.parametrize(
+    "include_file_types,exclude_file_types",
+    [
+        ("python", "python"),
+        ("python", "topmark:python"),
+        ("topmark:python", "python"),
+        ("topmark:python", "topmark:python"),
+    ],
+)
+def test_probe_exit_code_config_error_for_strict_file_type_overlap(
+    tmp_path: Path,
+    include_file_types: str,
+    exclude_file_types: str,
+) -> None:
+    """Strict config warnings should exit CONFIG_ERROR before probing inputs."""
+    file: Path = tmp_path / "example.py"
+    file.write_text("print('hello')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            include_file_types,
+            CliOpt.EXCLUDE_FILE_TYPES,
+            exclude_file_types,
+            str(file),
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
 
 
 # --- Unsupported / unresolved inputs ---

--- a/tests/cli/test_probe_human_output.py
+++ b/tests/cli/test_probe_human_output.py
@@ -22,9 +22,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from click.testing import CliRunner
 from click.testing import Result
 
+from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
 from topmark.cli.keys import CliCmd
@@ -181,6 +183,95 @@ def test_probe_text_output_reports_missing_input_only_once(
 
     assert "probe-missing" in result.output
     assert "<filtered>" not in result.output
+
+
+# --- TEXT output: strict config diagnostics ---
+
+
+@pytest.mark.parametrize(
+    ("include_file_types", "exclude_file_types", "expected_removed_file_types"),
+    [
+        ("python", "python", ("topmark:python",)),
+        ("python", "topmark:python", ("topmark:python",)),
+        ("topmark:python", "python", ("topmark:python",)),
+        ("topmark:python", "topmark:python", ("topmark:python",)),
+        (
+            "topmark:python,topmark:markdown",
+            "python,markdown",
+            ("topmark:python", "topmark:markdown"),
+        ),
+    ],
+)
+def test_probe_text_output_reports_strict_file_type_overlap_warning(
+    tmp_path: Path,
+    include_file_types: str,
+    exclude_file_types: str,
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """TEXT probe output should include config diagnostics on strict failure.
+
+    Strict mode escalates configuration warnings to `CONFIG_ERROR`, but the
+    warning remains the actionable explanation. Probe should therefore render
+    the normalized include/exclude overlap diagnostic instead of showing only
+    the aggregate validation failure.
+    """
+    file: Path = tmp_path / "example.py"
+    file.write_text("print('hello')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            include_file_types,
+            CliOpt.EXCLUDE_FILE_TYPES,
+            exclude_file_types,
+            str(file),
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
+    out: str = result.output.lower()
+    assert "file types specified in both include and exclude filters" in out
+    assert "exclusion wins" in out
+    for expected_removed_file_type in expected_removed_file_types:
+        assert expected_removed_file_type in out
+
+
+# --- Markdown output: strict config diagnostics ---
+
+
+def test_probe_markdown_output_reports_strict_file_type_overlap_warning(
+    tmp_path: Path,
+) -> None:
+    """Markdown probe output should include config diagnostics on strict failure."""
+    file: Path = tmp_path / "example.py"
+    file.write_text("print('hello')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            CliOpt.STRICT,
+            CliOpt.INCLUDE_FILE_TYPES,
+            "topmark:python,topmark:markdown",
+            CliOpt.EXCLUDE_FILE_TYPES,
+            "python,markdown",
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            str(file),
+        ],
+    )
+
+    assert_CONFIG_ERROR(result)
+    out: str = result.output.lower()
+    assert "file types specified in both include and exclude filters" in out
+    assert "exclusion wins" in out
+    assert "topmark:python" in out
+    assert "topmark:markdown" in out
 
 
 # --- Markdown output: verbosity and quiet controls ---

--- a/tests/helpers/config_diagnostics.py
+++ b/tests/helpers/config_diagnostics.py
@@ -1,0 +1,90 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : config_diagnostics.py
+#   file_relpath : tests/helpers/config_diagnostics.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Shared assertions for configuration diagnostics test payloads.
+
+The helpers in this module intentionally assert on public CLI/machine-output
+contracts rather than implementation details. They are used by CLI tests that
+need to verify config diagnostics remain visible when validation stops command
+execution before normal probe or processing results are produced.
+"""
+
+from __future__ import annotations
+
+from topmark.core.typing_guards import as_object_dict
+from topmark.core.typing_guards import is_any_list
+from topmark.core.typing_guards import is_mapping
+
+
+def assert_overlap_warning_text(
+    text: str,
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """Assert text contains the include/exclude overlap warning.
+
+    Args:
+        text: Serialized diagnostic text or joined diagnostic messages.
+        expected_removed_file_types: Canonical file-type identifiers expected to be
+            reported as removed from the include set.
+    """
+    lowered: str = text.lower()
+    expected_lowered: tuple[str, ...] = tuple(
+        file_type.lower() for file_type in expected_removed_file_types
+    )
+    assert "file types specified in both include and exclude filters" in lowered
+    assert "exclusion wins" in lowered
+    for expected_removed_file_type in expected_lowered:
+        assert expected_removed_file_type in lowered
+
+
+def assert_config_diagnostics_warning_payload(
+    payload: dict[str, object],
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """Assert a JSON config-diagnostics envelope carries overlap diagnostics.
+
+    Args:
+        payload: Parsed JSON object emitted by a machine-output command.
+        expected_removed_file_types: Canonical file-type identifiers expected to be
+            reported as removed from the include set.
+    """
+    assert "meta" in payload
+
+    diagnostics_obj: object | None = payload.get("config_diagnostics")
+    assert diagnostics_obj is not None
+    assert is_mapping(diagnostics_obj)
+    diagnostics_payload: dict[str, object] = as_object_dict(diagnostics_obj)
+
+    counts_obj: object | None = diagnostics_payload.get("diagnostic_counts")
+    assert is_mapping(counts_obj)
+    counts: dict[str, object] = as_object_dict(counts_obj)
+    warning_count_obj: object | None = counts.get("warning")
+    assert isinstance(warning_count_obj, int)
+    assert warning_count_obj >= 1
+
+    entries_obj: object | None = diagnostics_payload.get("diagnostics")
+    assert is_any_list(entries_obj)
+    entries: list[object] = entries_obj
+    assert entries
+
+    messages: list[str] = []
+    for entry_obj in entries:
+        assert is_mapping(entry_obj)
+        entry: dict[str, object] = as_object_dict(entry_obj)
+        level_obj: object | None = entry.get("level")
+        message_obj: object | None = entry.get("message")
+        assert level_obj == "warning"
+        assert isinstance(message_obj, str)
+        messages.append(message_obj)
+
+    assert_overlap_warning_text(
+        "\n".join(messages),
+        expected_removed_file_types,
+    )

--- a/tools/docs/check_docs_hygiene.py
+++ b/tools/docs/check_docs_hygiene.py
@@ -149,8 +149,15 @@ HEADING_LINE_RE: Final[re.Pattern[str]] = re.compile(
 
 # Dedicated changelog hygiene constants
 CHANGELOG_PATH: Final[Path] = Path("CHANGELOG.md")
+CHANGELOG_VERSION_IDENTIFIER_RE: Final[str] = (
+    r"\d+\.\d+\.\d+(?:a\d+|b\d+|rc\d+|\.post\d+|\.dev\d+)?"
+)
 CHANGELOG_RELEASE_HEADING_RE: Final[re.Pattern[str]] = re.compile(
-    r"^## \[(?P<version>[^\]]+)\] - \d{4}-\d{2}-\d{2}$"
+    rf"^## \[(?P<version>Unreleased|{CHANGELOG_VERSION_IDENTIFIER_RE})\]"
+    rf"(?: - \d{{4}}-\d{{2}}-\d{{2}})?$"
+)
+CHANGELOG_DATED_RELEASE_HEADING_RE: Final[re.Pattern[str]] = re.compile(
+    rf"^## \[(?P<version>{CHANGELOG_VERSION_IDENTIFIER_RE})\] - \d{{4}}-\d{{2}}-\d{{2}}$"
 )
 CHANGELOG_SECTION_HEADING_RE: Final[re.Pattern[str]] = re.compile(
     r"^### (?P<section>[A-Za-z][A-Za-z /-]*) - (?P<version>\S+)$"
@@ -603,7 +610,25 @@ def _check_changelog_hygiene(path: Path, text: str) -> list[Diagnostic]:
                         line=line,
                         message=(
                             "CHANGELOG.md level-2 headings must be release entries shaped "
-                            f"like '## [1.0.0] - YYYY-MM-DD', found '{marker} {title}'"
+                            "like '## [Unreleased]' or '## [1.0.0] - YYYY-MM-DD', "
+                            f"found '{marker} {title}'"
+                        ),
+                    )
+                )
+                continue
+
+            if title != "[Unreleased]" and not CHANGELOG_DATED_RELEASE_HEADING_RE.fullmatch(
+                heading.group(0)
+            ):
+                diagnostics.append(
+                    Diagnostic(
+                        severity="error",
+                        path=path,
+                        line=line,
+                        message=(
+                            "CHANGELOG.md dated release headings must use a proper version "
+                            "identifier and date, shaped like '## [1.0.0] - YYYY-MM-DD', "
+                            f"found '{marker} {title}'"
                         ),
                     )
                 )


### PR DESCRIPTION
## Summary

Fixes #73.

Strict configuration-validation failures previously exited with
`CONFIG_ERROR` but often hid the diagnostic that triggered the failure.

Human-readable output typically showed only an aggregate validation
summary, while JSON/NDJSON output could fall back to plain text and
become invalid machine output.

This PR preserves the underlying diagnostics across all output formats
while keeping the existing strict-validation and exit-code contracts.

## Changes

### CLI

- Add a shared `exit_for_config_validation_error()` helper.
- Use the shared helper from:
  - `check`
  - `strip`
  - `probe`
- Preserve actionable config diagnostics for:
  - TEXT output
  - Markdown output
  - JSON output
  - NDJSON output
- Keep `CONFIG_ERROR` behavior unchanged.

### Configuration

- Refine include/exclude file-type overlap normalization.
- Preserve normalized include and exclude selectors.
- Continue reporting overlap diagnostics where exclusion wins.

### Tests

Add regression coverage for:

- strict config-validation failures in TEXT output;
- strict config-validation failures in Markdown output;
- strict config-validation failures in JSON output;
- strict config-validation failures in NDJSON output;
- probe exit-code behavior under strict validation;
- normalized overlap handling for qualified and local file-type identifiers.

Also introduce shared config-diagnostics test helpers to reduce
duplication across machine-output and CLI tests.

### Documentation

- Document strict-validation diagnostic visibility in
  `docs/_snippets/config-strictness.md`.
- Document machine-output behavior when strict validation stops commands
  before probing or processing.
- Add an `[Unreleased]` changelog section summarizing post-1.0.1 work.
- Update changelog hygiene validation to support `[Unreleased]`
  headings alongside dated release entries.

## Behavior before

```text
strict validation warning
→ CONFIG_ERROR
→ aggregate validation summary only
```

JSON/NDJSON output could become non-machine-readable on this path.

## Behavior after

```text
strict validation warning
→ CONFIG_ERROR
→ underlying diagnostics remain visible
```

JSON and NDJSON output remain valid machine-readable config-diagnostics
payloads even when execution stops before probing or processing begins.

## Compatibility

No changes to:

- exit-code contracts;
- normal processing behavior;
- probe semantics;
- JSON/NDJSON schemas.

The change only affects how strict configuration-validation failures are
reported and makes machine-output behavior consistent with documented
contracts.