### PR TITLE
fix(machine): normalize processing result paths to POSIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ ______________________________________________________________________
   generic `FAILURE (1)` exit code.
 - Aligned path-oriented command parsing with Click and POSIX-style option handling: unknown
   option-like tokens are now parser errors unless passed after `--`.
+- Standardized processing machine-output path serialization for `check` and `strip` JSON/NDJSON
+  result payloads to use POSIX `/` separators, matching existing `probe` machine-output behavior.
 
 ### Breaking Changes - Unreleased
 
@@ -46,6 +48,9 @@ ______________________________________________________________________
 - `topmark check`, `topmark strip`, and `topmark probe` now reject unknown option-like arguments
   before `--` as Click parser-level usage errors. Literal filenames that begin with `-` must be
   passed after the standard `--` delimiter, for example `topmark check -- --generated.py`.
+- `topmark check` and `topmark strip` JSON/NDJSON `result.path` values now use POSIX `/` separators
+  on all platforms. Consumers that compare Windows machine-output paths literally may need to update
+  expectations from backslash-separated paths to slash-separated paths.
 
 ### Fixed - Unreleased
 
@@ -63,6 +68,8 @@ ______________________________________________________________________
   outcomes.
 - Fixed unknown options passed to `check`, `strip`, and `probe` so they are no longer interpreted as
   missing input paths.
+- Fixed inconsistent path serialization between `probe` machine output and `check` / `strip`
+  processing result machine output.
 
 ### Documentation - Unreleased
 
@@ -76,12 +83,22 @@ ______________________________________________________________________
 - Documented the exit-code migration from `WOULD_CHANGE (2)` to `WOULD_CHANGE (3)` and the revised
   `config check` validation-failure behavior.
 - Documented use of the standard `--` delimiter for literal dash-prefixed path names.
+- Documented TopMark's path serialization contract for header metadata, processing machine output,
+  probe machine output, and human-readable display output.
+- Added temporary documentation notes for configuration/provenance machine payloads that are not yet
+  covered by the future all-machine-paths POSIX serialization contract.
+- Clarified that registry filename tail-subpath rules are declarative matching rules that use
+  POSIX-style `/` separators, not discovered filesystem paths.
 
 ### Internal - Unreleased
 
 - Removed stale tox references.
 - Updated pre-commit dependencies, including TopMark itself.
 - Refreshed locked dependencies including Ruff, Hypothesis, and uv.
+- Added shared machine-path formatting helpers and regression coverage for Windows-style processing
+  machine-output path serialization.
+- Documented follow-up issues for normalizing registry filename rules and extending POSIX path
+  serialization to all machine-readable path fields.
 
 ### Notes - Unreleased
 
@@ -92,6 +109,10 @@ ______________________________________________________________________
 - Strict configuration-validation failures now preserve machine-readable JSON/NDJSON output. This
   fixes invalid machine output in error paths, but consumers that previously treated such failures
   as unparseable plain text may need to adjust their error handling.
+- Machine-readable `check` and `strip` processing result paths now match the existing `probe` path
+  serialization convention by using POSIX `/` separators on all platforms. This improves
+  cross-platform stability for machine consumers, but may require updates to Windows-specific golden
+  tests or literal path comparisons.
 - This release intentionally introduces a breaking CLI exit-code change: `WOULD_CHANGE` now exits
   with code `3` instead of `2` so automation can distinguish dry-run change signals from Click
   parser-level usage errors. Existing CI jobs, shell scripts, and tests that checked for exit code

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ TopMark is useful when you need to:
 - configure behavior differently across nested projects or file types;
 - inspect why a file was included, excluded, or matched to a specific processor;
 - integrate header checks into CI, pre-commit, Git hooks, or custom automation;
-- consume deterministic JSON or NDJSON output from scripts and tooling.
+- consume deterministic JSON or NDJSON output from scripts and tooling, with stable machine-readable
+  path serialization.
 
 The goal is not to replace formatters, linters, or license scanners. TopMark focuses on one job:
 safe, deterministic, comment-aware file header management.

