### PR TITLE
Normalize and validate FileType filename rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ ______________________________________________________________________
   option-like tokens are now parser errors unless passed after `--`.
 - Standardized processing machine-output path serialization for `check` and `strip` JSON/NDJSON
   result payloads to use POSIX `/` separators, matching existing `probe` machine-output behavior.
+- Normalized `FileType.filenames` tail-subpath rules to canonical POSIX-style `/` separators during
+  file-type construction.
+- Standardized registry, resolver, presentation, and machine-readable registry output to consume the
+  canonical filename-rule representation.
+- Clarified that `FileType.filenames` entries are declarative registry matching rules rather than
+  filesystem paths.
 
 ### Breaking Changes - Unreleased
 
@@ -51,6 +57,19 @@ ______________________________________________________________________
 - `topmark check` and `topmark strip` JSON/NDJSON `result.path` values now use POSIX `/` separators
   on all platforms. Consumers that compare Windows machine-output paths literally may need to update
   expectations from backslash-separated paths to slash-separated paths.
+- `FileType.filenames` tail-subpath rules are now canonicalized during file-type construction.
+  Definitions that previously used backslash separators are normalized to POSIX-style `/` separators
+  before matching, registry composition, presentation, and machine-readable output.
+- Invalid filename-rule definitions are now rejected during file-type construction. Rejected forms
+  include:
+  - empty rules;
+  - absolute paths;
+  - UNC paths;
+  - Windows drive paths;
+  - rules containing empty path segments;
+  - rules containing `.` or `..` path segments.
+- Plugin authors and custom file-type providers should treat `FileType.filenames` values as relative
+  registry matching rules rather than filesystem paths.
 
 ### Fixed - Unreleased
 
@@ -70,6 +89,10 @@ ______________________________________________________________________
   missing input paths.
 - Fixed inconsistent path serialization between `probe` machine output and `check` / `strip`
   processing result machine output.
+- Fixed platform-dependent registry filename-rule behavior by normalizing tail-subpath matching
+  rules before resolution and registry serialization.
+- Fixed inconsistent registry output where equivalent filename rules could be represented using
+  different path-separator spellings.
 
 ### Documentation - Unreleased
 
@@ -89,6 +112,9 @@ ______________________________________________________________________
   covered by the future all-machine-paths POSIX serialization contract.
 - Clarified that registry filename tail-subpath rules are declarative matching rules that use
   POSIX-style `/` separators, not discovered filesystem paths.
+- Documented the canonical filename-rule contract for `FileType.filenames`.
+- Documented normalization and validation behavior for tail-subpath filename rules.
+- Clarified plugin-author guidance around filename-rule definitions and canonical registry metadata.
 
 ### Internal - Unreleased
 
@@ -99,6 +125,9 @@ ______________________________________________________________________
   machine-output path serialization.
 - Documented follow-up issues for normalizing registry filename rules and extending POSIX path
   serialization to all machine-readable path fields.
+- Added centralized filename-rule normalization and validation helpers.
+- Added regression coverage for filename-rule normalization, validation, matching, registry
+  serialization, resolver behavior, and presentation output.
 
 ### Notes - Unreleased
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ TopMark is useful when you need to:
 - inspect why a file was included, excluded, or matched to a specific processor;
 - integrate header checks into CI, pre-commit, Git hooks, or custom automation;
 - consume deterministic JSON or NDJSON output from scripts and tooling, with stable machine-readable
-  path serialization.
+  path serialization and canonical cross-platform registry metadata.
 
 The goal is not to replace formatters, linters, or license scanners. TopMark focuses on one job:
 safe, deterministic, comment-aware file header management.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -107,11 +107,17 @@ file-type-to-processor bindings.
 At the architecture level, the important invariants are:
 
 - identity registration and processor binding are separate concerns;
+- file type filename rules are canonical registry matching rules, not filesystem paths;
 - built-in registry data is never mutated directly;
 - runtime additions and removals are represented as overlay state;
 - effective registry views are composed from base registries plus overlays;
 - public integrations should prefer the read-only `Registry` facade;
 - advanced integrations and tests may use overlay mutation helpers deliberately.
+
+File type `filenames` entries are normalized during `FileType` construction so registry composition,
+resolution, presentation, and machine-readable output all consume canonical POSIX-style matching
+rules. Exact basename rules match file names, while relative tail-subpath rules match normalized
+POSIX path tails.
 
 Detailed registry behavior, including base/overlay composition, caching, invalidation, bindings,
 qualified/local file type identifiers, plugin integration, and registry CLI inspection, is

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -574,6 +574,10 @@ ______________________________________________________________________
 
 Registry commands expose the effective composed runtime registry composition.
 
+File type `filenames` fields are emitted as canonical POSIX-style registry matching rules.
+Tail-subpath rules therefore use `/` separators consistently across platforms, regardless of the
+spelling used by the file type definition.
+
 Important identity fields:
 
 - `qualified_key`: canonical file type or processor identity

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -108,7 +108,7 @@ ______________________________________________________________________
 Every \[`FileType`\][topmark.filetypes.model.FileType] has two identity components:
 
 - `namespace`: identifies the producer, such as `topmark`, `acme`, or `my_plugin`
-- `name`: the local file type key within that namespace
+- `local_key`: the local file type key within that namespace
 
 TopMark reserves the namespace `topmark` (the internal constant
 \[`TOPMARK_NAMESPACE`\][topmark.core.constants.TOPMARK_NAMESPACE]) for built-in file types.
