### PR TITLE
Reserve exit code 2 for Click parser errors and move WOULD_CHANGE to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ ______________________________________________________________________
 - Centralized CLI option metadata and command-applicability groups used by diagnostics.
 - Hid singular file-type compatibility aliases from help output while preserving them as accepted
   hidden aliases.
+- Reworked CLI exit-code semantics to reserve exit code `2` for Click parser-level usage errors and
+  moved `WOULD_CHANGE` to exit code `3`.
+- Updated `config check` to report validation failures using `CONFIG_ERROR (78)` instead of the
+  generic `FAILURE (1)` exit code.
+
+### Breaking Changes - Unreleased
+
+- Exit code `WOULD_CHANGE` changed from `2` to `3`.
+- Exit code `2` is now reserved for Click parser-level usage errors (for example, unknown options or
+  invalid option values encountered before TopMark command logic runs).
+- CI workflows, shell scripts, tests, and automation that previously treated exit code `2` as the
+  TopMark dry-run change signal must be updated to expect exit code `3` instead.
+- `topmark config check` now reports validation failures using `CONFIG_ERROR (78)` instead of the
+  generic `FAILURE (1)` exit code.
 
 ### Fixed - Unreleased
 
@@ -40,6 +54,8 @@ ______________________________________________________________________
   human-readable output.
 - Preserved valid JSON/NDJSON config diagnostics when strict config validation stops command
   execution.
+- Clarified and disambiguated Click parser-level usage errors versus TopMark semantic exit-code
+  outcomes.
 
 ### Documentation - Unreleased
 
@@ -48,6 +64,10 @@ ______________________________________________________________________
   documentation.
 - Documented machine-readable output behavior when strict config validation stops commands before
   probing or processing.
+- Updated CLI exit-code documentation to distinguish Click-owned parser failures from TopMark-owned
+  semantic outcomes.
+- Documented the exit-code migration from `WOULD_CHANGE (2)` to `WOULD_CHANGE (3)` and the revised
+  `config check` validation-failure behavior.
 
 ### Internal - Unreleased
 
@@ -64,6 +84,10 @@ ______________________________________________________________________
 - Strict configuration-validation failures now preserve machine-readable JSON/NDJSON output. This
   fixes invalid machine output in error paths, but consumers that previously treated such failures
   as unparseable plain text may need to adjust their error handling.
+- This release intentionally introduces a breaking CLI exit-code change: `WOULD_CHANGE` now exits
+  with code `3` instead of `2` so automation can distinguish dry-run change signals from Click
+  parser-level usage errors. Existing CI jobs, shell scripts, and tests that checked for exit code
+  `2` must be updated.
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -272,12 +272,15 @@ documented in:
 TopMark uses a small, stable set of exit codes for automation:
 
 - `SUCCESS (0)` - success (no changes needed or changes applied)
-- `WOULD_CHANGE (2)` - dry-run indicates changes would be made (`check`, `strip`)
-- `FAILURE (1)` - validation failed (`config check`)
+- `WOULD_CHANGE (3)` - dry-run indicates changes would be made (`check`, `strip`)
+- `CONFIG_ERROR (78)` - configuration validation failed (`check`, `strip`, `probe`, `config check`)
 - `USAGE_ERROR (64)` - CLI usage error
 - invalid command/option combinations, positional paths on file-agnostic commands, and unsupported
   STDIN modes are reported as usage errors
 - `CONFIG_ERROR (78)` - configuration error
+
+Exit code `2` is reserved for Click-owned parser-level usage errors, such as unknown commands,
+unknown options or invalid option values.
 
 Other codes (for example `UNSUPPORTED_FILE_TYPE (69)`, `PIPELINE_ERROR (70)`, `IO_ERROR (74)`,
 `PERMISSION_DENIED (77)`) are used for more specific runtime conditions after CLI usage has been

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -176,7 +176,7 @@ Command applicability is stricter:
 The CLI exit-code contract is now enum-backed, documented, and tested. Notable stable outcomes
 include:
 
-- `check` / `strip` use `WOULD_CHANGE (2)` for dry-run would-change results;
+- `check` / `strip` use `WOULD_CHANGE (3)` for dry-run would-change results;
 - explicit missing literal inputs produce `FILE_NOT_FOUND (66)`;
 - unmatched globs are soft discovery diagnostics for `check` / `strip`;
 - `probe` reports unresolved, unsupported, filtered, and unmatched-glob semantic outcomes with

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,9 +86,14 @@ them as CLI usage errors before runtime processing begins.
 TopMark uses a small stable set of exit codes suitable for CI and scripting:
 
 - `SUCCESS (0)` - success (no changes needed or changes applied)
