### PR TITLE
Fix canonical path casing for built-in file fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
   # Build release artifacts in unprivileged CI so privileged release workflow can publish without checking out/building repo code.
   release-artifacts:
     name: Build release artifacts
-    needs: [changes, python-metadata, lint, pre-commit, docs, tests, coverage, links, links-site]
+    needs: [changes, python-metadata, lint, pre-commit, docs, tests, filesystem-tests, coverage, links, links-site]
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -338,6 +338,32 @@ jobs:
       - name: Run nox QA for ${{ matrix.python-version }}
         run: |
           nox -s qa -p ${{ matrix.python-version }}
+
+  filesystem-tests:
+    name: Filesystem tests (${{ matrix.os }})
+    needs: [changes, python-metadata]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.python_changed == 'true' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-python-nox
+        with:
+          python-version: ${{ needs.python-metadata.outputs.canonical }}
+
+      - name: Run canonical Python QA on ${{ matrix.os }}
+        run: |
+          nox -s qa -p ${{ needs.python-metadata.outputs.canonical }}
 
   coverage:
     name: Coverage

--- a/docs/ci/ci-workflow.md
+++ b/docs/ci/ci-workflow.md
@@ -78,19 +78,20 @@ ______________________________________________________________________
 
 ## Jobs and validation scope
 
-| Job                 | Purpose                                                               | Main tools                                 |
-| ------------------- | --------------------------------------------------------------------- | ------------------------------------------ |
-| `changes`           | Detect changed file groups for PR job gating                          | `dorny/paths-filter`                       |
-| `python-metadata`   | Resolve supported and canonical Python versions for CI jobs           | `nox`, `pyproject.toml`                    |
-| `lint`              | Validate formatting, linting, typing, and docstring links             | `nox`, `ruff`, `pyright`                   |
-| `pre-commit`        | Run configured pre-commit hooks                                       | `pre-commit`                               |
-| `docs`              | Build the documentation site in strict mode                           | `nox`, `mkdocs`                            |
-| `tests`             | Run the supported Python test matrix                                  | `nox`, `pytest`                            |
-| `coverage`          | Generate and publish canonical coverage reports                       | `nox`, `coverage.py`, `pytest`             |
-| `api-snapshot`      | Check public API stability for source-changing pull requests          | `nox`, `tools/api_snapshot.py`             |
-| `links`             | Validate links in source Markdown files                               | `lycheeverse/lychee-action`, `lychee.toml` |
-| `links-site`        | Validate links in the rendered MkDocs site, including generated pages | `mkdocs`, `lycheeverse/lychee-action`      |
-| `release-artifacts` | Build and upload release artifacts for version tags                   | `uv build`, `actions/upload-artifact`      |
+| Job                 | Purpose                                                                 | Main tools                                 |
+| ------------------- | ----------------------------------------------------------------------- | ------------------------------------------ |
+| `changes`           | Detect changed file groups for PR job gating                            | `dorny/paths-filter`                       |
+| `python-metadata`   | Resolve supported and canonical Python versions for CI jobs             | `nox`, `pyproject.toml`                    |
+| `lint`              | Validate formatting, linting, typing, and docstring links               | `nox`, `ruff`, `pyright`                   |
+| `pre-commit`        | Run configured pre-commit hooks                                         | `pre-commit`                               |
+| `docs`              | Build the documentation site in strict mode                             | `nox`, `mkdocs`                            |
+| `tests`             | Run the supported Python test matrix                                    | `nox`, `pytest`                            |
+| `filesystem-tests`  | Run canonical Python tests across Linux, macOS, and Windows filesystems | `nox`, `pytest`                            |
+| `coverage`          | Generate and publish canonical coverage reports                         | `nox`, `coverage.py`, `pytest`             |
+| `api-snapshot`      | Check public API stability for source-changing pull requests            | `nox`, `tools/api_snapshot.py`             |
+| `links`             | Validate links in source Markdown files                                 | `lycheeverse/lychee-action`, `lychee.toml` |
+| `links-site`        | Validate links in the rendered MkDocs site, including generated pages   | `mkdocs`, `lycheeverse/lychee-action`      |
+| `release-artifacts` | Build and upload release artifacts for version tags                     | `uv build`, `actions/upload-artifact`      |
 
 Most jobs delegate validation to nox sessions so local development and CI share the same stable
 validation contracts and execution semantics. The `python-metadata` job resolves supported Python
