### PR TITLE
Fix unknown option handling for path commands 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ ______________________________________________________________________
   moved `WOULD_CHANGE` to exit code `3`.
 - Updated `config check` to report validation failures using `CONFIG_ERROR (78)` instead of the
   generic `FAILURE (1)` exit code.
+- Aligned path-oriented command parsing with Click and POSIX-style option handling: unknown
+  option-like tokens are now parser errors unless passed after `--`.
 
 ### Breaking Changes - Unreleased
 
@@ -41,6 +43,9 @@ ______________________________________________________________________
   TopMark dry-run change signal must be updated to expect exit code `3` instead.
 - `topmark config check` now reports validation failures using `CONFIG_ERROR (78)` instead of the
   generic `FAILURE (1)` exit code.
+- `topmark check`, `topmark strip`, and `topmark probe` now reject unknown option-like arguments
+  before `--` as Click parser-level usage errors. Literal filenames that begin with `-` must be
+  passed after the standard `--` delimiter, for example `topmark check -- --generated.py`.
 
 ### Fixed - Unreleased
 
@@ -56,6 +61,8 @@ ______________________________________________________________________
   execution.
 - Clarified and disambiguated Click parser-level usage errors versus TopMark semantic exit-code
   outcomes.
+- Fixed unknown options passed to `check`, `strip`, and `probe` so they are no longer interpreted as
+  missing input paths.
 
 ### Documentation - Unreleased
 
@@ -68,6 +75,7 @@ ______________________________________________________________________
   semantic outcomes.
 - Documented the exit-code migration from `WOULD_CHANGE (2)` to `WOULD_CHANGE (3)` and the revised
   `config check` validation-failure behavior.
+- Documented use of the standard `--` delimiter for literal dash-prefixed path names.
 
 ### Internal - Unreleased
 

--- a/docs/usage/commands/check.md
+++ b/docs/usage/commands/check.md
@@ -133,8 +133,10 @@ topmark check --exclude-file-types topmark:markdown docs/
 
 Notes:
 
-- Positional arguments are resolved **relative to the current working directory** (CWD),
-  Black-style.
+- Positional arguments are parsed by Click and resolved **relative to the current working
+  directory** (CWD).
+- Unknown option-like tokens before the standard `--` delimiter are parser errors. Use `--` before
+  literal path names that begin with a dash, for example `topmark check -- --generated.py`.
 - Patterns in `--include`, `--exclude`, and the files passed to `--include-from` / `--exclude-from`
   are also resolved **relative to CWD**. Absolute patterns are not supported.
 - Path-based filters are evaluated **before** file-type filters.

--- a/docs/usage/filtering.md
+++ b/docs/usage/filtering.md
@@ -96,8 +96,10 @@ TopMark supports the following path-based filtering controls:
 
 Stable path-filtering semantics:
 
-- Positional arguments are resolved **relative to the current working directory** (CWD),
-  Black-style.
+- Positional arguments are parsed by Click and resolved **relative to the current working
+  directory** (CWD).
+- Unknown option-like tokens before the standard `--` delimiter are parser errors. Use `--` before
+  literal path names that begin with a dash, for example `topmark check -- --generated.py`.
 - Patterns in `--include`, `--exclude`, and files referenced by `--include-from` / `--exclude-from`
   are also resolved **relative to CWD**.
 - Absolute patterns are not supported.

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -90,7 +90,6 @@ from topmark.cli.options import shared_policy_options
 from topmark.cli.state import TopmarkCliState
 from topmark.cli.state import bootstrap_cli_state
 from topmark.cli.validators import apply_color_policy_for_output_format
-from topmark.cli.validators import validate_common_forbidden_path_command_options_in_extra_args
 from topmark.cli.validators import validate_diff_policy_for_output_format
 from topmark.cli.validators import validate_stdin_dash_requires_piped_input
 from topmark.cli.validators import warn_if_report_scope_ignored
@@ -167,6 +166,7 @@ logger: TopmarkLogger = get_logger(__name__)
         ),
     ),
 )
+@click.argument("paths", nargs=-1, type=click.UNPROCESSED)
 @common_color_options
 @common_text_output_verbosity_options
 @common_text_output_quiet_options