--- a/docs/_snippets/machine-path-contract-current-scope.md
+++ b/docs/_snippets/machine-path-contract-current-scope.md
@@ -1,0 +1,22 @@
+<!--
+topmark:header:start
+
+  project      : TopMark
+  file         : machine-path-contract-current-scope.md
+  file_relpath : docs/_snippets/machine-path-contract-current-scope.md
+  license      : MIT
+  copyright    : (c) 2025 Olivier Biot
+
+topmark:header:end
+-->
+
+> [!NOTE] **Current machine path contract scope**
+>
+> TopMark currently guarantees POSIX `/` path serialization for:
+>
+> - header metadata path fields; and
+> - processing and probe machine-readable output.
+>
+> Some machine-readable configuration and provenance payloads may still emit path-like values
+> outside this contract. A future compatibility update may extend POSIX serialization to all
+> machine-readable path fields.

--- a/docs/_snippets/path-serialization-contract.md
+++ b/docs/_snippets/path-serialization-contract.md
@@ -1,0 +1,17 @@
+<!--
+topmark:header:start
+
+  project      : TopMark
+  file         : path-serialization-contract.md
+  file_relpath : docs/_snippets/path-serialization-contract.md
+  license      : MIT
+  copyright    : (c) 2025 Olivier Biot
+
+topmark:header:end
+-->
+
+> [!NOTE] **Path representation**
+>
+> TopMark serializes header metadata, processing machine-output paths, and probe machine-output
+> paths with POSIX `/` separators on all platforms. Human CLI output may use the host platform's
+> native path representation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ ______________________________________________________________________
 - Explains repository filtering, file-type resolution, and processor selection via
   [`topmark probe`](usage/commands/probe.md)
 - Exposes layered configuration provenance via `topmark config dump --show-layers`
-- Provides machine-readable JSON and NDJSON output for automation and reporting
+- Provides stable machine-readable JSON and NDJSON output suitable for automation and reporting
 - Supports canonical qualified file type identifiers such as `topmark:python`
 - Supports local identifiers such as `python` when unambiguous
 

--- a/docs/usage/ci.md
+++ b/docs/usage/ci.md
@@ -132,7 +132,7 @@ Notes:
 - Warning-only diagnostics exit with `SUCCESS (0)` unless strict configuration checking is enabled.
 - Malformed TOML discovered by `config check` is reported as a configuration-validation failure and
   exits with `CONFIG_ERROR (78)`.
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - TopMark semantic validation and configuration-loading failures use `CONFIG_ERROR (78)`.
 

--- a/docs/usage/commands/check.md
+++ b/docs/usage/commands/check.md
@@ -21,6 +21,8 @@ end with `- previewed`. When run with `--apply`, files are actually modified and
 
 {% include-markdown "\_snippets/terminology.md" %}
 
+{% include-markdown "\_snippets/path-serialization-contract.md" %}
+
 ______________________________________________________________________
 
 ## Quick start
@@ -287,9 +289,9 @@ For the canonical schema, stable `kind` values, and shared conventions, see:
 
 {% include-markdown "\_snippets/output-contract.md" %}
 
-Machine-readable output emits resolved file type identities using canonical qualified identity
-strings when available. Configuration payloads also emit normalized file type filters and
-`policy_by_type` keys.
+Machine-readable output emits processing result paths with POSIX `/` separators and resolved file
+type identities using canonical qualified identity strings when available. Configuration payloads
+also emit normalized file type filters and `policy_by_type` keys.
 
 Notes:
 
@@ -297,6 +299,8 @@ Notes:
 - The `config` payload in JSON and NDJSON is the resolved runtime configuration snapshot after
   per-source TOML validation, layered configuration merge, staged configuration-loading validation,
   and CLI override application.
+- Per-file `result.path` values use POSIX `/` separators on all platforms. This path serialization
+  contract applies to processing result payloads; human TEXT output remains display-oriented.
 
 ### JSON schema (detail mode)
 
@@ -401,7 +405,7 @@ Common `check` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - Explicit missing literal paths are hard input errors and produce `FILE_NOT_FOUND (66)`.
 - Unmatched glob patterns are soft discovery diagnostics and do not fail `check`.