@@ -117,7 +117,7 @@ TopMark reserves the namespace `topmark` (the internal constant
 
 - Set `namespace` to your package or organization identifier, for example `"acme"` or
   `"my_company"`.
-- Choose a clear local `name`, for example `"django_html"` or `"my_lang"`.
+- Choose a clear `local_key`, for example `"django_html"` or `"my_lang"`.
 - Use qualified file type identities, such as `"acme:django_html"`, in shared configuration,
   processor bindings, and documentation.
 
@@ -125,7 +125,7 @@ Note: `namespace` is **mandatory** for both file types and processors. The built
 `topmark` is reserved for TopMark-provided types.
 
 TopMark normalizes file type identifiers to canonical qualified keys of the form
-`<namespace>:<name>`.
+`<namespace>:<local_key>`.
 
 TopMark accepts both:
 
@@ -146,6 +146,27 @@ For the complete identity contract, see
 Create a module that returns an iterable of \[`FileType`\][topmark.filetypes.model.FileType]
 objects.
 
+#### Filename matching rules
+
+`FileType.filenames` entries are registry matching rules rather than filesystem paths.
+
+Supported forms:
+
+- exact-basename rules, for example `Makefile`;
+- relative tail-subpath rules, for example `.vscode/settings.json`.
+
+Tail-subpath rules should use POSIX-style `/` separators. Backslash-containing rules are accepted as
+compatibility input and normalized during file-type construction.
+
+Invalid filename rules include:
+
+- absolute paths;
+- UNC paths;
+- Windows drive paths;
+- empty rules;
+- rules containing empty path segments;
+- rules containing `.` or `..` path segments.
+
 Example:
 
 ```python
@@ -157,7 +178,7 @@ from topmark.filetypes.model import FileType
 def provide_filetypes() -> list[FileType]:
     return [
         FileType(
-            name="my_lang",
+            local_key="my_lang",
             namespace="my_plugin",
             extensions=[".mylang"],
             filenames=[],
@@ -167,6 +188,10 @@ def provide_filetypes() -> list[FileType]:
         )
     ]
 ```
+
+TopMark stores filename rules in canonical POSIX form. Registry inspection, machine-readable output,
+and resolver diagnostics therefore always expose normalized filename-rule values regardless of
+platform.
 
 ### Using the FileType factory (recommended)
 
@@ -179,7 +204,7 @@ from topmark.filetypes.factory import make_filetype_factory
 make_my_ft = make_filetype_factory(namespace="my_plugin")
 
 MY_FILETYPE = make_my_ft(
-    name="my_lang",
+    local_key="my_lang",
     description="MyLang source files",
     extensions=[".mylang"],
 )

--- a/docs/dev/registry-model.md
+++ b/docs/dev/registry-model.md
@@ -151,6 +151,7 @@ Each file type has:
 - local key
 - qualified key
 - extensions
+- filename rules
 - resolver and matching metadata
 
 Examples of local identifiers:
@@ -168,6 +169,10 @@ topmark:markdown
 ```
 
 TopMark normalizes file type identifiers to canonical qualified keys.
+
+TopMark also normalizes file type filename rules to canonical POSIX-style registry matching rules.
+Exact-basename rules are preserved, while relative tail-subpath rules are stored and emitted using
+`/` separators regardless of platform.
 
 Local identifiers are accepted only when unambiguous.
 
@@ -360,7 +365,9 @@ Plugin authors should:
 - use a stable namespace such as `acme` or `my_plugin`;
 - choose clear local keys such as `django_html` or `my_lang`;
 - document and use qualified identifiers such as `acme:django_html` in shared examples;
-- avoid relying on local identifiers remaining unambiguous as ecosystems grow.
+- avoid relying on local identifiers remaining unambiguous as ecosystems grow;
+- define filename rules as relative registry matching rules rather than filesystem paths, preferring
+  POSIX-style `/` separators for tail-subpath matching.
 
 Header processor plugins currently use advanced runtime-overlay integration semantics. They should
 bind processor definitions to canonical qualified file type identifiers.

--- a/docs/dev/resolution.md
+++ b/docs/dev/resolution.md
@@ -191,10 +191,17 @@ Candidate generation operates against the effective composed runtime registry.
 The resolver computes three name-based match signals:
 
 - **extension**: the basename ends with one of the file type's configured extensions
-- **filename**: the basename or normalized path tail matches one of the file type's configured
-  filenames
+- **filename**: the basename or normalized POSIX path tail matches one of the file type's configured
+  filename rules
 - **pattern**: the basename fully matches one of the file type's configured regular-expression
   patterns
+
+Filename rules are declarative registry matching rules rather than filesystem paths. Exact-basename
+rules match against `path.name`; relative tail-subpath rules match against `path.as_posix()`.
+
+Tail-subpath rules are stored and emitted using canonical POSIX-style `/` separators.
+Backslash-containing definitions are normalized during file-type construction before candidate
+generation and scoring occur.
 
 These signals are represented by \[`MatchSignals`\][topmark.resolution.filetypes.MatchSignals].
 
@@ -249,8 +256,8 @@ header-capable types a stable advantage on otherwise equal matches.
 
 More specifically:
 
-- filename and path-tail matches receive the highest scores and become more specific as the matched
-  tail becomes longer
+- exact-basename and tail-subpath filename-rule matches receive the highest scores and become more
+  specific as the matched tail becomes longer
 - content-confirmed matches outrank generic pattern and extension matches
 - pattern matches outrank plain extension matches
 - extension matches remain valid fallbacks for generic formats

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,8 @@ ______________________________________________________________________
 - Explains repository filtering, file-type resolution, and processor selection via
   [`topmark probe`](usage/commands/probe.md)
 - Exposes layered configuration provenance via `topmark config dump --show-layers`
-- Provides stable machine-readable JSON and NDJSON output suitable for automation and reporting
+- Provides stable machine-readable JSON and NDJSON output together with canonical registry metadata
+  suitable for automation and reporting
 - Supports canonical qualified file type identifiers such as `topmark:python`
 - Supports local identifiers such as `python` when unambiguous
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -121,8 +121,10 @@ python
 
 ### Canonical identity
 
-The normalized qualified-key representation used internally for comparison, storage,
-machine-readable output, filtering, runtime policy lookup, registry composition, and resolution.
+The normalized representation used internally for comparison, storage, machine-readable output,
+filtering, runtime policy lookup, registry composition, and resolution.
+
+Examples include qualified file-type identities and canonicalized registry matching rules.
 
 ### Namespace
 
@@ -139,6 +141,25 @@ ______________________________________________________________________
 ### Resolution
 
 The process of selecting the most appropriate file type for a path or input.
+
+### Filename rule
+
+A declarative file-type matching rule used by `FileType.filenames`.
+
+Filename rules are registry matching rules rather than filesystem paths.
+
+Two forms are supported:
+
+- exact-basename rules (for example `Makefile`);
+- relative tail-subpath rules (for example `.vscode/settings.json`).
+
+Tail-subpath rules are stored and emitted using canonical POSIX-style `/` separators regardless of
+platform.
+
+> [!NOTE]
+>
+> Absolute paths, UNC paths, Windows drive paths, empty rules, empty path segments, and `.` / `..`
+> path segments are invalid filename rules.
 
 ### Probe
 

--- a/docs/usage/commands/registry/filetypes.md
+++ b/docs/usage/commands/registry/filetypes.md
@@ -113,7 +113,7 @@ Rendered consistently across `text`, `json`, `ndjson`, and `markdown`:
 - Canonical qualified key
 - Namespace / local key
 - Extensions (comma-separated)
-- Filenames (comma-separated)
+- Filenames (comma-separated exact-basename and tail-subpath matching rules)
 - Patterns (comma-separated)
 - `skip_processing` (`true`/`false`)
 - `has_content_matcher` (`true`/`false`)
@@ -165,6 +165,9 @@ The `kind` field is always `filetype` for this command.
 
 Machine-readable output emits canonical qualified file type identities suitable for stable
 automation and tooling integration.
+
+Filename-rule fields (`filenames`) are emitted using canonical POSIX-style representations.
+Tail-subpath rules therefore appear consistently across all platforms and registry implementations.
 
 Unlike [`topmark registry bindings`](bindings.md), this command focuses on canonical file type
 identities, not processor-dispatch relationships.
@@ -250,12 +253,40 @@ types not marked `skip_processing = true`).
 ### Path-suffix matching
 
 Filename rules that contain path separators (for example, `.vscode/settings.json`) are treated as
-path-suffix matches against normalized POSIX-style paths. Plain filename rules still match only the
-basename.
+relative tail-subpath matching rules against normalized POSIX-style paths. Plain filename rules
+continue to match only the basename.
 
-Registry `filenames` values are matching rules, not discovered filesystem paths. Values that contain
-path separators use POSIX-style `/` separators because TopMark evaluates path-suffix filename rules
-against normalized POSIX-style paths.
+Registry `filenames` values are matching rules, not filesystem paths. They are stored and emitted
+using canonical POSIX-style `/` separators regardless of the host platform.
+
+Examples:
+
+```text
+Makefile
+.vscode/settings.json
+```
+
+Built-in definitions and plugins should prefer POSIX-style / separators.
+
+For compatibility, backslash-containing definitions such as:
+
+```text
+Makefile
+.vscode\\settings.json
+```
+
+are accepted during registration and normalized to:
+
+```text
+Makefile
+.vscode/settings.json
+```
+
+before matching, registry composition, and machine-readable serialization.
+
+Filename rules must be relative matching rules. Absolute paths, UNC paths, Windows drive paths,
+empty rules, and rules containing empty path segments or `.` or `..` path segments are rejected
+during file-type construction.
 
 ### Content-based disambiguation
 

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -981,6 +981,10 @@ JSON envelope:
 `qualified_key` is the canonical file type identity. `namespace` and `local_key` are provided for
 inspection, grouping, and display.
 
+Detailed `filenames` values are canonical filename rules, not filesystem paths. Exact-basename rules
+are emitted unchanged, while tail-subpath rules are emitted with POSIX-style `/` separators across
+platforms.
+
 Brief entry (default):
 
 ```jsonc

--- a/src/topmark/core/errors.py
+++ b/src/topmark/core/errors.py
@@ -147,6 +147,47 @@ class ReservedNamespaceError(TopmarkError):
 # ---- File-type / registry lookup errors ----
 
 
+class InvalidFileTypeDefinitionError(TopmarkError):
+    """Raised when a file type definition is malformed.
+
+    This error is intended for registry construction and plugin/model definition
+    boundaries where invalid declarative file-type metadata should be rejected
+    explicitly before it reaches matching, resolution, or serialization code.
+
+    Args:
+        message: Human-readable error message, without CLI styling.
+        file_type: Optional file type identifier associated with the invalid
+            definition.
+        field_name: Optional file type field containing the invalid value.
+        value: Optional invalid scalar value.
+    """
+
+    def __init__(
+        self,
+        *,
+        message: str,
+        file_type: str | None = None,
+        field_name: str | None = None,
+        value: str | None = None,
+    ) -> None:
+        details: list[str] = []
+        if field_name is not None:
+            details.append(f"field={field_name}")
+        if value is not None:
+            details.append(f"value={value}")
+
+        super().__init__(
+            ErrorContext(
+                message=message,
+                qualified_key=file_type,
+                details=tuple(details),
+            )
+        )
+        self.file_type: Final[str | None] = file_type
+        self.field_name: Final[str | None] = field_name
+        self.value: Final[str | None] = value
+
+
 class UnsupportedFileTypeError(TopmarkError):
     """Raised when a file type is recognized but currently unsupported.
 

--- a/src/topmark/filetypes/filename_rules.py
+++ b/src/topmark/filetypes/filename_rules.py
@@ -1,0 +1,124 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : filename_rules.py
+#   file_relpath : src/topmark/filetypes/filename_rules.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Normalize and validate file type filename rules.
+
+`FileType.filenames` entries are declarative registry matching rules, not
+filesystem paths. Rules are stored as canonical POSIX-style strings so registry
+output and resolver behavior stay stable across platforms.
+
+A rule may be either an exact basename such as `Makefile` or a relative
+tail-subpath such as `.vscode/settings.json`. Backslashes are accepted as
+compatibility input and normalized to `/`; absolute paths, drive paths, UNC
+paths, empty segments, and `.` / `..` segments are rejected.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+from typing import Final
+
+from topmark.core.errors import InvalidFileTypeDefinitionError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+_WINDOWS_DRIVE_RULE_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z]:/")
+
+
+def _normalize_filename_rule(rule: str, *, file_type: str) -> str:
+    """Return the canonical POSIX-style representation for a filename rule.
+
+    Args:
+        rule: Exact basename or relative tail-subpath filename rule.
+        file_type: Qualified file type identifier used in validation errors.
+
+    Returns:
+        The canonical filename rule using `/` as separator.
+
+    Raises:
+        InvalidFileTypeDefinitionError: If `rule` is not a valid relative
+            registry matching rule.
+    """
+    normalized: str = rule.replace("\\", "/")
+    if normalized == "":
+        raise InvalidFileTypeDefinitionError(
+            message="Invalid filename rule: filename rules must not be empty.",
+            file_type=file_type,
+            field_name="filenames",
+            value=rule,
+        )
+    if normalized in {".", ".."}:
+        raise InvalidFileTypeDefinitionError(
+            message=(
+                "Invalid filename rule: filename rules must be exact basenames "
+                "or relative tail-subpath rules, not directory segments."
+            ),
+            file_type=file_type,
+            field_name="filenames",
+            value=rule,
+        )
+    if normalized.startswith("//"):
+        raise InvalidFileTypeDefinitionError(
+            message="Invalid filename rule: filename rules must not be UNC paths.",
+            file_type=file_type,
+            field_name="filenames",
+            value=rule,
+        )
+    if normalized.startswith("/"):
+        raise InvalidFileTypeDefinitionError(
+            message="Invalid filename rule: filename rules must not be absolute paths.",
+            file_type=file_type,
+            field_name="filenames",
+            value=rule,
+        )
+    if _WINDOWS_DRIVE_RULE_RE.match(normalized):
+        raise InvalidFileTypeDefinitionError(
+            message="Invalid filename rule: filename rules must not be Windows drive paths.",
+            file_type=file_type,
+            field_name="filenames",
+            value=rule,
+        )
+
+    parts: list[str] = normalized.split("/")
+    if any(part == "" for part in parts):
+        raise InvalidFileTypeDefinitionError(
+            message="Invalid filename rule: filename rules must not contain empty path segments.",
+            file_type=file_type,
+            field_name="filenames",
+            value=rule,
+        )
+    if any(part in {".", ".."} for part in parts):
+        raise InvalidFileTypeDefinitionError(
+            message="Invalid filename rule: filename rules must not contain '.' or '..' segments.",
+            file_type=file_type,
+            field_name="filenames",
+            value=rule,
+        )
+    return normalized
+
+
+def normalize_filename_rules(rules: Iterable[str], *, file_type: str) -> list[str]:
+    """Return canonical POSIX-style filename rules.
+
+    Args:
+        rules: Exact basename and relative tail-subpath filename rules to
+            normalize.
+        file_type: Qualified file type identifier used in validation errors.
+
+    Returns:
+        Canonical filename rules using `/` as separator.
+
+    Invalid rules are rejected by the single-rule normalizer before any
+    canonical value is returned.
+    """
+    return [_normalize_filename_rule(rule, file_type=file_type) for rule in rules]

--- a/src/topmark/filetypes/model.py
+++ b/src/topmark/filetypes/model.py
@@ -8,14 +8,17 @@
 #
 # topmark:header:end
 
-"""Abstract base class for all file type implementations in TopMark.
+"""File type definitions and matching behavior for TopMark.
 
-Defines the FileType class, which represents a file type definition used to match files
-and generate standardized header blocks. This base class is meant to be subclassed
-by specific file type implementations.
+This module defines `FileType`, the value object used by the registry and
+resolver to recognize files and decide whether they are eligible for TopMark
+header processing.
 
-If `skip_processing` is True, the pipeline will recognize files of this type and
-skip header processing by design.
+A file type can match files by extension, filename rule, regular expression, and
+optional content probing. Filename rules are declarative registry matching rules,
+not filesystem paths. They are normalized and validated when a `FileType` is
+constructed so matching, registry output, and machine-readable serialization use
+the same canonical representation on every platform.
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ from typing import TypedDict
 from typing import runtime_checkable
 
 from topmark.core.logging import get_logger
+from topmark.filetypes.filename_rules import normalize_filename_rules
 from topmark.filetypes.policy import FileTypeHeaderPolicy
 from topmark.registry.identity import make_qualified_key
 from topmark.registry.identity import owner_label
@@ -224,13 +228,16 @@ class FileType:
         extensions: List of filename extensions associated with this type. Values
             should include the leading dot (e.g. ``.py``) or be consistent with the
             matcher used elsewhere in TopMark.
-        filenames: Exact basenames or POSIX-style tail subpaths to match. Values containing
-            `/` or `\` are treated as tail-subpath rules and are matched against
-            `path.as_posix()`. Built-in file type definitions should prefer POSIX `/`
-            separators for cross-platform stability.
-        patterns: Regular expressions evaluated against the basename only (see
-            `re.fullmatch`). Patterns are not path-aware and do not receive POSIX-normalized
-            subpaths; use `filenames` for exact basename or POSIX-style tail-subpath rules.
+        filenames: Exact basename or relative tail-subpath matching rules. Rules
+            are registry identifiers, not filesystem paths. Backslashes are
+            accepted as compatibility input and normalized to POSIX-style `/`
+            separators during construction. Stored values are always canonical
+            POSIX-style strings. Rules must not be empty, absolute, UNC-like,
+            Windows drive paths, or contain empty, `.` or `..` segments.
+        patterns: Regular expressions evaluated against the basename only with
+            `re.fullmatch`. Patterns are not path-aware and do not receive
+            POSIX-normalized subpaths; use `filenames` for exact basename or
+            relative tail-subpath rules.
         description: Human-readable description of the file type.
         skip_processing: When ``True``, the pipeline **recognizes** files of this
             type but intentionally **skips header processing** (e.g. JSON without
@@ -273,6 +280,10 @@ class FileType:
         * `matches` first tries extensions, filenames, and regex patterns.
           Only if those fail and `content_matcher` is set will it call the
           matcher to decide.
+        * `filenames` entries are normalized and validated during construction.
+          Tail-subpath rules are matched against `path.as_posix()`, but the
+          rules themselves are stored canonically and should be serialized as
+          POSIX-style strings.
         * Content matchers should read a small portion of the file where possible
           to remain fast on large trees. The current implementation leaves that
           policy to the callable to keep the base class simple.
@@ -309,7 +320,7 @@ class FileType:
     _compiled_patterns: list[re.Pattern[str]] | None = None
 
     def __post_init__(self) -> None:
-        """Validate file type identity attributes on instances.
+        """Validate and canonicalize file type metadata.
 
         Every concrete `FileType` instance must define a stable identity:
 
@@ -326,6 +337,11 @@ class FileType:
 
         Uniqueness of the qualified key (``"<namespace>:<local_key>"``) is validated at registry
         composition time.
+
+        Filename rules are also normalized here so all downstream consumers see
+        canonical POSIX-style rules. Invalid filename-rule definitions raise
+        `InvalidFileTypeDefinitionError` before the instance reaches registry
+        composition, matching, or serialization.
         """
         cls: type[FileType] = self.__class__
         owner: Final[str] = owner_label(cls)
@@ -342,6 +358,12 @@ class FileType:
         self.namespace = namespace
         self.local_key = local_key
 
+        # Store filename rules canonically before matching, registration, or serialization.
+        self.filenames = normalize_filename_rules(
+            self.filenames,
+            file_type=self.qualified_key,
+        )  # raises InvalidFileTypeDefinitionError
+
         # Reserve the builtin namespace for TopMark itself. Since this is an
         # instance, the defining module is the best available provenance signal.
         validate_reserved_topmark_namespace(
@@ -352,15 +374,20 @@ class FileType:
         )
 
     def matches(self, path: Path) -> bool:
-        """Determine if the file type matches the given file path.
+        """Determine whether this file type matches a path.
 
-        This method must be implemented by subclasses to define matching logic.
+        Matching is attempted in deterministic order: extensions, filename
+        rules, regex patterns, and then an optional content matcher if permitted
+        by `content_gate`. Exact basename filename rules compare against
+        `path.name`; relative tail-subpath filename rules compare against
+        `path.as_posix()`.
 
         Args:
-            path: The path to the file to check.
+            path: Path to test against this file type.
 
         Returns:
-            True if the file matches this file type, False otherwise.
+            True if the path matches this file type, False otherwise. Content
+            matcher exceptions are caught and treated as non-matches.
         """
         # Track which name rule (if any) matched; used for content gating.
         matched_by: str | None = None
@@ -383,14 +410,14 @@ class FileType:
 
         # 2) if still not matched, try filenames
         if matched_by is None and self.filenames:
-            # Filenames support exact basename matches and POSIX-style tail-subpath matches:
+            # Filename rules support exact basename and POSIX-style tail-subpath matches:
             #    - "settings.json" matches only if basename == "settings.json".
             #    - ".vscode/settings.json" matches if path.as_posix() ends with that tail.
             # Tail-subpath filename rules are matched against normalized POSIX-style paths.
             basename: str = path.name
             posix: str = path.as_posix()
             for fname in self.filenames:
-                if "/" in fname or "\\" in fname:
+                if "/" in fname:  # Path separators are already normalized
                     if posix.endswith(fname):
                         matched_by = "filename"
                         break

--- a/tests/cli/machine/test_registry_machine.py
+++ b/tests/cli/machine/test_registry_machine.py
@@ -57,7 +57,7 @@ class UnusedRegistryProcessor(HeaderProcessor):
     description: ClassVar[str] = "Processor left intentionally unused in registry tests."
 
 
-pytestmark = pytest.mark.cli
+pytestmark: pytest.MarkDecorator = pytest.mark.cli
 
 
 FILETYPE_BRIEF_KEYS: frozenset[str] = frozenset(
@@ -120,7 +120,12 @@ BINDING_DETAIL_KEYS: frozenset[str] = frozenset(
     }
 )
 REF_DETAIL_KEYS: frozenset[str] = frozenset(
-    {"local_key", "namespace", "qualified_key", "description"}
+    {
+        "local_key",
+        "namespace",
+        "qualified_key",
+        "description",
+    }
 )
 
 
@@ -132,7 +137,7 @@ def registry_snapshot() -> Iterator[None]:
         namespace="pytest",
         description="Bound registry test file type.",
         extensions=[".bound"],
-        filenames=["BoundFile"],
+        filenames=["BoundFile", r".vscode\settings.json"],
         patterns=[r".*\\.bound"],
     )
     unbound_filetype: FileType = make_file_type(
@@ -268,6 +273,7 @@ def test_registry_filetypes_machine_json(
         assert unbound_entry.get("bound") is False
         assert bound_entry.get("extensions") == [".bound"]
         assert unbound_entry.get("extensions") == [".unbound"]
+        assert bound_entry.get("filenames") == ["BoundFile", ".vscode/settings.json"]
 
         bound_policy_obj: object | None = bound_entry.get("policy")
         assert is_mapping(bound_policy_obj)
@@ -473,6 +479,7 @@ def test_registry_filetypes_machine_ndjson(
     if show_details:
         assert set(bound_payload.keys()) == set(FILETYPE_DETAIL_KEYS)
         assert bound_payload.get("bound") is True
+        assert bound_payload.get("filenames") == ["BoundFile", ".vscode/settings.json"]
     else:
         assert set(bound_payload.keys()) == set(FILETYPE_BRIEF_KEYS)
 

--- a/tests/filetypes/test_content_gate.py
+++ b/tests/filetypes/test_content_gate.py
@@ -69,6 +69,18 @@ class Probe:
         return self.result
 
 
+class FailingProbe:
+    """Callable probe that raises to exercise fail-closed matcher behavior."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, path: Path) -> bool:  # content_matcher signature
+        """Increment call counter and raise a deterministic error."""
+        self.calls += 1
+        raise OSError("simulated matcher failure")
+
+
 _USE_JSON_AS_JSONC_FILE_TYPE = object()
 
 
@@ -189,6 +201,40 @@ def test_gate_if_filename_calls_matcher_only_on_filename_match(tmp_path: Path) -
     p2.write_text("{}")
     assert ft2.matches(p2) is True  # extension matched; gate blocks probe
     assert probe2.calls == 0
+
+
+def test_gate_if_filename_uses_normalized_tail_subpath_rules(tmp_path: Path) -> None:
+    """IF_FILENAME gate treats backslash rules as POSIX tail-subpath rules."""
+    probe = Probe(result=True)
+    ft: FileType = make_file_type(
+        local_key="vscode",
+        filenames=[r".vscode\settings.json"],
+        content_matcher=probe,
+        content_gate=ContentGate.IF_FILENAME,
+    )
+
+    path: Path = tmp_path / ".vscode" / "settings.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("// jsonc\n{}")
+
+    assert ft.matches(path) is True
+    assert probe.calls == 1
+
+
+def test_content_matcher_exception_fails_closed(tmp_path: Path) -> None:
+    """Matcher exceptions should fail closed instead of leaking."""
+    probe = FailingProbe()
+    ft: FileType = make_file_type(
+        local_key="json",
+        extensions=[".json"],
+        content_matcher=probe,
+        content_gate=ContentGate.ALWAYS,
+    )
+    path: Path = tmp_path / "settings.json"
+    path.write_text("{}\n", encoding="utf-8")
+
+    assert ft.matches(path) is False
+    assert probe.calls == 1
 
 
 def test_gate_if_pattern_calls_matcher_only_on_pattern_match(tmp_path: Path) -> None:

--- a/tests/filetypes/test_filename_rules.py
+++ b/tests/filetypes/test_filename_rules.py
@@ -1,0 +1,94 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_filename_rules.py
+#   file_relpath : tests/filetypes/test_filename_rules.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for FileType filename-rule normalization and validation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers.registry import make_file_type
+from topmark.core.errors import InvalidFileTypeDefinitionError
+
+if TYPE_CHECKING:
+    from topmark.filetypes.model import FileType
+
+
+def test_file_type_normalizes_filename_tail_subpath_rules() -> None:
+    """Backslash-containing filename rules are stored as POSIX tail rules."""
+    file_type: FileType = make_file_type(
+        local_key="vscode_settings",
+        extensions=[],
+        filenames=[r".vscode\settings.json"],
+        patterns=[],
+    )
+
+    assert file_type.filenames == [".vscode/settings.json"]
+
+
+def test_file_type_normalizes_mixed_separator_filename_rules() -> None:
+    """Mixed separator filename rules are canonicalized during construction."""
+    file_type: FileType = make_file_type(
+        local_key="nested_config",
+        extensions=[],
+        filenames=[
+            r"config\nested/settings.json",  # raw string containing a backslash, not a newline
+        ],
+        patterns=[],
+    )
+
+    assert file_type.filenames == ["config/nested/settings.json"]
+
+
+def test_file_type_keeps_basename_filename_rules_unchanged() -> None:
+    """Basename filename rules are preserved when no separator is present."""
+    file_type: FileType = make_file_type(
+        local_key="makefile",
+        extensions=[],
+        filenames=["Makefile"],
+        patterns=[],
+    )
+
+    assert file_type.filenames == ["Makefile"]
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        pytest.param("", id="empty"),
+        pytest.param(".", id="dot"),
+        pytest.param("..", id="dot-dot"),
+        pytest.param("/absolute/settings.json", id="posix-absolute"),
+        pytest.param("//server/share/settings.json", id="posix-unc-like"),
+        pytest.param(r"\\server\share\settings.json", id="windows-unc"),
+        pytest.param("C:/Users/example/settings.json", id="windows-drive-posix"),
+        pytest.param(
+            r"C:\Users\example\settings.json",
+            id="windows-drive-backslash",
+        ),
+        pytest.param("config//settings.json", id="empty-segment"),
+        pytest.param("config/./settings.json", id="dot-segment"),
+        pytest.param("config/../settings.json", id="dot-dot-segment"),
+        pytest.param("config/settings.json/.", id="trailing-dot-segment"),
+        pytest.param("config/settings.json/..", id="trailing-dot-dot-segment"),
+    ],
+)
+def test_file_type_rejects_invalid_filename_rules(rule: str) -> None:
+    """Filename rules must be relative registry matching rules, not paths."""
+    with pytest.raises(InvalidFileTypeDefinitionError, match="filename rule"):
+        make_file_type(
+            local_key="invalid_filename_rule",
+            extensions=[],
+            filenames=[rule],
+            patterns=[],
+            description="Invalid filename-rule fixture",
+        )