@@ -98,14 +99,20 @@ versions and the canonical single-version Python from project metadata through
 `nox -s print_python_matrix`. The test matrix consumes that supported-version list with `fail-fast`
 disabled so failures on one Python version do not hide failures on others.
 
+Filesystem-sensitive behavior is validated separately by the `filesystem-tests` job. That job runs
+the canonical Python QA session across Ubuntu, macOS, and Windows so platform-dependent path and
+filesystem semantics are checked on real GitHub-hosted filesystems without multiplying the full
+supported Python-version matrix across every operating system.
+
 Coverage reporting runs in a dedicated canonical job on Ubuntu using the resolved canonical Python
 version and the existing `nox -s coverage` session. Coverage intentionally runs outside the full
 test matrix to avoid duplicating expensive QA work that is already covered by the compatibility
 matrix.
 
-The coverage job depends on the full test matrix succeeding before coverage reports are generated.
-This keeps the compatibility matrix as the primary validation gate while avoiding additional
-coverage-processing noise after known test failures.
+The coverage job depends on the full supported-version test matrix succeeding before coverage
+reports are generated. This keeps the compatibility matrix as the primary validation gate while
+avoiding additional coverage-processing noise after known test failures. Platform-dependent
+filesystem validation remains a separate gate through `filesystem-tests`.
 
 Canonical single-version jobs such as linting, documentation builds, coverage, API snapshot checks,
 and release-artifact construction use the same resolved canonical Python value rather than carrying