--- a/docs/usage/commands/config.md
+++ b/docs/usage/commands/config.md
@@ -113,7 +113,7 @@ Notes:
 
 - `CONFIG_ERROR (78)` covers both configuration-loading failures and completed validation runs that
   report configuration errors.
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 
 See [`Exit codes`](../exit-codes.md) for the complete CLI-wide exit-code contract.

--- a/docs/usage/commands/config/check.md
+++ b/docs/usage/commands/config/check.md
@@ -203,6 +203,8 @@ The canonical schema, stable `kind` values, and shared conventions are documente
 Machine-readable configuration snapshots emit normalized canonical qualified file type identities
 after configuration normalization.
 
+{% include-markdown "\_snippets/machine-path-contract-current-scope.md" %}
+
 Notes:
 
 - `config check` emits diagnostics for both TOML schema validation and configuration
@@ -292,7 +294,7 @@ Common `config check` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - `CONFIG_ERROR (78)` is the normal validation-failure result for this command.
 - Warning-only diagnostics exit with `SUCCESS (0)` unless strict configuration checking is enabled.

--- a/docs/usage/commands/config/defaults.md
+++ b/docs/usage/commands/config/defaults.md
@@ -182,7 +182,7 @@ Common `config defaults` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - This command does not inspect project files and does not use file-processing exit codes such as
   `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.

--- a/docs/usage/commands/config/dump.md
+++ b/docs/usage/commands/config/dump.md
@@ -182,6 +182,8 @@ The canonical schema, stable `kind` values, and shared conventions are documente
 Machine-readable configuration snapshots emit normalized canonical qualified file type identities
 after configuration normalization.
 
+{% include-markdown "\_snippets/machine-path-contract-current-scope.md" %}
+
 Notes:
 
 - `config dump` is file-agnostic and emits the effective runtime configuration after applying
@@ -256,7 +258,7 @@ Common `config dump` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - This command does not process files and does not use file-processing exit codes such as
   `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.

--- a/docs/usage/commands/config/init.md
+++ b/docs/usage/commands/config/init.md
@@ -192,7 +192,7 @@ Common `config init` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - This command does not inspect project files and does not use file-processing exit codes such as
   `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.

--- a/docs/usage/commands/probe.md
+++ b/docs/usage/commands/probe.md
@@ -29,6 +29,8 @@ Instead, it exposes the resolution decision process, including:
 
 {% include-markdown "\_snippets/terminology.md" %}
 
+{% include-markdown "\_snippets/path-serialization-contract.md" %}
+
 ______________________________________________________________________
 
 ## Quick start
@@ -201,8 +203,8 @@ For the canonical schema, see:
 - [Machine-readable output](../machine-output.md)
 - [Machine-readable format conventions](../../dev/machine-formats.md)
 
-Probe machine-readable output emits resolved file type identities using canonical qualified identity
-strings when available.
+Probe machine-readable output emits probe paths with POSIX `/` separators and resolved file type
+identities using canonical qualified identity strings when available.
 
 ### Shared output controls
 
@@ -237,7 +239,7 @@ ______________________________________________________________________
   "config_diagnostics": { /* ConfigDiagnosticsPayload */ },
   "probes": [
     {
-      "path": "README.md",
+      "path": "README.md", // POSIX path serialization
       "status": "resolved",
       "reason": "selected_highest_score",
       "selected_file_type": { ... },
@@ -256,7 +258,7 @@ probe results.
 
 ```jsonc
 {
-  "path": "__pycache__/example.cpython-312.pyc",
+  "path": "__pycache__/example.cpython-312.pyc", // POSIX path serialization
   "status": "filtered",
   "reason": "excluded_by_path_filter",
   "selected_file_type": null,
@@ -283,6 +285,9 @@ Filtered probe results may use one of the following reasons:
 
 Canonical file type identities in machine-readable output use normalized qualified-key identities
 such as `topmark:python`.
+
+Probe payload `path` values use POSIX `/` separators on all platforms. Human TEXT output remains
+display-oriented and may use the host platform's native path representation.
 
 ______________________________________________________________________
 
@@ -323,7 +328,7 @@ Common `probe` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - `UNSUPPORTED_FILE_TYPE (69)` indicates runtime-resolution failure (e.g., unsupported file type or
   filtered input), not a crash.

--- a/docs/usage/commands/registry.md
+++ b/docs/usage/commands/registry.md
@@ -98,7 +98,7 @@ Invalid positional paths or file-processing input options are reported as CLI us
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 
 See [`Exit codes`](../exit-codes.md) for the complete CLI-wide exit-code contract.

--- a/docs/usage/commands/registry/bindings.md
+++ b/docs/usage/commands/registry/bindings.md
@@ -225,7 +225,7 @@ Common `registry bindings` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - This command does not process project files and does not use file-processing exit codes such as
   `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.

--- a/docs/usage/commands/registry/filetypes.md
+++ b/docs/usage/commands/registry/filetypes.md
@@ -206,7 +206,7 @@ Common `registry filetypes` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - This command does not process project files and does not use file-processing exit codes such as
   `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.
@@ -252,6 +252,10 @@ types not marked `skip_processing = true`).
 Filename rules that contain path separators (for example, `.vscode/settings.json`) are treated as
 path-suffix matches against normalized POSIX-style paths. Plain filename rules still match only the
 basename.