@@ -185,6 +185,7 @@ logger: TopmarkLogger = get_logger(__name__)
 @common_header_formatting_options
 @common_output_format_options
 def check_command(
+    paths: tuple[str, ...],
     *,
     # common_ui_options (verbosity, color):
     verbosity: int,
@@ -233,8 +234,7 @@ def check_command(
 ) -> None:
     """Run the header check pipeline in dry-run or apply mode.
 
-    The command reads positional paths from ``click.get_current_context().args``
-    (Black-style) and supports three input styles:
+    The command receives Click-parsed positional paths and supports three input styles:
 
     1. Paths mode (default): PATHS and/or ``--files-from FILE``.
     2. Content-on-STDIN: use ``-`` as the sole PATH **and** provide ``--stdin-filename``.
@@ -242,6 +242,8 @@ def check_command(
        ``--include-from -``, or ``--exclude-from -`` (exactly one may consume STDIN).
 
     Args:
+        paths: Positional paths parsed by Click. Use ``--`` before literal
+            path names that begin with a dash.
         verbosity: Increase TEXT output detail.
         quiet: Suppress TEXT output.
         color_mode: Set the color mode (default: auto).
@@ -299,6 +301,7 @@ def check_command(
         UNEXPECTED_ERROR (255): An unhandled error occurred.
     """
     ctx: click.Context = click.get_current_context()
+    ctx.args = list(paths)
     state: TopmarkCliState = bootstrap_cli_state(ctx)
     # Effective output format (stored early so shared initialization sees it).
     state.output_format = output_format or OutputFormat.TEXT
@@ -314,10 +317,6 @@ def check_command(
 
     # Effective TEXT verbosity for console-oriented progressive disclosure.
     verbosity_level: int = state.verbosity
-
-    # Reject common unsupported option spellings that permissive path parsing
-    # would otherwise pass through as positional input paths, such as `--stdin`.
-    validate_common_forbidden_path_command_options_in_extra_args(ctx)
 
     # Machine metadata.
     meta: MetaPayload = build_meta_payload()

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -63,7 +63,6 @@ from topmark.cli.help import HelpExample
 from topmark.cli.help import render_examples_epilog
 from topmark.cli.io import plan_cli_inputs
 from topmark.cli.keys import CliCmd
-from topmark.cli.option_groups import PROBE_FORBIDDEN_OPTIONS
 from topmark.cli.options import PATH_COMMAND_CONTEXT_SETTINGS
 from topmark.cli.options import common_color_options
 from topmark.cli.options import common_config_resolution_options
@@ -79,8 +78,6 @@ from topmark.cli.options import config_strict_options
 from topmark.cli.options import shared_policy_options
 from topmark.cli.state import bootstrap_cli_state
 from topmark.cli.validators import apply_color_policy_for_output_format
-from topmark.cli.validators import validate_common_forbidden_path_command_options_in_extra_args
-from topmark.cli.validators import validate_forbidden_options_in_extra_args
 from topmark.cli.validators import validate_stdin_dash_requires_piped_input
 from topmark.config.policy import MutablePolicy
 from topmark.core.errors import ConfigValidationError
@@ -143,6 +140,7 @@ logger: TopmarkLogger = get_logger(__name__)
         ),
     ),
 )
+@click.argument("paths", nargs=-1, type=click.UNPROCESSED)
 @common_color_options
 @common_text_output_verbosity_options
 @common_text_output_quiet_options