--- a/tests/filetypes/test_instances_plugins.py
+++ b/tests/filetypes/test_instances_plugins.py
@@ -19,7 +19,6 @@ from typing import cast
 
 from tests.helpers.registry import make_file_type
 from topmark.filetypes.instances import get_base_file_type_registry
-from topmark.filetypes.model import FileType
 from topmark.registry.filetypes import FileTypeRegistry
 
 if TYPE_CHECKING:

--- a/tests/filetypes/test_model_matching.py
+++ b/tests/filetypes/test_model_matching.py
@@ -1,0 +1,117 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_model_matching.py
+#   file_relpath : tests/filetypes/test_model_matching.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Unit tests for direct FileType filename, extension, and pattern matching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tests.helpers.registry import make_file_type
+
+if TYPE_CHECKING:
+    from topmark.filetypes.model import FileType
+
+
+def test_file_type_matches_extension_rule() -> None:
+    """Extension rules match paths by suffix."""
+    file_type: FileType = make_file_type(
+        local_key="python",
+        extensions=[".py"],
+        filenames=[],
+        patterns=[],
+    )
+
+    assert file_type.matches(Path("src/topmark/__init__.py")) is True
+
+
+def test_file_type_does_not_match_unrelated_extension_rule() -> None:
+    """Extension rules do not match unrelated suffixes."""
+    file_type: FileType = make_file_type(
+        local_key="python",
+        extensions=[".py"],
+        filenames=[],
+        patterns=[],
+    )
+
+    assert file_type.matches(Path("docs/index.md")) is False
+
+
+def test_file_type_matches_basename_filename_rule() -> None:
+    """Basename filename rules match exact path names."""
+    file_type: FileType = make_file_type(
+        local_key="makefile",
+        extensions=[],
+        filenames=["Makefile"],
+        patterns=[],
+    )
+
+    assert file_type.matches(Path("build/Makefile")) is True
+
+
+def test_file_type_does_not_match_basename_filename_rule_as_tail() -> None:
+    """Basename filename rules do not match partial tail-subpaths."""
+    file_type: FileType = make_file_type(
+        local_key="makefile",
+        extensions=[],
+        filenames=["Makefile"],
+        patterns=[],
+    )
+
+    assert file_type.matches(Path("build/Makefile.local")) is False
+
+
+def test_file_type_matches_normalized_tail_subpath_filename_rule() -> None:
+    """Backslash-origin filename rules match canonical POSIX tail-subpaths."""
+    file_type: FileType = make_file_type(
+        local_key="vscode_settings",
+        extensions=[],
+        filenames=[r".vscode\settings.json"],
+        patterns=[],
+    )
+
+    assert file_type.matches(Path("project/.vscode/settings.json")) is True
+
+
+def test_file_type_does_not_match_unrelated_tail_subpath_filename_rule() -> None:
+    """Tail-subpath filename rules do not match unrelated paths."""
+    file_type: FileType = make_file_type(
+        local_key="vscode_settings",
+        extensions=[],
+        filenames=[".vscode/settings.json"],
+        patterns=[],
+    )
+
+    assert file_type.matches(Path("project/settings.json")) is False
+
+
+def test_file_type_matches_pattern_rule() -> None:
+    """Pattern rules match POSIX-style path strings."""
+    file_type: FileType = make_file_type(
+        local_key="requirements",
+        extensions=[],
+        filenames=[],
+        patterns=[r"requirements\.(in|txt)"],
+    )
+
+    assert file_type.matches(Path("requirements.txt")) is True
+
+
+def test_file_type_does_not_match_unrelated_pattern_rule() -> None:
+    """Pattern rules do not match unrelated POSIX-style path strings."""
+    file_type: FileType = make_file_type(
+        local_key="requirements",
+        extensions=[],
+        filenames=[],
+        patterns=[r"requirements\.(in|txt)"],
+    )
+
+    assert file_type.matches(Path("constraints.txt")) is False