+
+Registry `filenames` values are matching rules, not discovered filesystem paths. Values that contain
+path separators use POSIX-style `/` separators because TopMark evaluates path-suffix filename rules
+against normalized POSIX-style paths.
 
 ### Content-based disambiguation
 

--- a/docs/usage/commands/registry/processors.md
+++ b/docs/usage/commands/registry/processors.md
@@ -202,7 +202,7 @@ Common `registry processors` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - This command does not process project files and does not use file-processing exit codes such as
   `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.

--- a/docs/usage/commands/strip.md
+++ b/docs/usage/commands/strip.md
@@ -20,6 +20,8 @@ end with `- removed`).
 
 {% include-markdown "\_snippets/terminology.md" %}
 
+{% include-markdown "\_snippets/path-serialization-contract.md" %}
+
 ______________________________________________________________________
 
 ## Quick start
@@ -223,9 +225,9 @@ For the canonical schema, stable `kind` values, and shared conventions, see:
 
 {% include-markdown "\_snippets/output-contract.md" %}
 
-Machine-readable output emits resolved file type identities using canonical qualified identity
-strings when available. Configuration payloads also emit normalized file type filters and
-`policy_by_type` keys.
+Machine-readable output emits processing result paths with POSIX `/` separators and resolved file
+type identities using canonical qualified identity strings when available. Configuration payloads
+also emit normalized file type filters and `policy_by_type` keys.
 
 Notes:
 
@@ -234,6 +236,8 @@ Notes:
 - The `config` payload in JSON and NDJSON is the resolved runtime configuration snapshot after
   per-source TOML validation, layered configuration merge, staged configuration-loading validation,
   and CLI override application.
+- Per-file `result.path` values use POSIX `/` separators on all platforms. This path serialization
+  contract applies to processing result payloads; human TEXT output remains display-oriented.
 
 ### JSON schema (detail mode)
 
@@ -337,7 +341,7 @@ Common `strip` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - Explicit missing literal paths are hard input errors and produce `FILE_NOT_FOUND (66)`.
 - Unmatched glob patterns are soft discovery diagnostics and do not fail `strip`.

--- a/docs/usage/commands/version.md
+++ b/docs/usage/commands/version.md
@@ -202,7 +202,7 @@ Common `version` exit codes:
 
 Notes:
 
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - This command does not process project files and does not use file-processing exit codes such as
   `WOULD_CHANGE (3)`, `FILE_NOT_FOUND (66)`, or `IO_ERROR (74)`.

--- a/docs/usage/exit-codes.md
+++ b/docs/usage/exit-codes.md
@@ -61,7 +61,7 @@ Notes:
 
 - Codes broadly follow **sysexits-style semantics** where applicable.
 - Not all codes are used by every command.
-- Click parser-level usage errors (for example, unknown commands, unknown options or invalid option
+- Click parser-level usage errors (for example, unknown commands, unknown options, or invalid option
   values) may exit with code `2` before command logic runs.
 - Commands may short-circuit on higher-severity errors (e.g., config errors before processing).
 - Canonical file-type identifier normalization does not affect exit-code semantics.

--- a/docs/usage/header-placement.md
+++ b/docs/usage/header-placement.md
@@ -29,6 +29,8 @@ header processor controls the concrete comment syntax and placement behavior.
 
 {% include-markdown "\_snippets/terminology.md" %}
 
+{% include-markdown "\_snippets/path-serialization-contract.md" %}
+
 > [!NOTE]
 >
 > File type identities are bound to header processors, and each processor defines how headers are
@@ -94,6 +96,8 @@ Example (Python / shell-style line comments):
 
 echo "Hello, World!"
 ```