@@ -192,6 +199,10 @@ nox -s qa -p 3.13
 nox -s coverage -p 3.13
 ```
 
+The `filesystem-tests` job runs the same canonical `qa` session on Ubuntu, macOS, and Windows. Local
+reproduction can validate the current machine's filesystem behavior, but it cannot replace the
+cross-platform GitHub-hosted runs for case-sensitivity and path-canonicalization behavior.
+
 The concrete `3.13` commands shown here reflect the current canonical Python version. That value is
 resolved from project metadata and is expected to move when the supported Python range moves.
 
@@ -235,6 +246,9 @@ When editing this workflow:
 - keep Python-version metadata sourced from `pyproject.toml` through `nox -s print_python_matrix`;
 - keep the coverage job canonical and lightweight rather than instrumenting the full compatibility
   matrix;
+- keep platform-dependent filesystem behavior covered by the canonical cross-platform
+  `filesystem-tests` job rather than expanding the full Python-version matrix across all operating
+  systems;
 - keep coverage reporting lightweight and diagnostic rather than turning it into a percentage-driven
   release gate;
 - keep release artifact building in CI unless the release trust model is deliberately redesigned;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,6 +274,7 @@ reportUnusedVariable               = true
 [tool.pytest.ini_options]
 markers = [
   "api: tests that exercise the API",
+  "case_insensitive_fs: tests for case-insensitive file systems",
   "cli: tests that exercise the CLI",
   "config: tests for config deserialization, path normalization, strictness, and layer merge behavior",
   "dev_validation: developer validation tests (e.g., registry validation)",

--- a/src/topmark/pipeline/machine/payloads.py
+++ b/src/topmark/pipeline/machine/payloads.py
@@ -46,6 +46,7 @@ from topmark.pipeline.outcomes import collect_outcome_reason_counts
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.machine.schemas import OutcomeSummaryRow
@@ -53,6 +54,11 @@ if TYPE_CHECKING:
     from topmark.resolution.probe import ResolutionProbeMatchSignals
     from topmark.resolution.probe import ResolutionProbeResult
     from topmark.resolution.probe import ResolutionProbeSelection
+
+
+def _machine_path(path: Path) -> str:
+    """Emit POSIX path for machine output."""
+    return path.as_posix()
 
 
 def build_probe_selection_payload(
@@ -147,7 +153,7 @@ def build_probe_result_payload(
     probe: ResolutionProbeResult | None = result.resolution_probe
     if probe is None:
         return {
-            "path": str(result.path),
+            "path": _machine_path(result.path),
             "status": "probe_missing",
             "reason": "no_resolution_probe_result",
             "selected_file_type": None,
@@ -156,7 +162,7 @@ def build_probe_result_payload(
         }
 
     return {
-        "path": str(probe.path),
+        "path": _machine_path(probe.path),
         "status": probe.status.value,
         "reason": probe.reason.value,
         "selected_file_type": build_probe_selection_payload(probe.selected_file_type),

--- a/src/topmark/pipeline/steps/builder.py
+++ b/src/topmark/pipeline/steps/builder.py
@@ -42,6 +42,7 @@ from topmark.pipeline.status import GenerationStatus
 from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import BuilderView
 from topmark.utils.file import compute_relpath
+from topmark.utils.path import canonicalize_existing_path
 
 if TYPE_CHECKING:
     from topmark.config.model import FrozenConfig
@@ -120,23 +121,24 @@ class BuilderStep(BaseStep):
         Path semantics:
             - `file_path` is `ctx.path` as provided by config resolution.
               It may be relative or absolute depending on how the file was discovered.
-            - `file_abspath` is computed from the logical header path and is therefore an
-              absolute, normalized path. In stdin mode this means it reflects the logical
-              `stdin_filename`, not the materialized temporary file path.
+            - For regular filesystem input, `file`, `file_relpath`, and `file_abspath`
+              are derived from the canonical filesystem spelling of the resolved path.
+              This avoids casing-only metadata drift on case-insensitive filesystems.
+            - In stdin mode, `file`, `file_relpath`, and `file_abspath` are derived from
+              the logical `stdin_filename`, not the materialized temporary file path.
             - `file_relpath` and `relpath` are computed by calling
-              `compute_relpath(file_path, relative_to)`. Note that this uses the
-              original `file_path` (not `file_path.resolve()`), so the relative
-              path is derived from the discovery spelling.
+              `compute_relpath(header_path, relative_to)`.
             - `relative_to` defaults to `Path.cwd()` when no explicit root is configured.
-              If `FrozenConfig.relative_to` is set, it is resolved to an absolute path via
-              `Path(config.relative_to).resolve()`.
+              If `FrozenConfig.relative_to` is set and exists on disk, it is canonicalized
+              before relative paths are computed.
             - `relpath` becomes "." at repo root.
 
             This behavior intentionally keeps `file_relpath` stable for common cases
             like running TopMark from the repository root (so `pyproject.toml` yields
             `file_relpath = "pyproject.toml"`). If you need `file_relpath` computed
             relative to a specific root, set `FrozenConfig.relative_to` (via config or CLI/API
-            overrides).
+            overrides). User-supplied path spelling is not treated as header metadata once a
+            regular filesystem path has been successfully resolved.
         """
         logger.debug("ctx: %s", ctx)
 
@@ -173,10 +175,12 @@ class BuilderStep(BaseStep):
         content_path: Path = file_path
 
         # In stdin mode, use `stdin_filename` (if provided) for logical header metadata.
+        # Otherwise, use the canonical filesystem spelling of the existing content path.
+        # This keeps generated metadata tied to filesystem identity instead of invocation spelling.
         header_path: Path = (
             Path(ctx.run_options.stdin_filename)
             if (ctx.run_options.stdin_mode and ctx.run_options.stdin_filename)
-            else content_path
+            else canonicalize_existing_path(content_path)
         )
 
         # File absolute path is derived from the logical header path so stdin mode reports the
@@ -185,9 +189,13 @@ class BuilderStep(BaseStep):
         content_absolute_path: Path = content_path.resolve(strict=True)
 
         # Relative paths are computed against `relative_to` using the logical header path.
-        # Note: `header_path` may not exist, so `compute_relpath()` must not rely on
-        # strict filesystem resolution.
-        relative_to: Path = Path(config.relative_to).resolve() if config.relative_to else Path.cwd()
+        # Note: `header_path` may not exist in stdin mode, so `compute_relpath()` must not rely
+        # on strict filesystem resolution.
+        relative_to: Path = (
+            canonicalize_existing_path(Path(config.relative_to))
+            if config.relative_to and Path(config.relative_to).exists()
+            else Path.cwd()
+        )
         # Determine relative path from the file to the root path
         # Default to the current working directory if 'relative_to' is not configured
         relative_path: Path = compute_relpath(header_path, relative_to)

--- a/src/topmark/resolution/files.py
+++ b/src/topmark/resolution/files.py
@@ -763,7 +763,7 @@ def resolve_file_list_with_diagnostics(
         # Report problems *after* expansion
         if "*" in str(p):
             if not expanded:
-                unmatched_patterns.append(str(p))  # glob that matched nothing
+                unmatched_patterns.append(p.as_posix())  # glob that matched nothing
         else:
             if not p.exists():
                 missing_literals.append(p)  # literal path that doesn't exist

--- a/src/topmark/utils/file.py
+++ b/src/topmark/utils/file.py
@@ -65,8 +65,13 @@ def compute_relpath(file_path: Path, root_path: Path) -> Path:
         # Direct subpath case
         return resolved_path.relative_to(resolved_root)
     except ValueError:
-        # Not a direct subpath - safe fallback using os.path.relpath
-        return Path(os.path.relpath(resolved_path, start=resolved_root))
+        # Not a direct subpath. Fall back to a relative path when possible.
+        # On Windows, `os.path.relpath()` raises ValueError when the path and root
+        # are on different drives; in that case, return the absolute resolved path.
+        try:
+            return Path(os.path.relpath(resolved_path, start=resolved_root))
+        except ValueError:
+            return resolved_path
 
 
 def rebase_glob_patterns(

--- a/src/topmark/utils/path.py
+++ b/src/topmark/utils/path.py
@@ -1,0 +1,62 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : path.py
+#   file_relpath : src/topmark/utils/path.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Filesystem path utilities.
+
+This module contains helpers for working with filesystem paths while preserving
+stable behavior across case-sensitive and case-insensitive filesystems.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def canonicalize_existing_path(path: Path) -> Path:
+    """Return a path using canonical filesystem casing.
+
+    The path is expected to exist and refer to a filesystem object.
+
+    The returned path refers to the same filesystem object as ``path`` but, on
+    case-insensitive filesystems, uses the directory-entry spelling stored on
+    disk rather than the spelling used by the caller.
+
+    Args:
+        path: Existing filesystem path.
+
+    Returns:
+        A path using canonical filesystem casing when it can be determined.
+    """
+    # The path must exist; `resolve(strict=True)` establishes filesystem identity
+    # before reconstructing canonical directory-entry casing.
+    resolved: Path = path.resolve(strict=True)
+
+    parts: tuple[str, ...] = resolved.parts
+    if not parts:
+        return resolved
+
+    current: Path = Path(parts[0])
+
+    for part in parts[1:]:
+        try:
+            entry_name: str = next(
+                (
+                    candidate.name
+                    for candidate in current.iterdir()
+                    if candidate.name.casefold() == part.casefold()
+                ),
+                part,
+            )
+        except OSError:
+            return resolved
+
+        current = current / entry_name
+
+    return current

--- a/tests/cli/machine/test_probe_machine.py
+++ b/tests/cli/machine/test_probe_machine.py
@@ -46,6 +46,14 @@ if TYPE_CHECKING:
     from pytest import MonkeyPatch
 
 
+def _machine_path(path: Path) -> str:
+    """Emit POSIX path for machine output.
+
+    See [topmark.pipeline.machine.payloads].
+    """
+    return path.as_posix()
+
+
 def test_probe_json_output_shape(tmp_path: Path) -> None:
     """JSON output should contain the expected probe structure."""
     file: Path = tmp_path / "example.py"
@@ -241,9 +249,9 @@ def test_probe_json_omits_directory_filtered_result_when_children_selected(
         probe_payloads.append(as_object_dict(probe_obj))
 
     paths: set[object] = {probe["path"] for probe in probe_payloads}
-    assert str(python_file) in paths
-    assert str(markdown_file) in paths
-    assert str(directory) not in paths
+    assert _machine_path(python_file) in paths
+    assert _machine_path(markdown_file) in paths
+    assert _machine_path(directory) not in paths
 
     statuses: set[object] = {probe["status"] for probe in probe_payloads}
     assert statuses == {"resolved"}
@@ -393,7 +401,7 @@ def test_probe_ndjson_reports_missing_input_only_once(tmp_path: Path) -> None:
         cli,
         [
             CliCmd.PROBE,
-            str(missing),
+            _machine_path(missing),
             CliOpt.OUTPUT_FORMAT,
             OutputFormat.NDJSON.value,
         ],
@@ -406,7 +414,7 @@ def test_probe_ndjson_reports_missing_input_only_once(tmp_path: Path) -> None:
     assert len(probe_records) == 1
 
     payload: dict[str, object] = record_payload(probe_records[0])
-    assert payload["path"] == str(missing)
+    assert payload["path"] == _machine_path(missing)
     assert payload["status"] == "probe_missing"
     assert payload["reason"] == "no_resolution_probe_result"
 

--- a/tests/cli/test_processing_case_insensitive_fs.py
+++ b/tests/cli/test_processing_case_insensitive_fs.py
@@ -1,0 +1,154 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_processing_case_insensitive_fs.py
+#   file_relpath : tests/cli/test_processing_case_insensitive_fs.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""CLI regression tests for case-insensitive filesystem path handling.
+
+These tests cover issue #75 at the command boundary. They intentionally rely on
+real filesystem behavior instead of mocking because the bug depends on whether
+lookup of differently cased path components resolves to the same file.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.cli.conftest import assert_SUCCESS
+from tests.cli.conftest import run_cli_in
+from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+
+pytestmark: list[pytest.MarkDecorator] = [
+    pytest.mark.cli,
+    pytest.mark.case_insensitive_fs,
+]
+
+
+def _write_readme_without_header(root: Path) -> Path:
+    """Create a Markdown file whose path uses canonical mixed casing.
+
+    Args:
+        root: Temporary project root used as the CLI working directory.
+
+    Returns:
+        The canonical path to the created README file.
+    """
+    docs_dir: Path = root / "Docs"
+    docs_dir.mkdir()
+
+    readme_path: Path = docs_dir / "README.md"
+    readme_path.write_text("# README\n", encoding="utf-8")
+    return readme_path
+
+
+def _apply_header_with_canonical_path(root: Path) -> Path:
+    """Create a canonical README file and apply a matching TopMark header.
+
+    Args:
+        root: Temporary project root used as the CLI working directory.
+
+    Returns:
+        The canonical path to the header-managed README file.
+    """
+    readme_path: Path = _write_readme_without_header(root)
+
+    result: Result = run_cli_in(
+        root,
+        [
+            CliCmd.CHECK,
+            CliOpt.APPLY_CHANGES,
+            "Docs/README.md",
+        ],
+    )
+
+    assert_SUCCESS(result)
+    return readme_path
+
+
+def test_check_uses_canonical_path_fields_for_mismatched_invocation_casing(
+    case_insensitive_fs: Path,
+) -> None:
+    """A casing-only invocation mismatch should not produce a false diff.
+
+    The header is first generated using the canonical filesystem spelling. The
+    follow-up check then uses different casing for both the directory and file
+    components. On a case-insensitive filesystem this should still be unchanged.
+    """
+    readme_path: Path = _apply_header_with_canonical_path(case_insensitive_fs)
+
+    before: str = readme_path.read_text(encoding="utf-8")
+
+    result: Result = run_cli_in(
+        case_insensitive_fs,
+        [
+            CliCmd.CHECK,
+            "docs/REadme.md",
+        ],
+    )
+
+    assert_SUCCESS(result)
+    assert readme_path.read_text(encoding="utf-8") == before
+    assert "would update" not in result.output.lower()
+    assert "changes found" not in result.output.lower()
+
+
+def test_check_apply_preserves_file_for_mismatched_invocation_casing_when_unchanged(
+    case_insensitive_fs: Path,
+) -> None:
+    """`check --apply` should not rewrite solely due to path casing drift."""
+    readme_path: Path = _apply_header_with_canonical_path(case_insensitive_fs)
+
+    before: str = readme_path.read_text(encoding="utf-8")
+    assert "file         : README.md" in before
+    assert "file_relpath : Docs/README.md" in before
+
+    result: Result = run_cli_in(
+        case_insensitive_fs,
+        [
+            CliCmd.CHECK,
+            CliOpt.APPLY_CHANGES,
+            "docs/REadme.md",
+        ],
+    )
+
+    assert_SUCCESS(result)
+    assert readme_path.read_text(encoding="utf-8") == before
+
+
+def test_check_uses_canonical_path_fields_for_absolute_mismatched_invocation_casing(
+    case_insensitive_fs: Path,
+) -> None:
+    """Absolute casing-only invocation mismatches should not produce false diffs."""
+    readme_path: Path = _apply_header_with_canonical_path(case_insensitive_fs)
+
+    before: str = readme_path.read_text(encoding="utf-8")
+    invocation_path: Path = case_insensitive_fs / "docs" / "REadme.md"
+    assert invocation_path.is_absolute()
+    assert invocation_path.exists()
+
+    result: Result = run_cli_in(
+        case_insensitive_fs,
+        [
+            CliCmd.CHECK,
+            invocation_path.as_posix(),
+        ],
+    )
+
+    assert_SUCCESS(result)
+    assert readme_path.read_text(encoding="utf-8") == before
+    assert "would update" not in result.output.lower()
+    assert "changes found" not in result.output.lower()

--- a/tests/cli/test_processing_case_sensitive_fs.py
+++ b/tests/cli/test_processing_case_sensitive_fs.py
@@ -1,0 +1,57 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_processing_case_sensitive_fs.py
+#   file_relpath : tests/cli/test_processing_case_sensitive_fs.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""CLI regression tests for case-sensitive filesystem path handling.
+
+These tests complement the issue #75 case-insensitive tests by asserting that
+TopMark does not treat differently cased path spellings as equivalent on a
+case-sensitive filesystem.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.cli.conftest import assert_FILE_NOT_FOUND
+from tests.cli.conftest import run_cli_in
+from topmark.cli.keys import CliCmd
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+
+pytestmark: list[pytest.MarkDecorator] = [pytest.mark.cli]
+
+
+def test_check_does_not_resolve_mismatched_invocation_casing_on_case_sensitive_fs(
+    tmp_path: Path,
+) -> None:
+    """A casing-only mismatch should fail on case-sensitive filesystems."""
+    actual_file: Path = tmp_path / "README.md"
+    actual_file.write_text("# README\n", encoding="utf-8")
+
+    invocation_path: Path = tmp_path / "REadme.md"
+    if invocation_path.exists():
+        pytest.skip("test requires a case-sensitive filesystem")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            "REadme.md",
+        ],
+    )
+
+    assert_FILE_NOT_FOUND(result)
+    assert "REadme.md" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,6 +163,46 @@ def isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return cwd
 
 
+# --- Filesystem Case Sensitivity Helpers ---
+
+
+def is_case_insensitive_filesystem(path: Path) -> bool:
+    """Return whether the filesystem containing `path` resolves names case-insensitively.
+
+    Args:
+        path: Existing directory used as the probe location.
+
+    Returns:
+        True when a differently cased spelling resolves to the same directory entry.
+    """
+    probe = path / "TopMarkCaseProbe.txt"
+    alias = path / "topmarkcaseprobe.txt"
+
+    probe.write_text("probe\n", encoding="utf-8")
+    try:
+        return alias.exists()
+    finally:
+        probe.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def case_insensitive_fs(tmp_path: Path) -> Path:
+    """Return `tmp_path` only when it is backed by a case-insensitive filesystem.
+
+    Args:
+        tmp_path: Pytest temporary directory used to probe filesystem behavior.
+
+    Returns:
+        The temporary directory when case-insensitive path lookup is available.
+
+    Raises:
+        pytest.skip.Exception: When the temporary filesystem is case-sensitive.
+    """
+    if not is_case_insensitive_filesystem(tmp_path):
+        pytest.skip("test requires a case-insensitive filesystem")
+    return tmp_path
+
+
 # --- Generic Test Helpers ---
 
 

--- a/tests/pipeline/steps/test_builder.py
+++ b/tests/pipeline/steps/test_builder.py
@@ -1,0 +1,136 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_builder.py
+#   file_relpath : tests/pipeline/steps/test_builder.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Unit tests for the `builder` pipeline step.
+
+These tests validate built-in field generation before rendering/comparison.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers.pipeline import make_pipeline_context
+from tests.helpers.pipeline import run_builder
+from topmark.config.io.deserializers import mutable_config_from_defaults
+from topmark.config.model import MutableConfig
+from topmark.pipeline.status import ContentStatus
+from topmark.pipeline.status import GenerationStatus
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import MonkeyPatch
+
+    from topmark.config.model import FrozenConfig
+    from topmark.pipeline.context.model import ProcessingContext
+
+
+def _build_for_path(path: Path, cfg: FrozenConfig) -> ProcessingContext:
+    """Run the builder step for an existing path.
+
+    Args:
+        path: Existing path used to seed the processing context.
+        cfg: Frozen configuration used by the builder.
+
+    Returns:
+        The processed context after running the builder step.
+    """
+    ctx: ProcessingContext = make_pipeline_context(path, cfg)
+    ctx.status.content = ContentStatus.OK
+    return run_builder(ctx)
+
+
+def test_builder_generates_path_fields_from_matching_filesystem_spelling(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Generate built-in path fields from a normally cased file path."""
+    monkeypatch.chdir(tmp_path)
+
+    file_path: Path = tmp_path / "README.md"
+    file_path.write_text("# README\n", encoding="utf-8")
+
+    cfg: FrozenConfig = mutable_config_from_defaults().freeze()
+    ctx: ProcessingContext = _build_for_path(file_path, cfg)
+
+    assert ctx.status.generation is GenerationStatus.GENERATED
+    assert ctx.views.build is not None
+    assert ctx.views.build.builtins is not None
+    assert ctx.views.build.builtins["file"] == "README.md"
+    assert ctx.views.build.builtins["file_relpath"] == "README.md"
+    assert ctx.views.build.builtins["file_abspath"] == file_path.resolve().as_posix()
+
+
+@pytest.mark.case_insensitive_fs
+def test_builder_generates_path_fields_from_canonical_filesystem_spelling(
+    case_insensitive_fs: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Generate built-in path fields from canonical casing after resolution.
+
+    This reproduces issue #75: on a case-insensitive filesystem, the invocation
+    path may resolve successfully even when its casing differs from the directory
+    entries stored on disk. Built-in fields should use the canonical filesystem
+    spelling, not the invocation spelling.
+    """
+    monkeypatch.chdir(case_insensitive_fs)
+
+    actual_dir: Path = case_insensitive_fs / "Docs"
+    actual_dir.mkdir()
+    actual_file: Path = actual_dir / "README.md"
+    actual_file.write_text("# README\n", encoding="utf-8")
+
+    invocation_path: Path = case_insensitive_fs / "docs" / "REadme.md"
+    assert invocation_path.exists()
+
+    cfg: FrozenConfig = mutable_config_from_defaults().freeze()
+    ctx: ProcessingContext = _build_for_path(invocation_path, cfg)
+
+    assert ctx.status.generation is GenerationStatus.GENERATED
+    assert ctx.views.build is not None
+    assert ctx.views.build.builtins is not None
+    assert ctx.views.build.builtins["file"] == "README.md"
+    assert ctx.views.build.builtins["file_relpath"] == "Docs/README.md"
+    assert ctx.views.build.builtins["file_abspath"] == actual_file.resolve().as_posix()
+
+
+@pytest.mark.case_insensitive_fs
+def test_builder_generates_relpath_from_canonical_filesystem_spelling_with_relative_to(
+    case_insensitive_fs: Path,
+) -> None:
+    """Generate `file_relpath` from canonical casing relative to a configured base."""
+    project_root: Path = case_insensitive_fs / "ProjectRoot"
+    actual_dir: Path = project_root / "Docs"
+    actual_dir.mkdir(parents=True)
+    actual_file: Path = actual_dir / "README.md"
+    actual_file.write_text("# README\n", encoding="utf-8")
+
+    invocation_path: Path = case_insensitive_fs / "projectroot" / "docs" / "REadme.md"
+    assert invocation_path.exists()
+
+    cfg: FrozenConfig = (
+        mutable_config_from_defaults().merge_with(
+            MutableConfig(
+                relative_to=project_root,
+            )
+        )
+    ).freeze()
+
+    ctx: ProcessingContext = _build_for_path(invocation_path, cfg)
+
+    assert ctx.status.generation is GenerationStatus.GENERATED
+    assert ctx.views.build is not None
+    assert ctx.views.build.builtins is not None
+    assert ctx.views.build.builtins["file"] == "README.md"
+    assert ctx.views.build.builtins["file_relpath"] == "Docs/README.md"
+    assert ctx.views.build.builtins["file_abspath"] == actual_file.resolve().as_posix()

--- a/tests/processors/test_cblock.py
+++ b/tests/processors/test_cblock.py
@@ -191,7 +191,8 @@ def test_cblock_detect_existing_header_without_star_on_directives(tmp_path: Path
                 ln = prefix + core
         new_lines.append(ln)
 
-    path.write_text("".join(new_lines), encoding="utf-8")
+    with path.open("w", encoding="utf-8", newline="") as fp:
+        fp.write("".join(new_lines))
 
     # Now the scanner should still detect it
     ctx2: ProcessingContext = ProcessingContext.bootstrap(

--- a/tests/processors/test_cblock.py
+++ b/tests/processors/test_cblock.py
@@ -201,7 +201,11 @@ def test_cblock_detect_existing_header_without_star_on_directives(tmp_path: Path
         policy_registry_override=policy_registry,
     )
     pipeline: Sequence[Step[ProcessingContext]] = Pipeline.CHECK.steps
-    ctx2 = runner.run(ctx2, pipeline)
+    ctx2 = runner.run(
+        ctx2,
+        pipeline,
+        prune_views=False,  # We must inspect ctx2.views.header.
+    )
     assert ctx2.views.header is not None
     assert ctx2.views.header.range is not None
 


### PR DESCRIPTION
## Summary

Fixes #75.

This PR ensures that built-in path-derived header fields are generated from canonical filesystem identity after successful file resolution, rather than from the path spelling used on the command line.

This prevents casing-only false positives on case-insensitive filesystems, for example when the actual file is `README.md` but the user runs:

```bash
topmark check REadme.md
```

## Changes

- Add cross-platform filesystem CI coverage on Ubuntu, macOS, and Windows.
- Add regression tests for case-sensitive and case-insensitive filesystem behavior.
- Canonicalize existing filesystem paths before generating built-in fields such as:
  - `file`
  - `file_relpath`
  - `file_abspath`
- Preserve logical `stdin_filename` behavior for stdin mode.
- Handle Windows cross-drive relative path fallback safely.
- Normalize machine-readable path output to POSIX-style separators where needed.
- Fix Windows-exposed test portability issues around machine-output path expectations and C-block fixture rewriting.

## Follow-up work

This PR intentionally keeps the implementation focused on #75.

Follow-up issues/PRs should audit broader path serialization and path-canonicalization behavior, including:

- human vs machine path formatting contracts;
- diagnostic path serialization;
- config discovery path casing;
- `relative_to` canonicalization policy;
- symlink identity policy;
- remaining path-like fields that may need explicit POSIX or OS-native output contracts.