@@ -156,6 +154,7 @@ logger: TopmarkLogger = get_logger(__name__)
 @shared_policy_options
 @common_output_format_options
 def probe_command(
+    paths: tuple[str, ...],
     *,
     # common_ui_options (verbosity, color):
     verbosity: int,
@@ -187,8 +186,7 @@ def probe_command(
 ) -> None:
     """Run the resolution probe pipeline.
 
-    The command reads positional paths from ``click.get_current_context().args``
-    (Black-style) and supports three input styles:
+    The command receives Click-parsed positional paths and supports three input styles:
 
     1. Paths mode (default): PATHS and/or ``--files-from FILE``.
     2. Content-on-STDIN: use ``-`` as the sole PATH **and** provide ``--stdin-filename``.
@@ -196,6 +194,8 @@ def probe_command(
        ``--include-from -``, or ``--exclude-from -`` (exactly one may consume STDIN).
 
     Args:
+        paths: Positional paths parsed by Click. Use ``--`` before literal
+            path names that begin with a dash.
         verbosity: Increase TEXT output detail.
         quiet: Suppress TEXT output.
         color_mode: Set the color mode (default: auto).
@@ -232,6 +232,7 @@ def probe_command(
         UNEXPECTED_ERROR (255): An unhandled error occurred.
     """
     ctx: click.Context = click.get_current_context()
+    ctx.args = list(paths)
     state: TopmarkCliState = bootstrap_cli_state(ctx)
     # Effective output format (stored early so shared initialization sees it).
     state.output_format = output_format or OutputFormat.TEXT
@@ -247,19 +248,6 @@ def probe_command(
 
     # Effective TEXT verbosity for console-oriented progressive disclosure.
     verbosity_level: int = state.verbosity
-
-    # Reject controls that belong to file mutation, patch planning, human
-    # pipeline reporting, or generated-header rendering. `probe` shares input
-    # and filtering semantics with `check`/`strip`, but remains read-only and
-    # diagnostic-only.
-    validate_forbidden_options_in_extra_args(
-        ctx,
-        forbidden_opts=PROBE_FORBIDDEN_OPTIONS,
-    )
-
-    # Reject common unsupported option spellings that permissive path parsing
-    # would otherwise pass through as positional input paths, such as `--stdin`.
-    validate_common_forbidden_path_command_options_in_extra_args(ctx)
 
     # Machine metadata.
     meta: MetaPayload = build_meta_payload()

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -65,7 +65,6 @@ from topmark.cli.help import render_examples_epilog
 from topmark.cli.io import plan_cli_inputs
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
-from topmark.cli.option_groups import STRIP_FORBIDDEN_OPTIONS
 from topmark.cli.options import PATH_COMMAND_CONTEXT_SETTINGS
 from topmark.cli.options import common_apply_and_write_options
 from topmark.cli.options import common_color_options
@@ -85,9 +84,7 @@ from topmark.cli.options import shared_policy_options
 from topmark.cli.state import TopmarkCliState
 from topmark.cli.state import bootstrap_cli_state
 from topmark.cli.validators import apply_color_policy_for_output_format
-from topmark.cli.validators import validate_common_forbidden_path_command_options_in_extra_args
 from topmark.cli.validators import validate_diff_policy_for_output_format
-from topmark.cli.validators import validate_forbidden_options_in_extra_args
 from topmark.cli.validators import validate_stdin_dash_requires_piped_input
 from topmark.cli.validators import warn_if_report_scope_ignored
 from topmark.config.policy import MutablePolicy
@@ -155,6 +152,7 @@ logger: TopmarkLogger = get_logger(__name__)
         ),
     ),
 )
+@click.argument("paths", nargs=-1, type=click.UNPROCESSED)
 @common_color_options
 @common_text_output_verbosity_options
 @common_text_output_quiet_options