+
+Note that header path fields such as `file_relpath` use POSIX `/` separators on all platforms.
 
 ______________________________________________________________________
 
@@ -194,6 +198,9 @@ topmark:header:end
 </configuration>
 ```
 
+Header metadata path fields are serialized with POSIX `/` separators regardless of the host
+operating system.
+
 ______________________________________________________________________
 
 ## Markdown files
@@ -229,6 +236,8 @@ ______________________________________________________________________
 
 ## Placement guarantees
 
+- Path serialization: generated header path fields (`file_relpath`, `file_abspath`, `relpath`, and
+  `abspath`) use POSIX `/` separators on all platforms.
 - Newline preservation: the inserted header uses the same newline style as the file (LF/CRLF/CR).
 - BOM preservation: if a UTF-8 BOM is present, it is preserved.
 - Idempotency: re-running TopMark on a file with a compliant header produces no runtime changes.

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -38,6 +38,8 @@ task-oriented examples consistent with this schema.
 
 {% include-markdown "\_snippets/terminology.md" %}
 
+{% include-markdown "\_snippets/path-serialization-contract.md" %}
+
 See also:
 
 - [CLI overview](../usage/cli.md)
@@ -391,8 +393,8 @@ Filtered probe payloads may use one of these reasons:
 
 Fields:
 
-- `path`: probed or explicitly requested filesystem path. For filtered and missing explicit inputs,
-  this is the path supplied to the command.
+- `path`: probed or explicitly requested filesystem path, serialized with POSIX `/` separators. For
+  filtered and missing explicit inputs, this is the path supplied to the command.
 - `status`: probe status, currently one of:
   - `resolved` - a file type and processor were selected.
   - `unsupported` - no file type candidate matched.
@@ -596,7 +598,7 @@ The canonical builders and typing live under:
 At a high level, per-file results include:
 
 - identity:
-  - `path`
+  - `path` (serialized with POSIX `/` separators)
   - `file_type` (resolved canonical TopMark file type key, for example `topmark:python`)
 - pipeline execution:
   - executed step names

--- a/src/topmark/filetypes/model.py
+++ b/src/topmark/filetypes/model.py
@@ -224,13 +224,13 @@ class FileType:
         extensions: List of filename extensions associated with this type. Values
             should include the leading dot (e.g. ``.py``) or be consistent with the
             matcher used elsewhere in TopMark.
-        filenames: Exact filenames or tail subpaths to match. If a value contains a
-            path separator (``/`` or ``\\``), it is matched against the *tail* of the
-            path (e.g. ``".vscode/settings.json"``). Otherwise, it must equal the
-            basename exactly (e.g. ``"Makefile"``).
-        patterns: Regular expressions evaluated against the basename (see
-            `re.fullmatch`). Useful for families of files that don't share a
-            simple extension.
+        filenames: Exact basenames or POSIX-style tail subpaths to match. Values containing
+            `/` or `\` are treated as tail-subpath rules and are matched against
+            `path.as_posix()`. Built-in file type definitions should prefer POSIX `/`
+            separators for cross-platform stability.
+        patterns: Regular expressions evaluated against the basename only (see
+            `re.fullmatch`). Patterns are not path-aware and do not receive POSIX-normalized
+            subpaths; use `filenames` for exact basename or POSIX-style tail-subpath rules.
         description: Human-readable description of the file type.
         skip_processing: When ``True``, the pipeline **recognizes** files of this
             type but intentionally **skips header processing** (e.g. JSON without
@@ -383,10 +383,10 @@ class FileType:
 
         # 2) if still not matched, try filenames
         if matched_by is None and self.filenames:
-            # Filenames: support exact basename or tail subpath matches
-            #    - "settings.json" matches only if basename == "settings.json"
-            #    - ".vscode/settings.json" matches
-            #      if path.as_posix().endswith(".vscode/settings.json")
+            # Filenames support exact basename matches and POSIX-style tail-subpath matches:
+            #    - "settings.json" matches only if basename == "settings.json".
+            #    - ".vscode/settings.json" matches if path.as_posix() ends with that tail.
+            # Tail-subpath filename rules are matched against normalized POSIX-style paths.
             basename: str = path.name
             posix: str = path.as_posix()
             for fname in self.filenames:

--- a/src/topmark/pipeline/context/model.py
+++ b/src/topmark/pipeline/context/model.py
@@ -52,6 +52,7 @@ from topmark.pipeline.hints import make_hint
 from topmark.pipeline.status import FsStatus
 from topmark.pipeline.views import UpdatedView
 from topmark.pipeline.views import Views
+from topmark.utils.path import format_machine_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -358,13 +359,14 @@ class ProcessingContext:
         the ``Views`` bundling.
 
         Returns:
-            A JSON-serializable mapping describing the context, including path, file type,
-            step statuses, views summary, diagnostics, and high-level outcome flags.
+            A JSON-serializable mapping describing the context, including the
+            POSIX-serialized path, file type, step statuses, views summary,
+            diagnostics, and high-level outcome flags.
         """
         views_summary: dict[str, object] = self.views.as_dict()
 
         return {
-            "path": str(self.path),
+            "path": format_machine_path(self.path),
             "file_type": {
                 "qualified_key": (self.file_type.qualified_key),
                 "description": (self.file_type.description),

--- a/src/topmark/pipeline/machine/payloads.py
+++ b/src/topmark/pipeline/machine/payloads.py
@@ -43,10 +43,10 @@ from typing import TYPE_CHECKING
 from topmark.pipeline.context.model import ProcessingContext
 from topmark.pipeline.outcomes import OutcomeReasonCount
 from topmark.pipeline.outcomes import collect_outcome_reason_counts
+from topmark.utils.path import format_machine_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.machine.schemas import OutcomeSummaryRow
@@ -54,11 +54,6 @@ if TYPE_CHECKING:
     from topmark.resolution.probe import ResolutionProbeMatchSignals
     from topmark.resolution.probe import ResolutionProbeResult
     from topmark.resolution.probe import ResolutionProbeSelection
-
-
-def _machine_path(path: Path) -> str:
-    """Emit POSIX path for machine output."""
-    return path.as_posix()
 
 
 def build_probe_selection_payload(
@@ -153,7 +148,7 @@ def build_probe_result_payload(
     probe: ResolutionProbeResult | None = result.resolution_probe
     if probe is None:
         return {
-            "path": _machine_path(result.path),
+            "path": format_machine_path(result.path),
             "status": "probe_missing",
             "reason": "no_resolution_probe_result",
             "selected_file_type": None,
@@ -162,7 +157,7 @@ def build_probe_result_payload(
         }
 
     return {
-        "path": _machine_path(probe.path),
+        "path": format_machine_path(probe.path),
         "status": probe.status.value,
         "reason": probe.reason.value,
         "selected_file_type": build_probe_selection_payload(probe.selected_file_type),

--- a/src/topmark/utils/path.py
+++ b/src/topmark/utils/path.py
@@ -60,3 +60,12 @@ def canonicalize_existing_path(path: Path) -> Path:
         current = current / entry_name
 
     return current
+
+
+def format_machine_path(path: Path) -> str:
+    """Serialize a path for processing machine-readable output.
+
+    Machine-readable processing payloads use POSIX separators on all platforms
+    so JSON and NDJSON output remain stable across operating systems.
+    """
+    return path.as_posix()

--- a/tests/cli/machine/test_probe_machine.py
+++ b/tests/cli/machine/test_probe_machine.py
@@ -38,20 +38,13 @@ from topmark.core.formats import OutputFormat
 from topmark.core.typing_guards import as_object_dict
 from topmark.core.typing_guards import is_any_list
 from topmark.core.typing_guards import is_mapping
+from topmark.utils.path import format_machine_path
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from click.testing import Result
     from pytest import MonkeyPatch
-
-
-def _machine_path(path: Path) -> str:
-    """Emit POSIX path for machine output.
-
-    See [topmark.pipeline.machine.payloads].
-    """
-    return path.as_posix()
 
 
 def test_probe_json_output_shape(tmp_path: Path) -> None:
@@ -249,9 +242,9 @@ def test_probe_json_omits_directory_filtered_result_when_children_selected(
         probe_payloads.append(as_object_dict(probe_obj))
 
     paths: set[object] = {probe["path"] for probe in probe_payloads}
-    assert _machine_path(python_file) in paths
-    assert _machine_path(markdown_file) in paths
-    assert _machine_path(directory) not in paths
+    assert format_machine_path(python_file) in paths
+    assert format_machine_path(markdown_file) in paths
+    assert format_machine_path(directory) not in paths
 
     statuses: set[object] = {probe["status"] for probe in probe_payloads}
     assert statuses == {"resolved"}
@@ -401,7 +394,7 @@ def test_probe_ndjson_reports_missing_input_only_once(tmp_path: Path) -> None:
         cli,
         [
             CliCmd.PROBE,
-            _machine_path(missing),
+            format_machine_path(missing),
             CliOpt.OUTPUT_FORMAT,
             OutputFormat.NDJSON.value,
         ],
@@ -414,7 +407,7 @@ def test_probe_ndjson_reports_missing_input_only_once(tmp_path: Path) -> None:
     assert len(probe_records) == 1
 
     payload: dict[str, object] = record_payload(probe_records[0])
-    assert payload["path"] == _machine_path(missing)
+    assert payload["path"] == format_machine_path(missing)
     assert payload["status"] == "probe_missing"
     assert payload["reason"] == "no_resolution_probe_result"
 

--- a/tests/cli/machine/test_processing_machine.py
+++ b/tests/cli/machine/test_processing_machine.py
@@ -37,29 +37,65 @@ All CLI invocations are executed via Click's `CliRunner`, using the helpers in
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import cast
 
 import pytest
 
 from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
 from tests.cli.conftest import run_cli_in
+from tests.helpers.config import make_frozen_config
 from tests.helpers.config_diagnostics import assert_config_diagnostics_warning_payload
 from tests.helpers.config_diagnostics import assert_overlap_warning_text
 from tests.helpers.json import parse_json_object
 from tests.helpers.ndjson import assert_ndjson_meta
 from tests.helpers.ndjson import parse_ndjson_records
 from tests.helpers.ndjson import record_kinds
+from tests.helpers.pipeline import make_pipeline_context
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.core.formats import OutputFormat
+from topmark.core.machine.schemas import MetaPayload
 from topmark.core.typing_guards import as_object_dict
 from topmark.core.typing_guards import is_any_list
 from topmark.core.typing_guards import is_mapping
+from topmark.pipeline.machine.envelopes import build_processing_results_json_envelope
+from topmark.pipeline.machine.envelopes import iter_processing_results_ndjson_records
+from topmark.toml.resolution import ResolvedTopmarkTomlSources
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from click.testing import Result
+
+    from topmark.config.model import FrozenConfig
+    from topmark.pipeline.context.model import ProcessingContext
+
+
+class _WindowsStylePath:
+    """Minimal path double for exercising Windows-native string serialization."""
+
+    def __str__(self) -> str:
+        """Return the Windows-native spelling produced by `Path.__str__()` on Windows."""
+        return r"C:\Repo\src\example.py"
+
+    def as_posix(self) -> str:
+        """Return the POSIX spelling expected for processing machine output."""
+        return "C:/Repo/src/example.py"
+
+
+def _machine_meta() -> MetaPayload:
+    """Return stable test metadata payload for machine-envelope builders."""
+    return MetaPayload(
+        tool="topmark",
+        version="test",
+        platform="test",
+    )
+
+
+def _empty_resolved_toml_sources() -> ResolvedTopmarkTomlSources:
+    """Return an empty TOML resolution result for envelope-builder tests."""
+    return ResolvedTopmarkTomlSources(sources=[], writer_options=None, strict=None)
 
 
 # ----- JSON -----
@@ -215,6 +251,48 @@ def test_processing_json_detail_shape(tmp_path: Path, command: str) -> None:
     # outcome: should be a mapping
     outcome_obj = first["outcome"]
     assert is_mapping(outcome_obj)
+
+
+# --- Path serialization contract tests ---
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        CliCmd.CHECK,
+        CliCmd.STRIP,
+    ],
+)
+def test_processing_json_detail_path_serializes_windows_style_path_as_posix(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Processing JSON result paths should use POSIX separators in detail mode."""
+    cfg: FrozenConfig = make_frozen_config()
+    ctx: ProcessingContext = make_pipeline_context(path=tmp_path / "example.py", cfg=cfg)
+
+    # The production attribute is a concrete Path, but this contract test needs
+    # to exercise Windows-native `str(path)` behavior on every host platform.
+    ctx.path = cast("Path", _WindowsStylePath())
+
+    payload: dict[str, object] = build_processing_results_json_envelope(
+        meta=_machine_meta(),
+        config=cfg,
+        resolved_toml=_empty_resolved_toml_sources(),
+        results=[ctx],
+        summary_mode=False,
+    )
+
+    results_obj: object = payload["results"]
+    assert is_any_list(results_obj)
+    results: list[object] = results_obj
+    assert len(results) == 1
+
+    first_obj: object = results[0]
+    assert is_mapping(first_obj)
+    first: dict[str, object] = as_object_dict(first_obj)
+
+    assert first.get("path") == "C:/Repo/src/example.py"
 
 
 @pytest.mark.parametrize(
@@ -415,6 +493,47 @@ def test_processing_ndjson_kinds_with_summary(tmp_path: Path, command: str) -> N
     assert "config" in kinds_set
     assert "config_diagnostics" in kinds_set
     assert "summary" in kinds_set
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        CliCmd.CHECK,
+        CliCmd.STRIP,
+    ],
+)
+def test_processing_ndjson_detail_path_serializes_windows_style_path_as_posix(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Processing NDJSON result paths should use POSIX separators in detail mode."""
+    cfg: FrozenConfig = make_frozen_config()
+    ctx: ProcessingContext = make_pipeline_context(path=tmp_path / "example.py", cfg=cfg)
+
+    # The production attribute is a concrete Path, but this contract test needs
+    # to exercise Windows-native `str(path)` behavior on every host platform.
+    ctx.path = cast("Path", _WindowsStylePath())
+
+    records: list[dict[str, object]] = list(
+        iter_processing_results_ndjson_records(
+            meta=_machine_meta(),
+            config=cfg,
+            resolved_toml=_empty_resolved_toml_sources(),
+            results=[ctx],
+            summary_mode=False,
+        )
+    )
+
+    result_records: list[dict[str, object]] = [
+        record for record in records if record.get("kind") == "result"
+    ]
+    assert len(result_records) == 1
+
+    result_obj: object | None = result_records[0].get("result")
+    assert is_mapping(result_obj)
+    result: dict[str, object] = as_object_dict(result_obj)
+
+    assert result.get("path") == "C:/Repo/src/example.py"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Normalize `check` and `strip` JSON/NDJSON `result.path` values to POSIX `/` separators.
- Reuse a shared machine-path formatter for processing and probe machine payloads.
- Add regression coverage for Windows-style processing result path serialization.
- Document the current path serialization contract for:
  - header metadata;
  - processing machine output;
  - probe machine output;
  - human-readable display output.
- Clarify current scope limitations for configuration/provenance machine payloads.
- Clarify that registry `filenames` tail-subpath rules are declarative POSIX-style matching rules.

## Compatibility

This is a machine-output compatibility change: Windows consumers comparing `check` or `strip`
`result.path` values literally may need to update expected paths from backslash-separated to
slash-separated form.

## Related issues

Fixes #88.

Follow-up work:
- #93 tracks defensive normalization/validation of registry tail-subpath filename rules.
- #94 tracks extending POSIX path serialization to all machine-readable path fields.