--- a/tests/pipeline/steps/test_resolver.py
+++ b/tests/pipeline/steps/test_resolver.py
@@ -529,6 +529,44 @@ def test_resolve_filename_tail_backslash_normalization(
     assert ctx.file_type and ctx.file_type.local_key == ft_vscode_name
 
 
+def test_resolve_normalized_filename_tail_beats_pattern(
+    tmp_path: Path,
+    effective_registries: EffectiveRegistries,
+) -> None:
+    """Normalized filename-tail rules must keep filename-tail precedence."""
+    folder: Path = tmp_path / ".vscode"
+    folder.mkdir()
+    file: Path = folder / "settings.json"
+    file.write_text("{}\n", encoding="utf-8")
+
+    ft_tail_name = "by-tail"
+    ft_tail: FileType = make_file_type(
+        local_key=ft_tail_name,
+        filenames=[r".vscode\settings.json"],
+    )
+
+    ft_pat_name = "by-pattern"
+    ft_pat: FileType = make_file_type(
+        local_key=ft_pat_name,
+        patterns=[r".*\.json"],
+    )
+
+    filetypes: dict[str, FileType] = {ft_tail_name: ft_tail, ft_pat_name: ft_pat}
+    processors: dict[str, HeaderProcessor] = {
+        ft_tail_name: HeaderProcessor(),
+        ft_pat_name: HeaderProcessor(),
+    }
+    ctx: ProcessingContext = _resolve(
+        file,
+        filetypes=filetypes,
+        processors=processors,
+        effective_registries=effective_registries,
+    )
+
+    assert ctx.status.resolve == ResolveStatus.RESOLVED
+    assert ctx.file_type and ctx.file_type.local_key == ft_tail_name
+
+
 def test_resolve_multi_dot_extension_specificity(
     tmp_path: Path,
     effective_registries: EffectiveRegistries,

--- a/tests/presentation/test_registry_rendering.py
+++ b/tests/presentation/test_registry_rendering.py
@@ -96,7 +96,7 @@ def _filetype_item(*, bound: bool = True) -> FileTypeHumanItem:
         description="Python source",
         bound=bound,
         extensions=(".py",),
-        filenames=("SConstruct",),
+        filenames=("SConstruct", ".vscode/settings.json"),
         patterns=(".*\\.pyi",),
         skip_processing=False,
         has_content_matcher=True,
@@ -191,7 +191,7 @@ def test_render_filetypes_text_details_include_matching_and_policy_metadata() ->
     assert "      namespace       : test" in output
     assert "      bound           : no" in output
     assert "      extensions      : .py" in output
-    assert "      filenames       : SConstruct" in output
+    assert "      filenames       : SConstruct, .vscode/settings.json" in output
     assert "      patterns        : .*\\.pyi" in output
     assert "      content matcher : yes" in output
     assert "      insert checker  : yes" in output
@@ -310,6 +310,7 @@ def test_render_filetypes_markdown_compact_and_details() -> None:
         "`test`",
         "**yes**",
     ]
+    assert "SConstruct, .vscode/settings.json" in find_table_row(detail_output, "`test.python`")
     assert "**supports_shebang**=true" in detail_output
 
 
@@ -418,6 +419,7 @@ def test_build_filetypes_human_report_sorts_and_maps_policy(
         namespace="test",
         description="Alpha type",
         extensions=[".a"],
+        filenames=[r".vscode\settings.json"],
         header_policy=FileTypeHeaderPolicy(
             supports_shebang=True,
             encoding_line_regex="^# coding:",
@@ -444,6 +446,7 @@ def test_build_filetypes_human_report_sorts_and_maps_policy(
 
     assert [item.qualified_key for item in report.items] == ["test:alpha", "test:beta"]
     assert report.items[0].bound is True
+    assert report.items[0].filenames == (".vscode/settings.json",)
     assert report.items[1].bound is False
     assert report.items[0].policy.supports_shebang is True
     assert report.items[0].policy.encoding_line_regex == "^# coding:"

--- a/tests/registry/test_filetype_identity.py
+++ b/tests/registry/test_filetype_identity.py
@@ -26,6 +26,30 @@ if TYPE_CHECKING:
     from topmark.filetypes.model import FileType
 
 
+def test_filename_rule_normalization_preserves_registry_identity() -> None:
+    """Filename-rule normalization does not affect registry identity fields."""
+    file_type: FileType = make_file_type(
+        local_key="settings_json",
+        namespace="pytest",
+        filenames=[r".vscode\settings.json"],
+        description="VS Code settings file type",
+    )
+
+    with patched_effective_registries(
+        filetypes={"settings_json": file_type},
+        processors={},
+    ):
+        resolved: FileType | None = FileTypeRegistry.resolve_filetype_id(
+            "pytest:settings_json",
+        )
+
+    assert file_type.local_key == "settings_json"
+    assert file_type.namespace == "pytest"
+    assert file_type.qualified_key == "pytest:settings_json"
+    assert file_type.filenames == [".vscode/settings.json"]
+    assert resolved is file_type
+
+
 def test_resolve_filetype_id_accepts_unambiguous_local_identifier() -> None:
     """Unqualified local identifiers resolve when they match exactly one file type."""
     file_type: FileType = make_file_type(

--- a/tests/registry/test_register_unregister.py
+++ b/tests/registry/test_register_unregister.py
@@ -43,6 +43,24 @@ def test_register_and_unregister_filetypes() -> None:
     assert "tmp" not in FileTypeRegistry.as_mapping_by_local_key()
 
 
+def test_register_filetype_exposes_normalized_filename_rules() -> None:
+    """Registered file types expose canonical POSIX filename rules."""
+    ft: FileType = make_file_type(
+        local_key="tmp_tail_rule",
+        extensions=[],
+        filenames=[r".vscode\settings.json"],
+        patterns=[],
+        description="tmp tail rule",
+    )
+
+    FileTypeRegistry.register(ft)
+    try:
+        registered: FileType = FileTypeRegistry.as_mapping_by_local_key()["tmp_tail_rule"]
+        assert registered.filenames == [".vscode/settings.json"]
+    finally:
+        FileTypeRegistry.unregister_by_local_key("tmp_tail_rule")
+
+
 def test_register_and_unregister_processors() -> None:
     """Verify that processor registration and binding mutators change behavior."""
     # Ensure the target file type exists before processor registration.


### PR DESCRIPTION
## Summary

This PR implements the filename-rule normalization and validation contract
described in #93.

`FileType.filenames` entries are now treated as declarative registry matching
rules rather than filesystem paths.

Tail-subpath rules are normalized to a canonical POSIX-style representation
during file-type construction and invalid filename-rule definitions are
rejected early.

## Changes

### Filename-rule normalization

- Added `topmark.filetypes.filename_rules`.
- Centralized filename-rule normalization and validation logic.
- Normalized tail-subpath rules to POSIX-style `/` separators.
- Standardized downstream consumers on canonical filename-rule values.

Examples:

```text
.vscode\settings.json
```

is normalized to:

```text
.vscode/settings.json
```

before matching, registry composition, presentation, and serialization.

### Validation

Added explicit validation for invalid filename-rule definitions.

Rejected forms include:

- empty rules;
- absolute paths;
- UNC paths;
- Windows drive paths;
- rules containing empty path segments;
- rules containing `.` segments;
- rules containing `..` segments.

Added:

- `InvalidFileTypeDefinitionError`

for invalid file-type metadata.

### Resolver and registry consistency

- Resolver matching now operates on canonical filename rules.
- Registry rendering emits canonical filename-rule values.
- Machine-readable registry output emits canonical filename-rule values.
- Registry identity and serialization behavior are now platform-independent.

### Documentation

Updated documentation across:

- registry filetype reference;
- machine-output documentation;
- resolution architecture;
- registry model;
- plugin authoring guidance;
- terminology;
- architecture and machine-format references.

Documentation now explicitly distinguishes:

```text
filesystem paths
```

from:

```text
registry filename rules
```

and documents canonical POSIX-style tail-subpath behavior.

### Tests

Added and expanded coverage for:

- filename-rule normalization;
- filename-rule validation;
- matching behavior;
- content-gate interactions;
- resolver precedence;
- registry registration;
- registry identity;
- registry rendering;
- machine-readable registry output.

## Breaking Changes

File-type providers that define invalid filename rules now fail during
file-type construction.

Backslash-containing tail-subpath rules remain accepted as compatibility
input but are normalized to canonical POSIX-style representations.

Plugin authors should treat `FileType.filenames` entries as relative registry
matching rules rather than filesystem paths.

## Related Issues

Fixes #93.

Related:
- #88 (path serialization contract)