-- `WOULD_CHANGE (2)` - dry-run indicates changes would be made ([`check`](usage/commands/check.md),
+
+- `WOULD_CHANGE (3)` - dry-run indicates changes would be made ([`check`](usage/commands/check.md),
   [`strip`](usage/commands/strip.md))
-- `FAILURE (1)` - validation failed ([`config check`](usage/commands/config/check.md))
+
+- `CONFIG_ERROR (78)` - configuration validation failed ([`check`](usage/commands/check.md),
+  [`strip`](usage/commands/strip.md), [`probe`](usage/commands/probe.md),
+  [`config check`](usage/commands/config/check.md))
+
 - `USAGE_ERROR (64)` - CLI usage error (invalid options, unsupported STDIN modes, or positional
   paths on file-agnostic commands)
 

--- a/docs/usage/ci.md
+++ b/docs/usage/ci.md
@@ -38,7 +38,7 @@ ______________________________________________________________________
 topmark check .
 ```
 
-This validates the selected files and exits with `WOULD_CHANGE (2)` when headers would need to be
+This validates the selected files and exits with `WOULD_CHANGE (3)` when headers would need to be
 inserted, updated, or removed.
 
 If you also want to validate the TopMark configuration, either provide `--strict` to `topmark check`
@@ -86,7 +86,7 @@ ______________________________________________________________________
 
 ### `topmark check`
 
-`topmark check` uses exit code `WOULD_CHANGE (2)` as a stable dry-run signal when changes would be
+`topmark check` uses exit code `WOULD_CHANGE (3)` as a stable dry-run signal when changes would be
 needed. Successful clean runs exit with `SUCCESS (0)`.
 
 Common `check` exit codes:
@@ -94,7 +94,7 @@ Common `check` exit codes:
 | Scenario                    | Exit code                |
 | --------------------------- | ------------------------ |
 | Clean run                   | `SUCCESS (0)`            |
-| Dry-run would add or update | `WOULD_CHANGE (2)`       |
+| Dry-run would add or update | `WOULD_CHANGE (3)`       |
 | Missing explicit input path | `FILE_NOT_FOUND (66)`    |
 | Permission failure          | `PERMISSION_DENIED (77)` |
 | Configuration error         | `CONFIG_ERROR (78)`      |
@@ -104,32 +104,37 @@ Notes:
 
 - Explicit missing literal paths are hard input errors and produce `FILE_NOT_FOUND (66)`.
 - Unmatched glob patterns are soft discovery diagnostics and do not fail `check`.
-- In mixed-result runs, hard input and filesystem errors take precedence over `WOULD_CHANGE (2)`.
+- In mixed-result runs, hard input and filesystem errors take precedence over `WOULD_CHANGE (3)`.
 
 ### `topmark config check`
 
 `topmark config check` exits with `SUCCESS (0)` when the effective runtime configuration is valid.
-It exits with `FAILURE (1)` when validation completes and reports failing diagnostics:
+It exits with `CONFIG_ERROR (78)` when configuration validation fails.
 
-- errors are present, or
-- effective strict config checking is enabled and warnings are present.
+This includes:
+
+- configuration-loading failures that prevent validation from completing;
+- validation runs that report configuration errors; and
+- warning-only results when strict configuration checking is enabled.
 
 Common `config check` exit codes:
 
-| Scenario                                       | Exit code           |
-| ---------------------------------------------- | ------------------- |
-| Valid effective runtime configuration          | `SUCCESS (0)`       |
-| Validation completed with failing diagnostics  | `FAILURE (1)`       |
-| Invalid CLI usage                              | `USAGE_ERROR (64)`  |
-| Configuration cannot be loaded for the command | `CONFIG_ERROR (78)` |
+| Scenario                              | Exit code           |
+| ------------------------------------- | ------------------- |
+| Valid effective runtime configuration | `SUCCESS (0)`       |
+| Configuration validation failed       | `CONFIG_ERROR (78)` |
+| Invalid CLI usage                     | `USAGE_ERROR (64)`  |
 
 Notes:
 
-- `FAILURE (1)` is a validation result for this command, not an unexpected crash.
+- `CONFIG_ERROR (78)` covers both configuration-loading failures and completed validation runs that
+  report configuration errors.
 - Warning-only diagnostics exit with `SUCCESS (0)` unless strict configuration checking is enabled.
-- Malformed TOML discovered by `config check` is reported as a failing validation result and exits
-  with `FAILURE (1)`.
-- CLI usage errors (for example, invalid options) exit with `USAGE_ERROR (64)`.
+- Malformed TOML discovered by `config check` is reported as a configuration-validation failure and
+  exits with `CONFIG_ERROR (78)`.
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
+- TopMark semantic validation and configuration-loading failures use `CONFIG_ERROR (78)`.
 
 Because `config check` is file-agnostic, invalid positional paths or file-processing input options
 are reported as CLI usage errors rather than as file-processing diagnostics.

--- a/docs/usage/commands/check.md
+++ b/docs/usage/commands/check.md
@@ -55,7 +55,7 @@ ______________________________________________________________________
 
 ## Input applicability
 
-- Dry-run by default; exit code `WOULD_CHANGE (2)` when changes would occur.
+- Dry-run by default; exit code `WOULD_CHANGE (3)` when changes would occur.
 - Preserves the file's original newline style (LF/CRLF/CR).
 - Preserves a leading UTF-8 BOM if present.
 - Places headers according to file-type policy (shebang and PEP 263 in Python; XML
@@ -382,7 +382,7 @@ ______________________________________________________________________
 
 ## Exit codes
 
-`topmark check` uses exit code `WOULD_CHANGE (2)` as a stable dry-run signal when changes would be
+`topmark check` uses exit code `WOULD_CHANGE (3)` as a stable dry-run signal when changes would be
 needed. Successful clean runs and successful `--apply` runs exit with `SUCCESS (0)`.
 
 Common `check` exit codes:
@@ -390,7 +390,7 @@ Common `check` exit codes:
 | Scenario                     | Exit code                |
 | ---------------------------- | ------------------------ |
 | Clean run / successful apply | `SUCCESS (0)`            |
-| Dry-run would add or update  | `WOULD_CHANGE (2)`       |
+| Dry-run would add or update  | `WOULD_CHANGE (3)`       |
 | Missing explicit input path  | `FILE_NOT_FOUND (66)`    |
 | Write/apply failure          | `IO_ERROR (74)`          |
 | Permission failure           | `PERMISSION_DENIED (77)` |
@@ -399,9 +399,11 @@ Common `check` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - Explicit missing literal paths are hard input errors and produce `FILE_NOT_FOUND (66)`.
 - Unmatched glob patterns are soft discovery diagnostics and do not fail `check`.
-- In mixed-result runs, hard input and filesystem errors take precedence over `WOULD_CHANGE (2)`.
+- In mixed-result runs, hard input and filesystem errors take precedence over `WOULD_CHANGE (3)`.
 
 See [`Exit codes`](../exit-codes.md) for the complete CLI-wide exit-code contract.
 
@@ -427,7 +429,7 @@ git ls-files -m -o --exclude-standard | topmark check --files-from - --diff
 ### 3) CI: summarize and fail when changes are needed
 
 ```bash
-# Print summary only. Exit 2 signals "would change" to fail the job.
+# Print summary only. Exit 3 signals "would change" to fail the job.
 topmark check --summary
 ```
 

--- a/docs/usage/commands/config.md
+++ b/docs/usage/commands/config.md
@@ -102,11 +102,19 @@ Exit-code behavior for `config` subcommands follows a consistent pattern:
 - Informational commands ([`config dump`](config/dump.md), [`config defaults`](config/defaults.md),
   [`config init`](config/init.md)) exit with `SUCCESS (0)` on success.
 - Validation command ([`config check`](config/check.md)) exits with:
-  - `SUCCESS (0)` when configuration is valid
-  - `FAILURE (1)` when validation completes and reports failing diagnostics
-- CLI usage errors (invalid options, incompatible flags) exit with `USAGE_ERROR (64)`.
-- Configuration loading/processing failures exit with `CONFIG_ERROR (78)` where applicable.
+  - `SUCCESS (0)` when configuration validation succeeds.
+  - `CONFIG_ERROR (78)` when configuration validation fails.
+- CLI usage errors (invalid options, incompatible flags) exit with `USAGE_ERROR (64)` when handled
+  by TopMark command logic.
+- Configuration loading and validation failures use `CONFIG_ERROR (78)` where applicable.
 - Unexpected internal failures exit with `UNEXPECTED_ERROR (255)`.
+
+Notes:
+
+- `CONFIG_ERROR (78)` covers both configuration-loading failures and completed validation runs that
+  report configuration errors.
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 
 See [`Exit codes`](../exit-codes.md) for the complete CLI-wide exit-code contract.
 

--- a/docs/usage/commands/config/check.md
+++ b/docs/usage/commands/config/check.md
@@ -75,7 +75,7 @@ ______________________________________________________________________
   content-on-STDIN for this command, and file-list STDIN modes such as `--files-from -` do not
   apply.
 
-- **CI-friendly**: exits with `FAILURE (1)` when validation fails.
+- **CI-friendly**: exits with `CONFIG_ERROR (78)` when validation fails.
 
 - **Strict mode**: effective strictness is determined as:
 
@@ -274,27 +274,31 @@ ______________________________________________________________________
 ## Exit codes
 
 `topmark config check` exits with `SUCCESS (0)` when the effective runtime configuration is valid.
-It exits with `FAILURE (1)` when validation completes and reports failing diagnostics:
+It exits with `CONFIG_ERROR (78)` when configuration validation fails.
 
-- errors are present, or
-- effective strict config checking is enabled and warnings are present.
+This includes:
+
+- configuration-loading failures that prevent validation from completing;
+- validation runs that report configuration errors; and
+- warning-only results when strict configuration checking is enabled.
 
 Common `config check` exit codes:
 
-| Scenario                                       | Exit code           |
-| ---------------------------------------------- | ------------------- |
-| Valid effective runtime configuration          | `SUCCESS (0)`       |
-| Validation completed with failing diagnostics  | `FAILURE (1)`       |
-| Invalid CLI usage                              | `USAGE_ERROR (64)`  |
-| Configuration cannot be loaded for the command | `CONFIG_ERROR (78)` |
+| Scenario                                      | Exit code           |
+| --------------------------------------------- | ------------------- |
+| Valid effective runtime configuration         | `SUCCESS (0)`       |
+| Validation completed with failing diagnostics | `CONFIG_ERROR (78)` |
+| Invalid CLI usage                             | `USAGE_ERROR (64)`  |
 
 Notes:
 
-- `FAILURE (1)` is a validation result for this command, not an unexpected crash.
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
+- `CONFIG_ERROR (78)` is the normal validation-failure result for this command.
 - Warning-only diagnostics exit with `SUCCESS (0)` unless strict configuration checking is enabled.
-- Malformed TOML discovered by `config check` is reported as a failing validation result and exits
-  with `FAILURE (1)`.
-- CLI usage errors (for example, invalid options) exit with `USAGE_ERROR (64)`.
+- Malformed TOML discovered by `config check` is reported as a configuration-validation failure and
+  exits with `CONFIG_ERROR (78)`.
+- TopMark semantic validation and configuration-loading failures use `CONFIG_ERROR (78)`.
 
 Because `config check` is file-agnostic, invalid positional paths or file-processing input options
 are reported as CLI usage errors rather than as file-processing diagnostics.

--- a/docs/usage/commands/config/defaults.md
+++ b/docs/usage/commands/config/defaults.md
@@ -182,8 +182,10 @@ Common `config defaults` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - This command does not inspect project files and does not use file-processing exit codes such as
-  `WOULD_CHANGE (2)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
+  `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
 - Invalid positional paths are reported as CLI usage errors, not file-processing diagnostics.
 - `--quiet` is unsupported because the command's primary purpose is to emit content.
 

--- a/docs/usage/commands/config/dump.md
+++ b/docs/usage/commands/config/dump.md
@@ -256,8 +256,10 @@ Common `config dump` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - This command does not process files and does not use file-processing exit codes such as
-  `WOULD_CHANGE (2)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
+  `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
 - Invalid positional paths are reported as CLI usage errors, not file-processing diagnostics.
 - `--quiet` is supported for TEXT rendering and suppresses the rendered TOML while preserving the
   exit status.

--- a/docs/usage/commands/config/init.md
+++ b/docs/usage/commands/config/init.md
@@ -192,8 +192,10 @@ Common `config init` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - This command does not inspect project files and does not use file-processing exit codes such as
-  `WOULD_CHANGE (2)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
+  `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
 - Invalid positional paths are reported as CLI usage errors, not file-processing diagnostics.
 - `--quiet` is unsupported because the command's primary purpose is to emit content.
 

--- a/docs/usage/commands/probe.md
+++ b/docs/usage/commands/probe.md
@@ -323,10 +323,13 @@ Common `probe` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - `UNSUPPORTED_FILE_TYPE (69)` indicates runtime-resolution failure (e.g., unsupported file type or
   filtered input), not a crash.
 - Explicit missing literal paths are treated as hard input errors and produce `FILE_NOT_FOUND (66)`.
-- Missing explicit inputs take precedence over runtime-resolution outcomes (`69`).
+- Missing explicit inputs take precedence over runtime-resolution outcomes
+  (`UNSUPPORTED_FILE_TYPE (69)`).
 - Unmatched glob patterns are reported as filtered probe results (e.g.,
   `filtered: excluded_by_discovery_filter`) and result in `UNSUPPORTED_FILE_TYPE (69)`.
 - Ambiguous local file type identifiers may also contribute to runtime-resolution outcomes unless

--- a/docs/usage/commands/registry.md
+++ b/docs/usage/commands/registry.md
@@ -92,9 +92,14 @@ All `registry` subcommands are informational introspection commands:
 - CLI usage errors (invalid or unsupported options) exit with `USAGE_ERROR (64)`.
 
 Registry subcommands do not process project files and therefore do not use file-processing exit
-codes such as `WOULD_CHANGE (2)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
+codes such as `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
 
 Invalid positional paths or file-processing input options are reported as CLI usage errors.
+
+Notes:
+
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 
 See [`Exit codes`](../exit-codes.md) for the complete CLI-wide exit-code contract.
 

--- a/docs/usage/commands/registry/bindings.md
+++ b/docs/usage/commands/registry/bindings.md
@@ -225,8 +225,10 @@ Common `registry bindings` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - This command does not process project files and does not use file-processing exit codes such as
-  `WOULD_CHANGE (2)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
+  `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
 - Invalid positional paths are reported as CLI usage errors, not file-processing diagnostics.
 - `--quiet` is not supported for registry commands; use output-format options instead for non-TEXT
   output.

--- a/docs/usage/commands/registry/filetypes.md
+++ b/docs/usage/commands/registry/filetypes.md
@@ -206,8 +206,10 @@ Common `registry filetypes` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - This command does not process project files and does not use file-processing exit codes such as
-  `WOULD_CHANGE (2)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
+  `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
 - Invalid positional paths are reported as CLI usage errors, not file-processing diagnostics.
 - `--quiet` is not supported for registry commands; use output-format options instead for non-TEXT
   output.

--- a/docs/usage/commands/registry/processors.md
+++ b/docs/usage/commands/registry/processors.md
@@ -202,8 +202,10 @@ Common `registry processors` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - This command does not process project files and does not use file-processing exit codes such as
-  `WOULD_CHANGE (2)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
+  `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
 - Invalid positional paths are reported as CLI usage errors, not file-processing diagnostics.
 - `--quiet` is not supported for registry commands; use output-format options instead for non-TEXT
   output.

--- a/docs/usage/commands/strip.md
+++ b/docs/usage/commands/strip.md
@@ -54,7 +54,7 @@ ______________________________________________________________________
 
 ## Input applicability
 
-- Dry-run by default; exit code `WOULD_CHANGE (2)` when removals would occur.
+- Dry-run by default; exit code `WOULD_CHANGE (3)` when removals would occur.
 - Preserves the file's original newline style (LF/CRLF/CR).
 - Preserves a leading UTF-8 BOM if present.
 - Honors XML/HTML placement rules and preserves the XML declaration (`<?xml ...?>`).
@@ -320,7 +320,7 @@ ______________________________________________________________________
 
 ## Exit codes
 
-`topmark strip` uses exit code `WOULD_CHANGE (2)` as a stable dry-run signal when removals would be
+`topmark strip` uses exit code `WOULD_CHANGE (3)` as a stable dry-run signal when removals would be
 needed. Successful no-op runs and successful `--apply` runs exit with `SUCCESS (0)`.
 
 Common `strip` exit codes:
@@ -328,7 +328,7 @@ Common `strip` exit codes:
 | Scenario                     | Exit code                |
 | ---------------------------- | ------------------------ |
 | Clean run / successful apply | `SUCCESS (0)`            |
-| Dry-run would remove headers | `WOULD_CHANGE (2)`       |
+| Dry-run would remove headers | `WOULD_CHANGE (3)`       |
 | Missing explicit input path  | `FILE_NOT_FOUND (66)`    |
 | Write/apply failure          | `IO_ERROR (74)`          |
 | Permission failure           | `PERMISSION_DENIED (77)` |
@@ -337,9 +337,11 @@ Common `strip` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - Explicit missing literal paths are hard input errors and produce `FILE_NOT_FOUND (66)`.
 - Unmatched glob patterns are soft discovery diagnostics and do not fail `strip`.
-- In mixed-result runs, hard input and filesystem errors take precedence over `WOULD_CHANGE (2)`.
+- In mixed-result runs, hard input and filesystem errors take precedence over `WOULD_CHANGE (3)`.
 
 See [`Exit codes`](../exit-codes.md) for the complete CLI-wide exit-code contract.
 
@@ -365,7 +367,7 @@ git ls-files -m -o --exclude-standard | topmark strip --files-from - --diff
 ### 3) CI: summarize and fail when removals are needed
 
 ```bash
-# Print summary only. Exit 2 signals "would change" to fail the job.
+# Print summary only. Exit 3 signals "would change" to fail the job.
 topmark strip --summary
 ```
 

--- a/docs/usage/commands/version.md
+++ b/docs/usage/commands/version.md
@@ -202,8 +202,10 @@ Common `version` exit codes:
 
 Notes:
 
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - This command does not process project files and does not use file-processing exit codes such as
-  `WOULD_CHANGE (2)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
+  `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
 - Invalid positional paths or file-processing input options are reported as CLI usage errors.
 - `--quiet` is not supported because the command's primary purpose is to emit content.
 

--- a/docs/usage/exit-codes.md
+++ b/docs/usage/exit-codes.md
@@ -44,7 +44,8 @@ ______________________________________________________________________
 | ---: | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 |    0 | SUCCESS                  | Operation completed successfully.                                                                                                  |
 |    1 | FAILURE                  | Generic failure (non-specific error).                                                                                              |
-|    2 | WOULD_CHANGE             | Dry-run indicates changes would be made (used by [`check`](commands/check.md) and [`strip`](commands/strip.md) without `--apply`). |
+|    2 | -                        | Reserved for Click parser-level usage errors (e.g., unknown options or invalid option values).                                     |
+|    3 | WOULD_CHANGE             | Dry-run indicates changes would be made (used by [`check`](commands/check.md) and [`strip`](commands/strip.md) without `--apply`). |
 |   64 | USAGE_ERROR              | Invalid CLI usage (invalid options, incompatible flags).                                                                           |
 |   65 | ENCODING_ERROR           | Text decoding/encoding error (e.g., Unicode issues).                                                                               |
 |   66 | FILE_NOT_FOUND           | Explicit input path does not exist.                                                                                                |
@@ -60,6 +61,8 @@ Notes:
 
 - Codes broadly follow **sysexits-style semantics** where applicable.
 - Not all codes are used by every command.
+- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+  values) may exit with code `2` before command logic runs.
 - Commands may short-circuit on higher-severity errors (e.g., config errors before processing).
 - Canonical file-type identifier normalization does not affect exit-code semantics.
 - Ambiguous or malformed file-type identifiers are reported diagnostically and may contribute to
@@ -95,7 +98,7 @@ ______________________________________________________________________
 | Scenario                                 | Exit code |
 | ---------------------------------------- | --------: |
 | No differences (clean)                   |         0 |
-| Differences found (dry-run)              |         2 |
+| Differences found (dry-run)              |         3 |
 | Changes applied successfully (`--apply`) |         0 |
 | Configuration error                      |        78 |
 | Write failure during apply               |        74 |
@@ -105,8 +108,8 @@ ______________________________________________________________________
 
 Notes:
 
-- `2` is a semantic change signal, not a runtime failure: it indicates that files would change.
-- In CI, treat `2` as "diff detected".
+- `3` is a semantic change signal, not a runtime failure: it indicates that files would change.
+- In CI, treat `3` as "diff detected".
 - Explicit missing input paths are reported as errors (66), even if no files are selected for
   processing.
 - Unmatched glob patterns are treated as discovery diagnostics and do not cause failure.
@@ -118,7 +121,7 @@ ______________________________________________________________________
 | Scenario                                 | Exit code |
 | ---------------------------------------- | --------: |
 | Nothing to strip / no changes            |         0 |
-| Changes would occur (dry-run)            |         2 |
+| Changes would occur (dry-run)            |         3 |
 | Changes applied successfully (`--apply`) |         0 |
 | Configuration error                      |        78 |
 | Write failure during apply               |        74 |
@@ -130,6 +133,8 @@ Notes:
 
 - Explicit missing input paths are reported as errors (66).
 - Unmatched glob patterns are treated as discovery diagnostics and do not cause failure.
+- `3` is a semantic change signal, not a runtime failure: it indicates that headers would be
+  stripped.
 
 ______________________________________________________________________
 
@@ -160,15 +165,14 @@ ______________________________________________________________________
 | Scenario                                     | Exit code |
 | -------------------------------------------- | --------: |
 | Configuration is valid                       |         0 |
-| Configuration is invalid (validation result) |         1 |
 | CLI usage error                              |        64 |
+| Configuration is invalid (validation result) |        78 |
 | Internal error                               |  70 / 255 |
 
 Important distinction:
 
-- Exit code `1` is not a runtime configuration-loading failure.
-- It indicates that configuration validation completed and found issues.
-- Errors that prevent validation entirely use `78` (not typically surfaced here).
+- Exit code `78` is used both when configuration cannot be loaded and when `config check` completes
+  validation and reports configuration errors.
 
 ______________________________________________________________________
 
@@ -227,9 +231,8 @@ ______________________________________________________________________
 Recommended handling:
 
 - Treat `0` as success.
-- Treat `2` as **non-error change signal** (for `check`/`strip`).
-- Treat `1` (from `config check`) as a configuration-validation result rather than a runtime
-  failure.
+- Treat `2` as a Click parser-level usage error.
+- Treat `3` as **non-error change signal** (for `check`/`strip`).
 - Treat `64`, `66`, `69`, `70`, `74`, `78`, `255` as errors.
 - `66` indicates explicit literal input errors (e.g., missing paths), not unmatched glob patterns.
 
@@ -258,7 +261,7 @@ semantic outcomes occur during a single invocation.
 1. Write/apply failures (`74`)
 1. Configuration errors (`78`)
 1. Semantic/availability signals (`69`)
-1. Generic failures (`1`)
+1. Dry-run change signals (`3`)
 
 This ensures that hard runtime or environment failures take precedence over informational, semantic,
 or availability-oriented outcomes.
@@ -268,7 +271,7 @@ Example:
 ```sh
 # Detect formatting/header drift without applying changes
 if ! topmark check . ; then
-  if [ $? -eq 2 ] ; then
+  if [ $? -eq 3 ] ; then
     echo "Changes required"
   else
     echo "Error during check"
@@ -290,14 +293,9 @@ ______________________________________________________________________
 
 ## Stability guarantee
 
-The exit-code contract defined on this page is part of TopMark's stable 1.x CLI compatibility
-surface.
-
-Future changes will:
-
-- preserve existing codes,
-- only introduce new codes in a backward-compatible manner, or
-- require a major version bump.
+The exit-code contract defined on this page is part of TopMark's stable CLI compatibility surface.
+Changing an existing TopMark-owned semantic exit code, such as `WOULD_CHANGE`, is a breaking CLI
+contract change and requires explicit release-note and migration documentation.
 
 ______________________________________________________________________
 

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -195,7 +195,7 @@ Validate repository headers in CI:
 topmark check .
 ```
 
-Exit code `2` means files would require header updates.
+Exit code `3` means files would require header updates.
 
 Further reading:
 

--- a/docs/usage/pre-commit.md
+++ b/docs/usage/pre-commit.md
@@ -257,7 +257,7 @@ and CI.
 - **`topmark-check` (non-destructive)**:
 
   - Exits with `SUCCESS (0)` when all headers are up-to-date.
-  - Exits with `WOULD_CHANGE (2)` when headers would be added/updated in dry-run mode (this causes
+  - Exits with `WOULD_CHANGE (3)` when headers would be added/updated in dry-run mode (this causes
     the hook to fail as intended).
   - May exit with other non-zero codes for errors, for example:
     - `FILE_NOT_FOUND (66)` for explicit missing input paths
@@ -279,7 +279,7 @@ and CI.
 Notes:
 
 - Pre-commit treats any non-zero exit code as a failure; this is expected for `topmark-check` when
-  changes are needed (`WOULD_CHANGE (2)`).
+  changes are needed (`WOULD_CHANGE (3)`).
 - Use `--quiet` in CI to suppress human-readable TEXT output and rely solely on exit status.
 - Use `topmark-probe` when a hook appears to skip, include, or classify files with unexpected
   semantic runtime outcomes.

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -289,7 +289,7 @@ def check_command(
 
     Exit Status:
         SUCCESS (0): No changes required or all requested changes were written.
-        WOULD_CHANGE (2): Dry-run detected files that would change with ``--apply``.
+        WOULD_CHANGE (3): Dry-run detected files that would change with ``--apply``.
         USAGE_ERROR (64): Invalid invocation (e.g., mixing ``-`` with ``--files-from -``).
         FILE_NOT_FOUND (66): One or more specified files or directories could not be found.
         PERMISSION_DENIED (77): Insufficient permissions to read or write a file.

--- a/src/topmark/cli/commands/config_check.py
+++ b/src/topmark/cli/commands/config_check.py
@@ -208,7 +208,7 @@ def config_check_command(
 
     def _exit(ctx: click.Context, *, success: bool) -> None:
         """Select exit code depending on outcome."""
-        ctx.exit(0 if success else ExitCode.FAILURE)
+        ctx.exit(0 if success else ExitCode.CONFIG_ERROR)
 
     if fmt in (OutputFormat.JSON, OutputFormat.NDJSON):
         emit_config_check_machine(

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -255,7 +255,7 @@ def strip_command(
 
     Exit Status:
         SUCCESS (0): No changes required or all requested changes were written.
-        WOULD_CHANGE (2): Dry-run detected files that would change with ``--apply``.
+        WOULD_CHANGE (3): Dry-run detected files that would change with ``--apply``.
         USAGE_ERROR (64): Invalid invocation (e.g., mixing ``-`` with ``--files-from -``).
         FILE_NOT_FOUND (66): One or more specified files or directories could not be found.
         PERMISSION_DENIED (77): Insufficient permissions to read or write a file.

--- a/src/topmark/core/exit_codes.py
+++ b/src/topmark/core/exit_codes.py
@@ -12,13 +12,12 @@
 
 This module centralizes the exit codes used by the CLI, engine helpers, and
 tests. TopMark aligns with the BSD ``sysexits`` convention where practical so
-that other tooling can interpret failures consistently. The one deliberate
-divergence is ``WOULD_CHANGE = 2``, which is used to signal a dry-run state
-where changes would be made; this allows automation and tests to distinguish
-between a "would change" result and a usage error (which, in Click, also
-defaults to 2). When used with Click-based CLIs, tests must assert
-``result.exception is None`` to disambiguate TopMark's dry-run from Click's
-own usage errors.
+that other tooling can interpret failures consistently. TopMark deliberately
+avoids assigning semantic runtime meaning to exit code ``2`` because Click uses
+it for parser-level usage errors before TopMark command logic can normalize the
+failure. Dry-run change detection therefore uses ``WOULD_CHANGE = 3`` so
+scripts can distinguish valid change signals from parser failures by exit code
+alone.
 """
 
 from __future__ import annotations
@@ -30,12 +29,13 @@ class ExitCode(IntEnum):
     """Standardized exit codes for the TopMark runtime and CLI.
 
     TopMark follows the BSD ``sysexits`` convention where practical so other
-    tooling can interpret failures consistently. The one deliberate
-    divergence is ``WOULD_CHANGE = 2``, which TopMark uses to signal a dry-run
-    state where changes would be made. When running under a Click-based CLI,
-    tests must assert that no Click exception was raised
-    (``result.exception is None``) to disambiguate from Click's own usage
-    errors (which also default to 2).
+    tooling can interpret failures consistently.
+
+    Exit code ``2`` is reserved for Click-owned parser usage errors, such as
+    unknown options or invalid option values raised before TopMark command logic runs.
+
+    TopMark dry-run change detection therefore uses ``WOULD_CHANGE = 3`` so automation
+    can distinguish valid change signals from parser failures by exit code alone.
 
     Attributes:
         SUCCESS: Successful execution with no errors.
@@ -57,15 +57,24 @@ class ExitCode(IntEnum):
         CONFIG_ERROR: Configuration error (missing/invalid/malformed config).
             Mirrors BSD ``EX_CONFIG (78)``.
         VERSION_CONVERSION_ERROR: Version conversion error (missing/invalid/malformed PEP version
-            identifier, version cannot be converted tot SemVer).
+            identifier, version cannot be converted to SemVer).
             Mirrors BSD ``EX_CONFIG (78)``.
         UNEXPECTED_ERROR: Unhandled/unknown error (last-resort). Mirrors BSD
             ``EX_SOFTWARE (70)`` but kept distinct for clarity.
+
+    Notes:
+        - Exit code ``2`` is intentionally not represented here because it is
+          owned by Click parser usage errors, not by TopMark semantic outcomes.
+
     """
 
     SUCCESS = 0
     FAILURE = 1
-    WOULD_CHANGE = 2  # deliberate divergence from sysexits; see class docstring
+
+    # Exit code 2 is intentionally unassigned here: Click owns it for parser-level
+    # usage errors such as invalid options or invalid option values.
+
+    WOULD_CHANGE = 3  # deliberate divergence from sysexits; see class docstring
 
     # sysexits-aligned values for better interoperability
     USAGE_ERROR = 64  # EX_USAGE

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -145,13 +145,32 @@ def assert_SUCCESS(result: Result) -> None:
     assert result.exit_code == ExitCode.SUCCESS, result.output
 
 
-def assert_WOULD_CHANGE(result: Result) -> None:
-    """Assert that the command exited with WOULD_CHANGE (code 2).
+def assert_FAILURE(result: Result) -> None:
+    """Assert that the command exited with generic failure (code 1).
+
+    This is a defensive fallback assertion for unexpected non-specific failures.
+    Prefer a more specific helper such as `assert_CONFIG_ERROR`,
+    `assert_IO_ERROR`, or `assert_FILE_NOT_FOUND` whenever the command contract
+    defines a specific outcome.
 
     Args:
         result: The Result object returned by `run_cli` or `run_cli_in`.
     """
-    # WOULD_CHANGE is a *normal* outcome; do not assert on exception.
+    assert result.exit_code == ExitCode.FAILURE, result.output
+
+
+def assert_WOULD_CHANGE(result: Result) -> None:
+    """Assert that the command exited with WOULD_CHANGE (code 3).
+
+    `WOULD_CHANGE` is a normal dry-run outcome, not a runtime failure. TopMark
+    intentionally uses code 3 so tests and scripts can distinguish this semantic
+    change signal from Click parser-level usage errors, which use code 2.
+
+    Args:
+        result: The Result object returned by `run_cli` or `run_cli_in`.
+    """
+    # WOULD_CHANGE is a normal TopMark outcome; Click parser usage errors use
+    # raw exit code 2 and must be asserted with parser-error-specific helpers.
     assert result.exit_code == ExitCode.WOULD_CHANGE, result.output
 
 
@@ -189,18 +208,6 @@ def assert_USAGE_ERROR(result: Result) -> None:
     """
     # TopMark normalizes usage errors to the public USAGE_ERROR contract code.
     assert result.exit_code == ExitCode.USAGE_ERROR, result.output
-
-
-def assert_FAILURE(result: Result) -> None:
-    """Assert that the command exited with validation failure (code 1).
-
-    This is used for commands that complete successfully as commands but report
-    a failing validation result, such as `topmark config check`.
-
-    Args:
-        result: The Result object returned by `run_cli` or `run_cli_in`.
-    """
-    assert result.exit_code == ExitCode.FAILURE, result.output
 
 
 def assert_CONFIG_ERROR(result: Result) -> None:
@@ -315,7 +322,7 @@ def assert_rich_output_does_not_contain(
 
 
 CLICK_USAGE_ERROR_EXIT_CODE: Final[int] = 2
-"""Exit code used by Click for reporting a usage error."""
+"""Raw exit code used by Click for parser-level usage errors."""
 
 
 def assert_rich_output_no_such_option(
@@ -325,15 +332,16 @@ def assert_rich_output_no_such_option(
 ) -> None:
     """Assert that Rich Click reported an unknown CLI option.
 
-    Click reports parser-level usage errors with exit code 2 before TopMark can
-    normalize them to `ExitCode.USAGE_ERROR`. That numeric code overlaps with
-    `ExitCode.WOULD_CHANGE`, so this helper also asserts the rendered
-    `No such option` diagnostic.
+    Click parser-level usage errors (for example, unknown commands, unknown options
+    options or invalid option values) may exit with code `2` before command logic runs.
+    TopMark intentionally does not assign code 2 to a semantic outcome; `WOULD_CHANGE`
+    uses code 3 instead. This helper therefore asserts both the Click-owned code
+    and the rendered `No such option` diagnostic.
     """
     # Click handles the parser error and `CliRunner` captures the resulting
     # `SystemExit(2)`, not the original `click.NoSuchOption` instance. The
-    # rendered diagnostic disambiguates this parser-level failure from
-    # TopMark's normal `ExitCode.WOULD_CHANGE` outcome, which also uses code 2.
+    # The rendered diagnostic distinguishes this parser-level failure from
+    # TopMark-owned semantic outcomes such as WOULD_CHANGE (code 3).
     assert result.exit_code == CLICK_USAGE_ERROR_EXIT_CODE, result.output
 
     # Use the message format used by `rich-click`:

--- a/tests/cli/machine/test_probe_machine.py
+++ b/tests/cli/machine/test_probe_machine.py
@@ -22,6 +22,7 @@ import pytest
 from click.testing import CliRunner
 
 from tests.cli.conftest import assert_CONFIG_ERROR
+from tests.cli.conftest import assert_FILE_NOT_FOUND
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
 from tests.helpers.config_diagnostics import assert_config_diagnostics_warning_payload
@@ -398,7 +399,7 @@ def test_probe_ndjson_reports_missing_input_only_once(tmp_path: Path) -> None:
         ],
     )
 
-    assert result.exit_code != 0
+    assert_FILE_NOT_FOUND(result)
 
     records: list[dict[str, object]] = parse_ndjson_records(result.output)
     probe_records: list[dict[str, object]] = [r for r in records if r["kind"] == "probe"]

--- a/tests/cli/test_check_exit_codes.py
+++ b/tests/cli/test_check_exit_codes.py
@@ -40,7 +40,7 @@ pytestmark: pytest.MarkDecorator = pytest.mark.exit_code
 
 # --- Dry-run contract ---
 def test_check_exits_would_change_when_changes_needed(tmp_path: Path) -> None:
-    """`check` should exit WOULD_CHANGE (2) when headers would be added or modified."""
+    """`check` should exit WOULD_CHANGE (3) when headers would be added or modified."""
     f: Path = tmp_path / "x.py"
     f.write_text("print('z')\n", "utf-8")
 

--- a/tests/cli/test_completion.py
+++ b/tests/cli/test_completion.py
@@ -62,7 +62,7 @@ def _complete(incomplete: str = "") -> list[CompletionItem]:
     items: list[CompletionItem] = enum_type.shell_complete(ctx, opt, incomplete)
     if items:
         return items
-    # Fallback for robustness; shouldn't happen on Click 8.2
+    # Fallback for robustness; shouldn't happen on Click 8.2+
     return [CompletionItem(str(x)) for x in items]
 
 

--- a/tests/cli/test_config_check_exit_codes.py
+++ b/tests/cli/test_config_check_exit_codes.py
@@ -13,8 +13,8 @@
 This module pins the command-level validation contract:
 - valid configuration exits SUCCESS (0),
 - warning-only diagnostics exit SUCCESS (0) in non-strict mode,
-- warning-only diagnostics exit FAILURE (1) in strict mode,
-- malformed/unusable configuration exits FAILURE (1) as a validation result.
+- warning-only diagnostics exit CONFIG_ERROR (78) in strict mode,
+- malformed/unusable configuration exits CONFIG_ERROR (78) as a validation result.
 
 Unlike processing commands, `config check` reports configuration problems as
 validation results rather than runtime `CONFIG_ERROR` exits.
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from tests.cli.conftest import assert_FAILURE
+from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
 from tests.cli.conftest import run_cli_in
@@ -86,7 +86,7 @@ def test_config_check_warning_only_config_exits_success_in_non_strict_mode(tmp_p
 
 
 def test_config_check_warning_only_config_exits_failure_in_strict_mode(tmp_path: Path) -> None:
-    """Warning-only diagnostics should exit FAILURE in strict mode."""
+    """Warning-only diagnostics should exit CONFIG_ERROR in strict mode."""
     (tmp_path / "topmark.toml").write_text(
         "\n".join(
             [
@@ -108,14 +108,14 @@ def test_config_check_warning_only_config_exits_failure_in_strict_mode(tmp_path:
     )
 
     # Strict config checking escalates warning-only diagnostics to validation failure.
-    assert_FAILURE(result)
+    assert_CONFIG_ERROR(result)
 
 
 # --- Malformed / unusable configuration ---
 
 
 def test_config_check_malformed_config_exits_failure(tmp_path: Path) -> None:
-    """Malformed config should exit FAILURE as a validation result."""
+    """Malformed config should exit CONFIG_ERROR as a validation result."""
     (tmp_path / "topmark.toml").write_text("this = [[[[ not_toml", "utf-8")
 
     result: Result = run_cli_in(
@@ -127,4 +127,4 @@ def test_config_check_malformed_config_exits_failure(tmp_path: Path) -> None:
     )
 
     # `config check` reports TOML parse errors as validation failures.
-    assert_FAILURE(result)
+    assert_CONFIG_ERROR(result)

--- a/tests/cli/test_probe_human_output.py
+++ b/tests/cli/test_probe_human_output.py
@@ -27,6 +27,7 @@ from click.testing import CliRunner
 from click.testing import Result
 
 from tests.cli.conftest import assert_CONFIG_ERROR
+from tests.cli.conftest import assert_FILE_NOT_FOUND
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
 from topmark.cli.keys import CliCmd
@@ -179,7 +180,7 @@ def test_probe_text_output_reports_missing_input_only_once(
         ],
     )
 
-    assert result.exit_code != 0
+    assert_FILE_NOT_FOUND(result)
 
     assert "probe-missing" in result.output
     assert "<filtered>" not in result.output

--- a/tests/cli/test_strip.py
+++ b/tests/cli/test_strip.py
@@ -49,11 +49,11 @@ if TYPE_CHECKING:
 # --- Dry-run exit-code contract ---
 
 
-def test_strip_dry_run_exits_2(tmp_path: Path) -> None:
-    """Dry-run should exit 2 when a header is present (action would occur).
+def test_strip_dry_run_exits_would_change(tmp_path: Path) -> None:
+    """Dry-run should exit 3 when a header is present (action would occur).
 
     Given a file that contains a recognizable TopMark header, calling `topmark strip`
-    without `--apply` should signal "would change" with exit code 2.
+    without `--apply` should signal "would change" with exit code 3.
     """
     f: Path = tmp_path / "x.py"
     f.write_text(
@@ -64,7 +64,7 @@ def test_strip_dry_run_exits_2(tmp_path: Path) -> None:
         [CliCmd.STRIP, str(f)],
     )
 
-    # Exit 2 means "changes would be made" (pre-commit friendly).
+    # Exit 3 means "changes would be made" (pre-commit friendly).
     assert_WOULD_CHANGE(result)
 
 
@@ -134,7 +134,7 @@ def test_strip_diff_shows_patch(tmp_path: Path) -> None:
         [CliCmd.STRIP, CliOpt.RENDER_DIFF, str(f)],
     )
 
-    # With a removable header, diff-only should exit 2 (would change).
+    # With a removable header, diff-only should exit 3 (would change).
     assert_WOULD_CHANGE(result)
 
     # Diff should include unified headers and removed header lines.

--- a/tests/resolver/test_filters_and_types.py
+++ b/tests/resolver/test_filters_and_types.py
@@ -96,7 +96,7 @@ def test_strip_applies_only_to_included_non_excluded_targets(tmp_path: Path) -> 
 
 
 @pytest.mark.parametrize("file_type_id", ["python", "topmark:python"])
-def test_file_type_filter_selects_only_matching_file_types(
+def test_check_file_type_filter_selects_only_matching_file_types(
     tmp_path: Path,
     file_type_id: str,
 ) -> None:
@@ -113,7 +113,12 @@ def test_file_type_filter_selects_only_matching_file_types(
 
     result: Result = run_cli_in(
         tmp_path,
-        [CliOpt.INCLUDE_FILE_TYPES, file_type_id, "*.*"],
+        [
+            CliCmd.CHECK,
+            CliOpt.INCLUDE_FILE_TYPES,
+            file_type_id,
+            "*.*",
+        ],
     )
 
     # Only x.py should be selected; because it lacks a header, check should report WOULD_CHANGE.
@@ -121,7 +126,7 @@ def test_file_type_filter_selects_only_matching_file_types(
 
 
 @pytest.mark.parametrize("file_type_id", ["python", "topmark:python"])
-def test_file_type_exclude_filter_skips_matching_file_types(
+def test_check_file_type_exclude_filter_skips_matching_file_types(
     tmp_path: Path,
     file_type_id: str,
 ) -> None:
@@ -133,7 +138,12 @@ def test_file_type_exclude_filter_skips_matching_file_types(
 
     result: Result = run_cli_in(
         tmp_path,
-        [CliOpt.EXCLUDE_FILE_TYPES, file_type_id, "*.*"],
+        [
+            CliCmd.CHECK,
+            CliOpt.EXCLUDE_FILE_TYPES,
+            file_type_id,
+            "*.*",
+        ],
     )
 
     assert_WOULD_CHANGE(result)


### PR DESCRIPTION
## Summary

This PR resolves the long-standing ambiguity between Click parser-level
usage errors and TopMark's `WOULD_CHANGE` dry-run outcome.

Historically both used numeric exit code `2`, making it impossible for
automation to distinguish:

```bash
topmark check --unknown-option
```

from:

```bash
topmark check .
```

when changes would be required.

This PR reserves exit code `2` for Click-owned parser failures and
moves TopMark's semantic dry-run signal to exit code `3`.

## Changes

### Exit-code contract

- Reserved exit code `2` for Click parser-level usage errors.
- Changed:
  - `WOULD_CHANGE`: `2` → `3`
- Changed:
  - `config check` validation failures:
    - `FAILURE (1)` → `CONFIG_ERROR (78)`

### Tests

- Updated CLI assertion helpers and documentation.
- Replaced remaining broad non-zero assertions with explicit helpers.
- Clarified parser-level versus TopMark-owned exit-code expectations.
- Updated dry-run exit-code assertions to use `WOULD_CHANGE (3)`.

### Documentation

- Updated the canonical exit-code reference.
- Updated command reference pages (`check`, `strip`, `probe`, `config`,
  `registry`, `version`, etc.).
- Added Click parser-error notes where relevant.
- Updated CI and automation guidance.
- Documented migration implications for existing scripts and pipelines.

## Breaking Change

`WOULD_CHANGE` now exits with code `3` instead of `2`.

Automation, CI workflows, shell scripts, and tests that previously
treated exit code `2` as the dry-run change signal must be updated.

Exit code `2` is now reserved for Click parser-level usage errors such
as unknown options or invalid option values.

## Related Issues

- Closes #67
- Related: #84