@@ -171,6 +169,7 @@ logger: TopmarkLogger = get_logger(__name__)
 @pipeline_reporting_options
 @common_output_format_options
 def strip_command(
+    paths: tuple[str, ...],
     *,
     # common_ui_options (verbosity, color):
     verbosity: int,
@@ -210,9 +209,8 @@ def strip_command(
 ) -> None:
     """Remove the TopMark header block from targeted files.
 
-    This command reads positional paths from ``click.get_current_context().args``
-    (Black-style) and reuses the standard config resolver and file selection logic.
-    It supports three input styles:
+    The command receives Click-parsed positional paths and reuses the standard
+    config resolver and file selection logic. It supports three input styles:
 
     1. Paths mode (default): PATHS and/or ``--files-from FILE``.
     2. Content-on-STDIN: use ``-`` as the sole PATH **and** provide ``--stdin-filename``.
@@ -223,6 +221,8 @@ def strip_command(
     options are intentionally not exposed for this command.
 
     Args:
+        paths: Positional paths parsed by Click. Use ``--`` before literal
+            path names that begin with a dash.
         verbosity: Increase TEXT output detail.
         quiet: Suppress TEXT output.
         color_mode: Set the color mode (default: auto).
@@ -265,6 +265,7 @@ def strip_command(
         UNEXPECTED_ERROR (255): An unhandled error occurred.
     """
     ctx: click.Context = click.get_current_context()
+    ctx.args = list(paths)
     state: TopmarkCliState = bootstrap_cli_state(ctx)
     # Effective output format (stored early so shared initialization sees it).
     state.output_format = output_format or OutputFormat.TEXT
@@ -280,18 +281,6 @@ def strip_command(
 
     # Effective TEXT verbosity for console-oriented progressive disclosure.
     verbosity_level: int = state.verbosity
-
-    # Reject options that belong to header generation/update. `strip` shares
-    # input, reporting, diff, and write semantics with `check`, but it is a
-    # removal-only command and must not accept generated-header controls.
-    validate_forbidden_options_in_extra_args(
-        ctx,
-        forbidden_opts=STRIP_FORBIDDEN_OPTIONS,
-    )
-
-    # Reject common unsupported option spellings that permissive path parsing
-    # would otherwise pass through as positional input paths, such as `--stdin`.
-    validate_common_forbidden_path_command_options_in_extra_args(ctx)
 
     # Machine metadata.
     meta: MetaPayload = build_meta_payload()

--- a/src/topmark/cli/option_groups.py
+++ b/src/topmark/cli/option_groups.py
@@ -10,12 +10,10 @@
 
 """Command applicability groups for CLI options.
 
-This module is a narrow metadata layer for TopMark-owned applicability
-validation. It groups already-declared option spellings by the path-oriented
-commands that may accept them.
-
-Click option declarations remain in `topmark.cli.options`; this module must not
-become a generated parser model or a replacement for Click decorators.
+This module is a narrow metadata layer for command-applicability test coverage.
+It groups already-declared option spellings by the path-oriented commands that
+may accept them. Click remains the authoritative parser: commands that do not
+declare these options reject them as parser-level unknown options.
 """
 
 from __future__ import annotations
@@ -78,18 +76,18 @@ PROBE_FORBIDDEN_OPTIONS: Final[dict[str, str]] = {
         CHECK_ONLY_OPTION_REASON,
     ),
 }
-"""Options accepted by permissive parsing but rejected by `topmark probe`.
+"""Options that `topmark probe` must not declare.
 
-The values are human-facing reason strings used by command applicability
-validation.
+The values document the historical command-applicability rationale and keep test
+parameterization close to production option metadata.
 """
 
 STRIP_FORBIDDEN_OPTIONS: Final[dict[str, str]] = dict.fromkeys(
     CHECK_ONLY_GENERATED_HEADER_OPTIONS,
     CHECK_ONLY_OPTION_REASON,
 )
-"""Options accepted by permissive parsing but rejected by `topmark strip`.
+"""Options that `topmark strip` must not declare.
 
-The values are human-facing reason strings used by command applicability
-validation.
+The values document the historical command-applicability rationale and keep test
+parameterization close to production option metadata.
 """

--- a/src/topmark/cli/options.py
+++ b/src/topmark/cli/options.py
@@ -74,11 +74,9 @@ GROUP_CONTEXT_SETTINGS: dict[str, list[str] | bool] = {
     ],
 }
 
-#: Click context settings to allow Black-style extra args and unknown options.
+#: Click context settings for path-oriented commands.
 PATH_COMMAND_CONTEXT_SETTINGS: dict[str, list[str] | bool] = {
     **GROUP_CONTEXT_SETTINGS,
-    "ignore_unknown_options": True,
-    "allow_extra_args": True,
 }
 
 

--- a/src/topmark/cli/validators.py
+++ b/src/topmark/cli/validators.py
@@ -36,7 +36,6 @@ import click
 from topmark.cli.console.color import ColorMode
 from topmark.cli.errors import TopmarkCliUsageError
 from topmark.cli.keys import CliOpt
-from topmark.cli.option_meta import format_option_label
 from topmark.cli.option_meta import format_option_labels
 from topmark.cli.state import get_cli_state
 from topmark.core.formats import OutputFormat
@@ -83,76 +82,6 @@ def _join_option_list(options: list[str]) -> str:
 
     opts: str = ", ".join(options[:-1])
     return f"{opts}, and {options[-1]}"
-
-
-def _extra_arg_matches_option(arg: str, opt: str) -> bool:
-    """Return whether an extra argument is the given option spelling.
-
-    Supports both bare flag form (``--flag``) and assignment form
-    (``--flag=value``). Short-option clustering is intentionally not supported
-    because TopMark command-specific option constants are long options.
-    """
-    return arg == opt or arg.startswith(f"{opt}=")
-
-
-_FORBIDDEN_PATH_COMMAND_OPTS_IN_EXTRA_ARGS: Mapping[str, str] = {
-    "--stdin": (f"Use '-' with '{CliOpt.STDIN_FILENAME}' to read one file's content from STDIN."),
-}
-"""Known option spellings that are intentionally unsupported by path commands.
-
-Path-oriented commands use permissive Click parsing so arbitrary file paths can
-start with a dash. As a consequence, unknown options remain in ``ctx.args`` and
-would otherwise be interpreted as literal input paths. Keep this mapping for
-cross-command spellings that TopMark wants to reject explicitly with an
-actionable message.
-"""
-
-
-def validate_common_forbidden_path_command_options_in_extra_args(
-    ctx: click.Context,
-) -> None:
-    """Reject common unsupported options left behind by permissive path parsing.
-
-    Path commands use ``ignore_unknown_options=True`` and ``allow_extra_args=True``
-    to support Black-style path handling. This means a mistyped or unsupported
-    option can survive Click parsing in ``ctx.args``. This validator catches
-    known common spellings before input planning can treat them as file paths.
-
-    Args:
-        ctx: Active Click context whose ``ctx.args`` may contain extra path-like
-            tokens and unknown option spellings.
-
-    Raises:
-        TopmarkCliUsageError: If a known common unsupported option is present in
-            ``ctx.args``.
-    """
-    extra_args: list[str] = list(ctx.args)
-    for opt, reason in _FORBIDDEN_PATH_COMMAND_OPTS_IN_EXTRA_ARGS.items():
-        if any(_extra_arg_matches_option(arg, opt) for arg in extra_args):
-            opt_label: str = format_option_label(opt)
-            raise TopmarkCliUsageError(
-                f"{ctx.command_path}: option {opt_label} is not supported. {reason}"
-            )
-
-
-def validate_forbidden_options_in_extra_args(
-    ctx: click.Context,
-    *,
-    forbidden_opts: Mapping[str, str],
-) -> None:
-    """Reject known-but-forbidden options that remain in `ctx.args`.
-
-    This is used for commands that enable Click's permissive path-oriented parsing
-    (`ignore_unknown_options=True` / `allow_extra_args=True`), where unsupported
-    options would otherwise be silently accepted as extra arguments.
-    """
-    extra_args: list[str] = list(ctx.args)
-    for opt, reason in forbidden_opts.items():
-        if any(_extra_arg_matches_option(arg, opt) for arg in extra_args):
-            opt_label: str = format_option_label(opt)
-            raise TopmarkCliUsageError(
-                f"{ctx.command_path}: option {opt_label} is not supported. {reason}"
-            )
 
 
 def validate_mutually_exclusive(
@@ -403,12 +332,10 @@ def apply_ignore_positional_paths_policy(
 ) -> None:
     """Ignore positional PATHS for file-agnostic commands.
 
-    Some CLI commands do not operate on input files (for example, configuration inspection
-    commands like ``topmark config check``). When such commands are implemented with
-    ``allow_extra_args=True`` / ``ignore_unknown_options=True``, Click places unexpected
-    positional arguments into ``ctx.args``.
-
-    This helper applies a consistent policy:
+    Some CLI commands do not operate on input files (for example, configuration
+    inspection commands like ``topmark config check``). This helper applies a
+    consistent policy for any positional arguments that command setup placed in
+    ``ctx.args``:
 
     - If any positional arguments were provided, emit a warning that they are ignored.
     - If ``"-"`` was provided (STDIN sentinel) and ``warn_stdin_dash`` is enabled, emit a

--- a/tests/cli/test_command_applicability.py
+++ b/tests/cli/test_command_applicability.py
@@ -22,24 +22,24 @@ from typing import TYPE_CHECKING
 import pytest
 
 from tests.cli.conftest import assert_FILE_NOT_FOUND
-from tests.cli.conftest import assert_rich_output_contains
 from tests.cli.conftest import assert_rich_output_does_not_contain
-from tests.cli.conftest import assert_USAGE_ERROR
+from tests.cli.conftest import assert_rich_output_no_such_option
+from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
 from tests.cli.conftest import assert_WOULD_CHANGE
 from tests.cli.conftest import run_cli
+from tests.cli.conftest import run_cli_in
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
-from topmark.cli.option_groups import CHECK_ONLY_OPTION_REASON
-from topmark.cli.option_groups import CHECK_OR_STRIP_ONLY_OPTION_REASON
 from topmark.cli.option_groups import PROBE_FORBIDDEN_OPTIONS
 from topmark.cli.option_groups import STRIP_FORBIDDEN_OPTIONS
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from click.testing import Result
 
 _STDIN_FLAG: str = "--stdin"
 _STDIN_FILENAME: str = CliOpt.STDIN_FILENAME
-_STDIN_GUIDANCE: str = "Use '-' with '--stdin-filename' to read one file's content from STDIN."
 
 
 # Values used when exercising option spellings that require an argument. Keep
@@ -68,41 +68,25 @@ _OPTION_VALUES: dict[str, str | None] = {
 
 
 @pytest.mark.parametrize(
-    ("option", "value", "reason"),
-    [
-        (option, _OPTION_VALUES[option], reason)
-        for option, reason in PROBE_FORBIDDEN_OPTIONS.items()
-    ],
+    ("option", "value"),
+    [(option, _OPTION_VALUES[option]) for option in PROBE_FORBIDDEN_OPTIONS],
 )
 def test_probe_rejects_inapplicable_path_command_options(
     option: str,
     value: str | None,
-    reason: str,
 ) -> None:
-    """`probe` rejects every centralized check/strip-only option."""
+    """`probe` leaves inapplicable options to Click parser handling."""
     argv: list[str] = [CliCmd.PROBE, option]
     if value is not None:
         argv.append(value)
 
     result: Result = run_cli(argv)
 
-    assert_USAGE_ERROR(result)
-    assert_rich_output_contains(
-        result.output,
-        expected=f"option {option} is not supported.",
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=CliCmd.PROBE,
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=reason,
-    )
+    assert_rich_output_no_such_option(result, option_name=option)
 
 
 def test_probe_rejects_inapplicable_option_assignment_form() -> None:
-    """Forbidden-option validation must catch `--option=value` spellings."""
+    """Click rejects `--option=value` spellings for inapplicable options."""
     result: Result = run_cli(
         [
             CliCmd.PROBE,
@@ -110,19 +94,7 @@ def test_probe_rejects_inapplicable_option_assignment_form() -> None:
         ]
     )
 
-    assert_USAGE_ERROR(result)
-    assert_rich_output_contains(
-        result.output,
-        expected=f"option {CliOpt.WRITE_MODE} is not supported.",
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=CliCmd.PROBE,
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=CHECK_OR_STRIP_ONLY_OPTION_REASON,
-    )
+    assert_rich_output_no_such_option(result, option_name=CliOpt.WRITE_MODE)
 
 
 @pytest.mark.parametrize(
@@ -133,26 +105,14 @@ def test_strip_rejects_generated_header_options(
     option: str,
     value: str | None,
 ) -> None:
-    """`strip` rejects every centralized check-only generated-header option."""
+    """`strip` leaves check-only options to Click parser handling."""
     argv: list[str] = [CliCmd.STRIP, option]
     if value is not None:
         argv.append(value)
 
     result: Result = run_cli(argv)
 
-    assert_USAGE_ERROR(result)
-    assert_rich_output_contains(
-        result.output,
-        expected=f"option {option} is not supported.",
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=CliCmd.STRIP,
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=CHECK_ONLY_OPTION_REASON,
-    )
+    assert_rich_output_no_such_option(result, option_name=option)
 
 
 @pytest.mark.parametrize(
@@ -164,7 +124,7 @@ def test_strip_rejects_generated_header_options(
     ],
 )
 def test_path_commands_reject_stdin_flag(command: str) -> None:
-    """Path commands must reject `--stdin` and instruct to use '-'."""
+    """Path commands reject `--stdin` at Click parser level."""
     result: Result = run_cli(
         [
             command,
@@ -174,19 +134,7 @@ def test_path_commands_reject_stdin_flag(command: str) -> None:
         ]
     )
 
-    assert_USAGE_ERROR(result)
-    assert_rich_output_contains(
-        result.output,
-        expected=f"option {_STDIN_FLAG} is not supported.",
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=command,
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=_STDIN_GUIDANCE,
-    )
+    assert_rich_output_no_such_option(result, option_name=_STDIN_FLAG)
 
 
 @pytest.mark.parametrize(
@@ -198,7 +146,7 @@ def test_path_commands_reject_stdin_flag(command: str) -> None:
     ],
 )
 def test_path_commands_reject_stdin_flag_assignment_form(command: str) -> None:
-    """`--stdin=value` must also be rejected."""
+    """`--stdin=value` is rejected at Click parser level."""
     result: Result = run_cli(
         [
             command,
@@ -208,23 +156,11 @@ def test_path_commands_reject_stdin_flag_assignment_form(command: str) -> None:
         ]
     )
 
-    assert_USAGE_ERROR(result)
-    assert_rich_output_contains(
-        result.output,
-        expected=f"option {_STDIN_FLAG} is not supported.",
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=command,
-    )
-    assert_rich_output_contains(
-        result.output,
-        expected=_STDIN_GUIDANCE,
-    )
+    assert_rich_output_no_such_option(result, option_name=_STDIN_FLAG)
 
 
 def test_probe_rejects_first_inapplicable_option_when_multiple_are_present() -> None:
-    """`probe` should fail deterministically on the first known forbidden option."""
+    """`probe` should fail deterministically on the first unsupported option."""
     result: Result = run_cli(
         [
             CliCmd.PROBE,
@@ -234,18 +170,65 @@ def test_probe_rejects_first_inapplicable_option_when_multiple_are_present() -> 
         ]
     )
 
-    assert_USAGE_ERROR(result)
-    assert_rich_output_contains(
-        result.output,
-        expected=f"option {CliOpt.RENDER_DIFF} is not supported.",
+    assert_rich_output_no_such_option(result, option_name=CliOpt.REPORT)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        CliCmd.CHECK,
+        CliCmd.STRIP,
+        CliCmd.PROBE,
+    ],
+)
+def test_path_commands_reject_existing_dash_prefixed_paths_before_delimiter(
+    command: str,
+    tmp_path: Path,
+) -> None:
+    """Dash-prefixed paths before `--` are parsed as unsupported options."""
+    path: Path = tmp_path / "--foo.py"
+    path.write_text("print('hello')\n", encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            "--foo.py",
+        ],
     )
-    assert_rich_output_contains(
-        result.output,
-        expected=CliCmd.PROBE,
+
+    assert_rich_output_no_such_option(result, option_name="--foo.py")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        CliCmd.CHECK,
+        CliCmd.STRIP,
+        CliCmd.PROBE,
+    ],
+)
+def test_path_commands_accept_existing_dash_prefixed_paths_after_delimiter(
+    command: str,
+    tmp_path: Path,
+) -> None:
+    """Literal dash-prefixed paths require the standard `--` delimiter."""
+    path: Path = tmp_path / "--foo.py"
+    path.write_text("print('hello')\n", encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            "--",
+            "--foo.py",
+        ],
     )
-    assert_rich_output_contains(
+
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+    assert_rich_output_does_not_contain(
         result.output,
-        expected=CHECK_OR_STRIP_ONLY_OPTION_REASON,
+        expected="No such option",
     )
 
 

--- a/tests/cli/test_policy_options.py
+++ b/tests/cli/test_policy_options.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tests.cli.conftest import assert_rich_output_no_such_option
 from tests.cli.conftest import assert_SUCCESS
-from tests.cli.conftest import assert_USAGE_ERROR
 from tests.cli.conftest import command_option_names
 from tests.cli.conftest import run_cli
 from tests.cli.conftest import run_cli_in
@@ -227,4 +227,7 @@ def test_strip_rejects_header_mutation_mode_option(tmp_path: Path) -> None:
             target.name,
         ],
     )
-    assert_USAGE_ERROR(result)
+    assert_rich_output_no_such_option(
+        result,
+        option_name=CliOpt.POLICY_HEADER_MUTATION_MODE,
+    )

--- a/tests/cli/test_validators.py
+++ b/tests/cli/test_validators.py
@@ -22,12 +22,9 @@ from topmark.cli.console.click_console import Console
 from topmark.cli.console.color import ColorMode
 from topmark.cli.errors import TopmarkCliUsageError
 from topmark.cli.state import TopmarkCliState
-from topmark.cli.validators import _extra_arg_matches_option  # pyright: ignore[reportPrivateUsage]
 from topmark.cli.validators import apply_color_policy_for_output_format
 from topmark.cli.validators import apply_ignore_positional_paths_policy
-from topmark.cli.validators import validate_common_forbidden_path_command_options_in_extra_args
 from topmark.cli.validators import validate_diff_policy_for_output_format
-from topmark.cli.validators import validate_forbidden_options_in_extra_args
 from topmark.cli.validators import validate_human_only_config_flags_for_machine_format
 from topmark.cli.validators import validate_machine_format_forbids_flags
 from topmark.cli.validators import validate_mutually_exclusive
@@ -87,64 +84,6 @@ def _state_with_console(
         console=Console(enable_color=False, err=err),
     )
     return state, err
-
-
-@pytest.mark.parametrize(
-    ("arg", "opt", "expected"),
-    [
-        ("--stdin", "--stdin", True),
-        ("--stdin=value", "--stdin", True),
-        ("--stdin-filename", "--stdin", False),
-        ("--std", "--stdin", False),
-        ("path.py", "--stdin", False),
-    ],
-)
-def test_extra_arg_matches_option(arg: str, opt: str, expected: bool) -> None:
-    """Extra option matching should support exact and assignment forms only."""
-    assert _extra_arg_matches_option(arg, opt) is expected
-
-
-def test_validate_common_forbidden_path_options_accepts_absent_options() -> None:
-    """Common forbidden-option validator should pass when no known option remains."""
-    ctx: click.Context = _make_click_context(args=["--unknown", "file.py"])
-
-    validate_common_forbidden_path_command_options_in_extra_args(ctx)
-
-
-@pytest.mark.parametrize("arg", ["--stdin", "--stdin=ignored"])
-def test_validate_common_forbidden_path_options_rejects_stdin(arg: str) -> None:
-    """Path commands should reject leftover `--stdin` spellings."""
-    ctx: click.Context = _make_click_context(args=[arg])
-
-    with pytest.raises(
-        TopmarkCliUsageError,
-        match=r"topmark-test: option --stdin is not supported.",
-    ):
-        validate_common_forbidden_path_command_options_in_extra_args(ctx)
-
-
-def test_validate_forbidden_options_in_extra_args_rejects_custom_option() -> None:
-    """Custom forbidden options should be rejected from permissive extra args."""
-    ctx: click.Context = _make_click_context(args=["--unsafe=true"])
-
-    with pytest.raises(
-        TopmarkCliUsageError,
-        match=r"topmark-test: option --unsafe is not supported. not allowed",
-    ):
-        validate_forbidden_options_in_extra_args(
-            ctx,
-            forbidden_opts={"--unsafe": "not allowed"},
-        )
-
-
-def test_validate_forbidden_options_in_extra_args_ignores_unmatched_options() -> None:
-    """Custom forbidden-option validator should ignore unrelated extras."""
-    ctx: click.Context = _make_click_context(args=["--other", "file.py"])
-
-    validate_forbidden_options_in_extra_args(
-        ctx,
-        forbidden_opts={"--unsafe": "not allowed"},
-    )
 
 
 def test_validate_mutually_exclusive_accepts_zero_or_one_enabled_flag() -> None:


### PR DESCRIPTION
## Summary

Fixes #84.

This PR aligns `topmark check`, `topmark strip`, and `topmark probe` with
Click and POSIX-style CLI option handling:

- unknown option-like arguments before `--` are now Click parser errors;
- parser-level failures use Click exit code `2`;
- literal filenames beginning with `-` remain supported after `--`;
- obsolete TopMark-side extra-argument validators were removed;
- command applicability tests now assert parser-level rejection;
- regression tests cover dash-prefixed paths before and after `--`;
- usage docs and the changelog document the breaking behavior.

## Breaking change

`topmark check --foo`, `topmark strip --foo`, and `topmark probe --foo`
are no longer interpreted as input paths. They now fail as unknown options.

Users with literal dash-prefixed filenames must use the standard delimiter:

```bash
topmark check -- --generated.py
```

## Validation

- Full test suite is green.
- Coverage remains healthy for the affected CLI modules.