### PR TITLE
Centralize path rendering helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ ______________________________________________________________________
   canonical filename-rule representation.
 - Clarified that `FileType.filenames` entries are declarative registry matching rules rather than
   filesystem paths.
+- Centralized path serialization and human-facing path presentation helpers for processing output,
+  generated header metadata, TEXT rendering, Markdown rendering, and unified diff labels.
+- Clarified that unified diff file labels follow human-facing display-path policy rather than the
+  machine-readable path serialization contract.
 
 ### Breaking Changes - Unreleased
 
@@ -93,6 +97,8 @@ ______________________________________________________________________
   rules before resolution and registry serialization.
 - Fixed inconsistent registry output where equivalent filename rules could be represented using
   different path-separator spellings.
+- Fixed STDIN-backed unified diff labels so they use the logical `--stdin-filename` instead of the
+  materialized temporary file path.
 
 ### Documentation - Unreleased
 
@@ -115,6 +121,10 @@ ______________________________________________________________________
 - Documented the canonical filename-rule contract for `FileType.filenames`.
 - Documented normalization and validation behavior for tail-subpath filename rules.
 - Clarified plugin-author guidance around filename-rule definitions and canonical registry metadata.
+- Documented the boundary between machine-readable path serialization and human-facing path
+  presentation, including TEXT, Markdown, and unified diff output.
+- Clarified that unified diff labels are human-facing display labels and should not be treated as
+  JSON/NDJSON path fields.
 
 ### Internal - Unreleased
 
@@ -128,6 +138,9 @@ ______________________________________________________________________
 - Added centralized filename-rule normalization and validation helpers.
 - Added regression coverage for filename-rule normalization, validation, matching, registry
   serialization, resolver behavior, and presentation output.
+- Added dedicated header-metadata path serialization and display-path presentation helper modules.
+- Added regression coverage for header metadata path serialization, TEXT and Markdown path labels,
+  and STDIN-backed unified diff labels.
 
 ### Notes - Unreleased
 

--- a/docs/_snippets/machine-path-contract-current-scope.md
+++ b/docs/_snippets/machine-path-contract-current-scope.md
@@ -17,6 +17,11 @@ topmark:header:end
 > - header metadata path fields; and
 > - processing and probe machine-readable output.
 >
+> Human-facing path labels are outside this contract, including:
+>
+> - CLI and Markdown presentation paths; and
+> - unified diff file labels.
+>
 > Some machine-readable configuration and provenance payloads may still emit path-like values
 > outside this contract. A future compatibility update may extend POSIX serialization to all
 > machine-readable path fields.

--- a/docs/_snippets/path-serialization-contract.md
+++ b/docs/_snippets/path-serialization-contract.md
@@ -13,5 +13,10 @@ topmark:header:end
 > [!NOTE] **Path representation**
 >
 > TopMark serializes header metadata, processing machine-output paths, and probe machine-output
-> paths with POSIX `/` separators on all platforms. Human CLI output may use the host platform's
-> native path representation.
+> paths with POSIX `/` separators on all platforms.
+>
+> Human-facing output follows display-path policy instead:
+>
+> - CLI and Markdown reports may use the host platform's native path representation;
+> - STDIN-backed processing displays the logical `--stdin-filename` when available; and
+> - unified diff file labels are human-facing display labels, not machine-readable path fields.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -316,6 +316,22 @@ Machine-readable output is also intentionally decoupled from process exit codes.
 payloads serialize structured results, diagnostics, and resolution state; they do not embed the CLI
 exit code. Consumers must inspect the process exit status separately from parsing machine payloads.
 
+Path representation follows the same separation between machine-facing serialization and
+human-facing presentation:
+
+- Internal filesystem identity is represented with `Path` objects where possible.
+- Header metadata path fields, processing machine-output paths, and probe machine-output paths are
+  serialized with POSIX `/` separators on all platforms.
+- Registry `filenames` entries are POSIX-style matching rules, not filesystem paths.
+- TEXT and Markdown output use shared display-path helpers so regular paths follow human-facing
+  display policy and STDIN-backed processing shows the logical `--stdin-filename` when available.
+- Unified diff file labels are human-facing display labels. They are not machine-readable path
+  serialization fields and should not be treated like JSON or NDJSON path values.
+
+Some machine-readable configuration and provenance payloads may still expose path-like values
+outside the current POSIX path contract. Extending POSIX serialization to those remaining fields is
+tracked separately from the presentation-helper refactor.
+
 ### CLI applicability and usage-error boundary
 
 CLI command applicability is enforced before pipeline execution and before presentation or machine

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -97,6 +97,9 @@ Stability guarantees:
 
 - Machine-readable payloads contain no ANSI color codes.
 - Payload shapes are JSON-safe (no Python-specific objects).
+- Processing and probe path fields are serialized with POSIX `/` separators on all platforms.
+- Header metadata path fields are also serialized with POSIX `/` separators when TopMark renders
+  headers.
 - New fields may be added over time as additive 1.x evolution.
 - Existing fields are not removed or renamed without a breaking-change signal.
 - Resolved file type identities are emitted using canonical qualified keys when available.
@@ -110,10 +113,18 @@ Consumers should:
 
 - Tolerate unknown fields.
 
-- Avoid string matching against formatted output.
+- Avoid string matching against formatted output, including human-facing path labels in TEXT,
+  Markdown, and unified diff output.
 
 - Prefer canonical identity fields such as `qualified_key`, `file_type_key`, and `processor_key`
   over display-oriented names or user-supplied input spellings.
+
+Path-like values are not all part of the same contract. Processing and probe machine payloads use
+POSIX path serialization, while registry `filenames` entries are POSIX-style matching rules rather
+than filesystem paths. Human-facing path labels, including unified diff file labels, follow display
+policy and are not machine-stable path fields. Some configuration and provenance payloads may still
+expose path-like values outside the current POSIX path contract; extending that contract is tracked
+separately from presentation rendering.
 
 ______________________________________________________________________
 

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -32,6 +32,15 @@ Source-local TOML options such as `[config].root` and `strict` are resolved befo
 execution. They influence configuration discovery and staged config-loading validation behavior, but
 do not become layered configuration fields.
 
+Path handling responsibilities are split between pipeline processing and presentation layers:
+
+- `BuilderStep` generates header metadata path fields (`file_relpath`, `file_abspath`, `relpath`,
+  and `abspath`) using POSIX `/` serialization on all platforms.
+- `PatcherStep` generates unified diffs for human review; diff file labels use human-facing display
+  paths rather than machine-readable path serialization.
+- TEXT and Markdown frontends share display-path helpers so STDIN-backed processing consistently
+  displays the logical `--stdin-filename` when available.
+
 {% include-markdown "\_snippets/config-strictness.md" %}
 
 ## Line-ending handling (contract)
@@ -76,12 +85,14 @@ API module.
   - [`topmark.pipeline.steps.sniffer`](../api/internals/topmark/pipeline/steps/sniffer.md)
   - [`topmark.pipeline.steps.reader`](../api/internals/topmark/pipeline/steps/reader.md)
   - [`topmark.pipeline.steps.scanner`](../api/internals/topmark/pipeline/steps/scanner.md)
-  - [`topmark.pipeline.steps.builder`](../api/internals/topmark/pipeline/steps/builder.md)
+  - [`topmark.pipeline.steps.builder`](../api/internals/topmark/pipeline/steps/builder.md) - header
+    values and metadata paths
   - [`topmark.pipeline.steps.renderer`](../api/internals/topmark/pipeline/steps/renderer.md)
   - [`topmark.pipeline.steps.comparer`](../api/internals/topmark/pipeline/steps/comparer.md)
   - [`topmark.pipeline.steps.stripper`](../api/internals/topmark/pipeline/steps/stripper.md)
   - [`topmark.pipeline.steps.planner`](../api/internals/topmark/pipeline/steps/planner.md)
-  - [`topmark.pipeline.steps.patcher`](../api/internals/topmark/pipeline/steps/patcher.md)
+  - [`topmark.pipeline.steps.patcher`](../api/internals/topmark/pipeline/steps/patcher.md) - unified
+    diffs and display labels
   - [`topmark.pipeline.steps.writer`](../api/internals/topmark/pipeline/steps/writer.md)
 
 ### Axes and statuses

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -230,6 +230,10 @@ SP --> B --> T
 - Rendered header available in context
 - No determination yet whether changes are needed
 
+`BuilderStep` derives built-in header metadata fields such as `file_relpath`, `file_abspath`,
+`relpath`, and `abspath`. These generated header metadata path fields are serialized with POSIX `/`
+separators on all platforms.
+
 Useful for debugging header generation.
 
 ______________________________________________________________________
@@ -283,6 +287,10 @@ CP --> P --> H
 
 - Patch generated
 - No patch if unchanged or skipped
+
+`PatcherStep` generates unified diffs for human review. Diff file labels use the same human-facing
+display-path policy as TEXT and Markdown reports, including the logical `--stdin-filename` for
+STDIN-backed processing when available. They are not machine-readable path serialization fields.
 
 Used when `--patch` is requested without `--apply`.
 
@@ -442,12 +450,12 @@ Each step implements the \[`Step`\][topmark.pipeline.protocols.Step] protocol an
 | \[`SnifferStep`\][topmark.pipeline.steps.sniffer.SnifferStep]    | Fast policy and newline checks                                                      |
 | \[`ReaderStep`\][topmark.pipeline.steps.reader.ReaderStep]       | Read file content safely                                                            |
 | \[`ScannerStep`\][topmark.pipeline.steps.scanner.ScannerStep]    | Locate existing header bounds                                                       |
-| \[`BuilderStep`\][topmark.pipeline.steps.builder.BuilderStep]    | Build expected header field values                                                  |
+| \[`BuilderStep`\][topmark.pipeline.steps.builder.BuilderStep]    | Build expected header field values and POSIX-serialized header metadata paths       |
 | \[`RendererStep`\][topmark.pipeline.steps.renderer.RendererStep] | Render header text                                                                  |
 | \[`ComparerStep`\][topmark.pipeline.steps.comparer.ComparerStep] | Compare existing vs rendered header                                                 |
 | \[`StripperStep`\][topmark.pipeline.steps.stripper.StripperStep] | Remove header content                                                               |
 | \[`PlannerStep`\][topmark.pipeline.steps.planner.PlannerStep]    | Decide insert / replace / remove plan                                               |
-| \[`PatcherStep`\][topmark.pipeline.steps.patcher.PatcherStep]    | Generate unified diff                                                               |
+| \[`PatcherStep`\][topmark.pipeline.steps.patcher.PatcherStep]    | Generate unified diff with human-facing display labels                              |
 | \[`WriterStep`\][topmark.pipeline.steps.writer.WriterStep]       | Persist changes                                                                     |
 
 ______________________________________________________________________

--- a/docs/dev/registry-model.md
+++ b/docs/dev/registry-model.md
@@ -174,6 +174,10 @@ TopMark also normalizes file type filename rules to canonical POSIX-style regist
 Exact-basename rules are preserved, while relative tail-subpath rules are stored and emitted using
 `/` separators regardless of platform.
 
+These normalized filename rules are registry metadata rather than filesystem paths. Their POSIX
+representation exists to provide stable matching, introspection, documentation examples, and
+machine-readable registry output across platforms.
+
 Local identifiers are accepted only when unambiguous.
 
 ### HeaderProcessorRegistry
@@ -366,8 +370,9 @@ Plugin authors should:
 - choose clear local keys such as `django_html` or `my_lang`;
 - document and use qualified identifiers such as `acme:django_html` in shared examples;
 - avoid relying on local identifiers remaining unambiguous as ecosystems grow;
-- define filename rules as relative registry matching rules rather than filesystem paths, preferring
-  POSIX-style `/` separators for tail-subpath matching.
+- define filename rules as relative registry matching rules rather than filesystem paths;
+- use POSIX-style `/` separators for tail-subpath matching rules so registry metadata remains stable
+  across platforms.
 
 Header processor plugins currently use advanced runtime-overlay integration semantics. They should
 bind processor definitions to canonical qualified file type identifiers.

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -72,6 +72,8 @@ Notes:
   output.
 - Markdown output is also independent from machine-readable formats and follows its own
   document-oriented contract.
+- Unified diff output from `--diff` is human-facing output. Its file labels follow display-path
+  policy and are not part of the JSON/NDJSON machine-readable path contract.
 
 ______________________________________________________________________
 
@@ -614,9 +616,11 @@ At a high level, per-file results include:
 >
 > - Diffs (`--diff`) and any ANSI coloring are **human-only** and are not included in machine
 >   payloads.
+> - Diff file labels use human-facing display paths, including the logical `--stdin-filename` for
+>   STDIN-backed processing when available. They are not machine-readable path serialization fields.
 > - Human presentation controls such as `-v` / `--verbose` and `-q` / `--quiet` are ignored by
->   machine-readable output. Consumers should use JSON/NDJSON fields rather than relying on TEXT or
->   Markdown rendering.
+>   machine-readable output. Consumers should use JSON/NDJSON fields rather than relying on TEXT,
+>   Markdown, or unified diff rendering.
 
 ______________________________________________________________________
 

--- a/src/topmark/pipeline/steps/builder.py
+++ b/src/topmark/pipeline/steps/builder.py
@@ -43,6 +43,7 @@ from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import BuilderView
 from topmark.utils.file import compute_relpath
 from topmark.utils.path import canonicalize_existing_path
+from topmark.utils.path import format_header_metadata_path
 
 if TYPE_CHECKING:
     from topmark.config.model import FrozenConfig
@@ -127,16 +128,18 @@ class BuilderStep(BaseStep):
             - In stdin mode, `file`, `file_relpath`, and `file_abspath` are derived from
               the logical `stdin_filename`, not the materialized temporary file path.
             - `file_relpath` and `relpath` are computed by calling
-              `compute_relpath(header_path, relative_to)`.
+              `compute_relpath(header_path, relative_to)` and serialized with
+              `format_header_metadata_path()`.
             - `relative_to` defaults to `Path.cwd()` when no explicit root is configured.
               If `FrozenConfig.relative_to` is set and exists on disk, it is canonicalized
               before relative paths are computed.
             - `relpath` becomes "." at repo root.
 
-            This behavior intentionally keeps `file_relpath` stable for common cases
-            like running TopMark from the repository root (so `pyproject.toml` yields
-            `file_relpath = "pyproject.toml"`). If you need `file_relpath` computed
-            relative to a specific root, set `FrozenConfig.relative_to` (via config or CLI/API
+            Header metadata path fields are serialized with POSIX separators on all
+            platforms. This behavior intentionally keeps `file_relpath` stable for common
+            cases like running TopMark from the repository root (so `pyproject.toml` yields
+            `file_relpath = "pyproject.toml"`). If you need `file_relpath` computed relative
+            to a specific root, set `FrozenConfig.relative_to` (via config or CLI/API
             overrides). User-supplied path spelling is not treated as header metadata once a
             regular filesystem path has been successfully resolved.
         """
@@ -204,13 +207,13 @@ class BuilderStep(BaseStep):
             # Base file name (without any path)
             "file": header_path.name,
             # File name with its relative path
-            "file_relpath": relative_path.as_posix(),
+            "file_relpath": format_header_metadata_path(relative_path),
             # File name with its absolute path
-            "file_abspath": absolute_path.as_posix(),
+            "file_abspath": format_header_metadata_path(absolute_path),
             # Parent directory path (relative)
-            "relpath": relative_path.parent.as_posix() if relative_path else "",
+            "relpath": format_header_metadata_path(relative_path.parent) if relative_path else "",
             # Parent directory path (absolute, of actual content)
-            "abspath": content_absolute_path.parent.as_posix(),
+            "abspath": format_header_metadata_path(content_absolute_path.parent),
         }
 
         # Merge in any additional fields from the configuration (may override built-ins).

--- a/src/topmark/pipeline/steps/patcher.py
+++ b/src/topmark/pipeline/steps/patcher.py
@@ -22,7 +22,8 @@ Inputs:
 
 Outputs:
   * ``ctx.views.diff`` - [`DiffView`][topmark.pipeline.views.DiffView] carrying the
-    unified diff text (or ``None``).
+    unified diff text (or ``None``). Diff file labels are human-facing display labels,
+    not machine-readable path serialization fields.
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import DiffView
 from topmark.pipeline.views import UpdatedView
 from topmark.presentation.formatters.unified_diff import format_patch_plain
+from topmark.presentation.shared.paths import get_display_path
 from topmark.utils.timestamp import format_gnu_diff_timestamp
 
 if TYPE_CHECKING:
@@ -107,6 +109,9 @@ class PatcherStep(BaseStep):
         The step runs only after comparison. If the comparison status is
         ``UNCHANGED`` or if no updated image is present, the diff is omitted.
 
+        Unified diff file labels use the shared human-facing display path policy,
+        including the logical ``--stdin-filename`` in STDIN content mode.
+
         Args:
             ctx: The processing context holding original/updated images
                 and statuses.
@@ -148,12 +153,14 @@ class PatcherStep(BaseStep):
             ctx.status.patch = PatchStatus.SKIPPED
             return
 
+        display_path: str = get_display_path(ctx)
+
         patch_lines: list[str] = list(
             difflib.unified_diff(
                 current_lines,
                 updated_lines,
-                fromfile=f"{ctx.path} (current)",
-                tofile=f"{ctx.path} (updated)",
+                fromfile=f"{display_path} (current)",
+                tofile=f"{display_path} (updated)",
                 fromfiledate=format_gnu_diff_timestamp(dt=ctx.timestamp),
                 n=3,
                 lineterm=ctx.newline_style,

--- a/src/topmark/presentation/markdown/paths.py
+++ b/src/topmark/presentation/markdown/paths.py
@@ -1,0 +1,51 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : paths.py
+#   file_relpath : src/topmark/presentation/markdown/paths.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Markdown-specific human-facing path presentation helpers.
+
+This module adapts shared display-path policy to Markdown output by applying
+Markdown-specific escaping and STDIN annotations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from topmark.presentation.markdown.utils import markdown_code_span
+from topmark.presentation.shared.paths import get_display_path
+
+if TYPE_CHECKING:
+    from topmark.pipeline.context.model import ProcessingContext
+
+
+def render_path_display_markdown(ctx: ProcessingContext) -> str:
+    """Render a short Markdown path label for headings and list items.
+
+    This helper formats
+    [`get_display_path()`][topmark.presentation.shared.paths.get_display_path]
+    for Markdown and annotates STDIN-backed content with ``_(via STDIN)_`` when a
+    synthetic filename is available.
+
+    The shared display-path policy determines the raw path label; this helper then
+    applies Markdown-specific code-span escaping and STDIN annotation rendering.
+
+    Args:
+        ctx: Processing context containing the path to display.
+
+    Returns:
+        Short Markdown label for per-file headings and guidance messages.
+    """
+    path: str = get_display_path(ctx)
+    code: str = markdown_code_span(path)
+
+    if ctx.run_options.stdin_mode and bool(ctx.run_options.stdin_filename):
+        return f"{code} _(via STDIN)_"
+
+    return code

--- a/src/topmark/presentation/markdown/pipeline.py
+++ b/src/topmark/presentation/markdown/pipeline.py
@@ -43,12 +43,12 @@ from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import WriteStatus
 from topmark.presentation.formatters.unified_diff import format_patch_plain
 from topmark.presentation.markdown.diagnostic import render_diagnostics_markdown
+from topmark.presentation.markdown.paths import render_path_display_markdown
 from topmark.presentation.markdown.utils import markdown_code_span
 from topmark.presentation.markdown.utils import render_fenced_code_block_markdown
 from topmark.presentation.markdown.utils import render_markdown_table
-from topmark.presentation.markdown.utils import render_path_display_markdown
+from topmark.presentation.shared.paths import get_display_path
 from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
-from topmark.presentation.shared.pipeline import get_display_path
 from topmark.presentation.shared.pipeline import get_file_type_label
 
 if TYPE_CHECKING:
@@ -130,6 +130,31 @@ def _render_pipeline_banner_markdown(
 # ---- Command guidance rendering ----
 
 
+def _render_apply_command_markdown(
+    *,
+    command: str,
+    ctx: ProcessingContext,
+) -> str:
+    """Render the suggested apply command for Markdown guidance.
+
+    The command uses the shared human-facing display-path policy so STDIN-backed
+    content is represented by its logical `--stdin-filename` value while regular
+    file processing uses the normal display path. The returned command is plain
+    text; callers are responsible for Markdown escaping.
+
+    Args:
+        command: TopMark subcommand name.
+        ctx: Processing context for the file.
+
+    Returns:
+        Suggested apply command for Markdown guidance output.
+    """
+    path_name: str = get_display_path(ctx)
+    if ctx.run_options.stdin_mode and ctx.run_options.stdin_filename:
+        return f"topmark {command} {CliOpt.APPLY_CHANGES} {CliOpt.STDIN_FILENAME} {path_name} -"
+    return f"topmark {command} {CliOpt.APPLY_CHANGES} {path_name}"
+
+
 def _render_check_guidance_message_markdown(
     ctx: ProcessingContext,
     apply_changes: bool,
@@ -151,7 +176,6 @@ def _render_check_guidance_message_markdown(
         return None
 
     path_label: str = render_path_display_markdown(ctx)
-    path_name: str = get_display_path(ctx)
     intent: Intent = determine_intent(ctx)
 
     if apply_changes:
@@ -168,12 +192,7 @@ def _render_check_guidance_message_markdown(
             else f"✏️  Updating header in {path_label}"
         )
 
-    if ctx.run_options.stdin_mode and ctx.run_options.stdin_filename:
-        apply_cmd: str = (
-            f"topmark {CliCmd.CHECK} {CliOpt.APPLY_CHANGES} {CliOpt.STDIN_FILENAME} {path_name} -"
-        )
-    else:
-        apply_cmd = f"topmark {CliCmd.CHECK} {CliOpt.APPLY_CHANGES} {path_name}"
+    apply_cmd: str = _render_apply_command_markdown(command=CliCmd.CHECK, ctx=ctx)
 
     if intent == Intent.INSERT:
         action: str = "add a TopMark header to this file"
@@ -208,7 +227,6 @@ def _render_strip_guidance_message_markdown(
         return None
 
     path_label: str = render_path_display_markdown(ctx)
-    path_name: str = get_display_path(ctx)
     intent: Intent = determine_intent(ctx)
 
     if apply_changes:
@@ -221,12 +239,7 @@ def _render_strip_guidance_message_markdown(
 
         return f"🧹 Stripping header in {path_label}"
 
-    if ctx.run_options.stdin_mode and ctx.run_options.stdin_filename:
-        apply_cmd: str = (
-            f"topmark {CliCmd.STRIP} {CliOpt.APPLY_CHANGES} {CliOpt.STDIN_FILENAME} {path_name} -"
-        )
-    else:
-        apply_cmd = f"topmark {CliCmd.STRIP} {CliOpt.APPLY_CHANGES} {path_name}"
+    apply_cmd: str = _render_apply_command_markdown(command=CliCmd.STRIP, ctx=ctx)
 
     if intent == Intent.STRIP:
         action: str = "strip the TopMark header from this file"

--- a/src/topmark/presentation/markdown/probe.py
+++ b/src/topmark/presentation/markdown/probe.py
@@ -21,9 +21,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from topmark.presentation.markdown.diagnostic import render_diagnostics_markdown
+from topmark.presentation.markdown.paths import render_path_display_markdown
 from topmark.presentation.markdown.utils import markdown_code_span
 from topmark.presentation.markdown.utils import render_markdown_table
-from topmark.presentation.markdown.utils import render_path_display_markdown
 
 if TYPE_CHECKING:
     from topmark.pipeline.context.model import ProcessingContext

--- a/src/topmark/presentation/markdown/utils.py
+++ b/src/topmark/presentation/markdown/utils.py
@@ -8,13 +8,15 @@
 #
 # topmark:header:end
 
-"""Shared presentation utilities for MARKDOWN.
+"""Shared low-level presentation utilities for Markdown.
 
-This module provides helpers to render Markdown fragments.
+This module provides pure string helpers for Markdown fragments.
 
 Scope:
 - Pure string rendering only (no I/O, no Click/Rich console usage).
 - Safe to import from any frontend (CLI, API tests, etc.).
+- No processing-context-aware rendering; context-aware Markdown presentation
+  belongs in dedicated Markdown presentation modules.
 
 The helpers here are intentionally small and composable; command-specific
 formatting belongs in the command's presentation module.
@@ -25,13 +27,9 @@ from __future__ import annotations
 import re
 import typing
 
-from topmark.presentation.shared.pipeline import get_display_path
-
 if typing.TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
-
-    from topmark.pipeline.context.model import ProcessingContext
 
 
 def markdown_code_span(text: str) -> str:
@@ -209,29 +207,3 @@ def render_toml_markdown(
     lines.append(fence)
 
     return "\n".join(lines) + "\n"
-
-
-# ---- Path rendering ----
-
-
-def render_path_display_markdown(ctx: ProcessingContext) -> str:
-    """Render a short Markdown path label for headings and list items.
-
-    This helper formats
-    [`get_display_path()`][topmark.presentation.shared.pipeline.get_display_path]
-    for Markdown and annotates STDIN-backed content with ``_(via STDIN)_`` when a
-    synthetic filename is available.
-
-    Args:
-        ctx: Processing context containing the path to display.
-
-    Returns:
-        Short Markdown label for per-file headings and guidance messages.
-    """
-    path: str = get_display_path(ctx)
-    code: str = markdown_code_span(path)
-
-    if ctx.run_options.stdin_mode and bool(ctx.run_options.stdin_filename):
-        return f"{code} _(via STDIN)_"
-
-    return code

--- a/src/topmark/presentation/shared/paths.py
+++ b/src/topmark/presentation/shared/paths.py
@@ -1,0 +1,68 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : paths.py
+#   file_relpath : src/topmark/presentation/shared/paths.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Shared human-facing path presentation helpers.
+
+This module contains frontend-neutral display helpers for path labels used by
+human-facing renderers. These helpers intentionally model presentation policy,
+not machine-readable path serialization.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from topmark.pipeline.context.model import ProcessingContext
+
+
+def get_display_path(
+    ctx: ProcessingContext,
+) -> str:
+    """Return the user-facing path to display for a processing result.
+
+    TopMark may process *content-on-STDIN* by writing it to a temporary file.
+    In that mode, `ProcessingContext.path` points at the temporary file on disk,
+    but users expect messages to refer to the logical filename supplied via
+    `--stdin-filename`.
+
+    This helper centralizes that policy so all human-facing renderers display
+    the same path labels.
+
+    Args:
+        ctx: Processing context to render.
+
+    Returns:
+        The logical filename in STDIN content mode, otherwise the actual file path.
+    """
+    if ctx.run_options.stdin_mode and bool(ctx.run_options.stdin_filename):
+        return ctx.run_options.stdin_filename
+    return str(ctx.path)
+
+
+def render_path_display_text(ctx: ProcessingContext) -> str:
+    """Render a short TEXT path label for headings and guidance messages.
+
+    This helper formats
+    [`get_display_path()`][topmark.presentation.shared.paths.get_display_path]
+    for human-facing TEXT output and annotates STDIN-backed content with `(via STDIN)`
+    when a synthetic filename is available.
+
+    Args:
+        ctx: Processing context containing the path to display.
+
+    Returns:
+        Short TEXT label for per-file headings and guidance messages.
+    """
+    path: str = get_display_path(ctx)
+    if ctx.run_options.stdin_mode and bool(ctx.run_options.stdin_filename):
+        return f"'{path}' (via STDIN)"
+
+    return f"'{path}'"

--- a/src/topmark/presentation/shared/pipeline.py
+++ b/src/topmark/presentation/shared/pipeline.py
@@ -97,30 +97,6 @@ class PipelineCommandHumanReport:
     apply_changes: bool
 
 
-def get_display_path(
-    r: ProcessingContext,
-) -> str:
-    """Return the user-facing path to display for a processing result.
-
-    TopMark may process *content-on-STDIN* by writing it to a temporary file.
-    In that mode, `ProcessingContext.path` points at the temporary file on disk,
-    but users expect messages to refer to the logical filename supplied via
-    `--stdin-filename`.
-
-    This helper centralizes that policy so all human-facing renderers (TEXT and
-    Markdown) display the same path labels.
-
-    Args:
-        r: Processing context to render.
-
-    Returns:
-        The logical filename in STDIN content mode, otherwise the actual file path.
-    """
-    if r.run_options.stdin_mode and bool(r.run_options.stdin_filename):
-        return r.run_options.stdin_filename
-    return str(r.path)
-
-
 def get_file_type_label(ctx: ProcessingContext) -> str | None:
     """Return the human-facing file-type label for a pipeline result.
 

--- a/src/topmark/presentation/text/pipeline.py
+++ b/src/topmark/presentation/text/pipeline.py
@@ -53,8 +53,9 @@ from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import WriteStatus
 from topmark.presentation.shared.outcomes import collect_outcome_counts_styled
 from topmark.presentation.shared.outcomes import get_outcome_style_role
+from topmark.presentation.shared.paths import get_display_path
+from topmark.presentation.shared.paths import render_path_display_text
 from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
-from topmark.presentation.shared.pipeline import get_display_path
 from topmark.presentation.shared.pipeline import get_file_type_label
 from topmark.presentation.text.diagnostic import render_diagnostics_text
 
@@ -82,30 +83,6 @@ _HINT_CLUSTER_STYLE_ROLE: Final[dict[str, StyleRole]] = {
     Cluster.BLOCKED_POLICY.value: StyleRole.BLOCKED_POLICY,
     Cluster.ERROR.value: StyleRole.ERROR,
 }
-
-
-# ---- Path rendering ----
-
-
-def _render_path_display_text(ctx: ProcessingContext) -> str:
-    """Render a short TEXT path label for guidance messages.
-
-    This helper formats
-    [`get_display_path()`][topmark.presentation.shared.pipeline.get_display_path]
-    for human-facing TEXT output and annotates STDIN-backed content with `(via STDIN)`
-    when a synthetic filename is available.
-
-    Args:
-        ctx: Processing context containing the path to display.
-
-    Returns:
-        Short TEXT label for guidance messages.
-    """
-    path: str = get_display_path(ctx)
-    if ctx.run_options.stdin_mode and bool(ctx.run_options.stdin_filename):
-        return f"'{path}' (via STDIN)"
-
-    return f"'{path}'"
 
 
 # ---- Hint rendering ----
@@ -220,6 +197,30 @@ def _render_pipeline_banner_text(
 # ---- Command guidance rendering ----
 
 
+def _render_apply_command_text(
+    *,
+    command: str,
+    ctx: ProcessingContext,
+) -> str:
+    """Render the suggested apply command for a processing context.
+
+    The command uses the shared human-facing display-path policy so STDIN-backed
+    content is represented by its logical `--stdin-filename` value while regular
+    file processing uses the normal display path.
+
+    Args:
+        command: TopMark subcommand name.
+        ctx: Processing context for the file.
+
+    Returns:
+        Suggested apply command for TEXT guidance output.
+    """
+    path_name: str = get_display_path(ctx)
+    if ctx.run_options.stdin_mode and ctx.run_options.stdin_filename:
+        return f"topmark {command} {CliOpt.APPLY_CHANGES} {CliOpt.STDIN_FILENAME} '{path_name}' -"
+    return f"topmark {command} {CliOpt.APPLY_CHANGES} '{path_name}'"
+
+
 def _render_check_guidance_message_text(
     ctx: ProcessingContext,
     apply_changes: bool,
@@ -240,8 +241,7 @@ def _render_check_guidance_message_text(
     if not effective_would_add_or_update(ctx):
         return None
 
-    path_label: str = _render_path_display_text(ctx)
-    path_name: str = get_display_path(ctx)
+    path_label: str = render_path_display_text(ctx)
     intent: Intent = determine_intent(ctx)
 
     if apply_changes:
@@ -258,12 +258,7 @@ def _render_check_guidance_message_text(
             else f"✏️  Updating header in {path_label}"
         )
 
-    if ctx.run_options.stdin_mode and ctx.run_options.stdin_filename:
-        apply_cmd: str = (
-            f"topmark {CliCmd.CHECK} {CliOpt.APPLY_CHANGES} {CliOpt.STDIN_FILENAME} '{path_name}' -"
-        )
-    else:
-        apply_cmd = f"topmark {CliCmd.CHECK} {CliOpt.APPLY_CHANGES} '{path_name}'"
+    apply_cmd: str = _render_apply_command_text(command=CliCmd.CHECK, ctx=ctx)
 
     if intent == Intent.INSERT:
         action: str = "add a TopMark header to this file"
@@ -296,8 +291,7 @@ def _render_strip_guidance_message_text(
     if not effective_would_strip(ctx):
         return None
 
-    path_label: str = _render_path_display_text(ctx)
-    path_name: str = get_display_path(ctx)
+    path_label: str = render_path_display_text(ctx)
     intent: Intent = determine_intent(ctx)
 
     if apply_changes:
@@ -310,12 +304,7 @@ def _render_strip_guidance_message_text(
 
         return f"🧹 Stripping header in {path_label}"
 
-    if ctx.run_options.stdin_mode and ctx.run_options.stdin_filename:
-        apply_cmd: str = (
-            f"topmark {CliCmd.STRIP} {CliOpt.APPLY_CHANGES} {CliOpt.STDIN_FILENAME} '{path_name}' -"
-        )
-    else:
-        apply_cmd = f"topmark {CliCmd.STRIP} {CliOpt.APPLY_CHANGES} '{path_name}'"
+    apply_cmd: str = _render_apply_command_text(command=CliCmd.STRIP, ctx=ctx)
 
     if intent == Intent.STRIP:
         action: str = "strip the TopMark header from this file"

--- a/src/topmark/presentation/text/probe.py
+++ b/src/topmark/presentation/text/probe.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from topmark.cli.presentation import TextStyler
 from topmark.cli.presentation import style_for_role
 from topmark.core.presentation import StyleRole
-from topmark.presentation.shared.pipeline import get_display_path
+from topmark.presentation.shared.paths import get_display_path
 from topmark.presentation.text.diagnostic import render_diagnostics_text
 
 if TYPE_CHECKING:

--- a/src/topmark/utils/path.py
+++ b/src/topmark/utils/path.py
@@ -67,5 +67,27 @@ def format_machine_path(path: Path) -> str:
 
     Machine-readable processing payloads use POSIX separators on all platforms
     so JSON and NDJSON output remain stable across operating systems.
+
+    Args:
+        path: Path to serialize.
+
+    Returns:
+        POSIX-style path string for machine-readable processing output.
+    """
+    return path.as_posix()
+
+
+def format_header_metadata_path(path: Path) -> str:
+    """Serialize a path for generated TopMark header metadata.
+
+    Header metadata is written into source files and should remain stable across
+    operating systems. Use POSIX separators for relative and absolute path
+    fields generated in TopMark headers.
+
+    Args:
+        path: Path to serialize.
+
+    Returns:
+        POSIX-style path string for generated header metadata.
     """
     return path.as_posix()

--- a/tests/pipeline/steps/test_patcher.py
+++ b/tests/pipeline/steps/test_patcher.py
@@ -42,6 +42,7 @@ from topmark.pipeline.views import DiffView
 from topmark.pipeline.views import ListFileImageView
 from topmark.pipeline.views import UpdatedView
 from topmark.presentation.formatters.unified_diff import format_patch_plain
+from topmark.runtime.model import RunOptions
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -235,3 +236,25 @@ def test_patcher_halts_when_comparison_status_is_pending(tmp_path: Path) -> None
     assert ctx.views.diff is None
     assert ctx.halt_state is not None
     assert ctx.halt_state.reason_code == "PatcherStep did not set state."
+
+
+def test_patcher_uses_stdin_filename_in_unified_diff_labels(tmp_path: Path) -> None:
+    """STDIN-backed diffs should label files with the logical stdin filename."""
+    ctx: ProcessingContext = _make_patcher_context(
+        tmp_path / "materialized-stdin.py",
+        image_lines=["old\n"],
+        updated_lines=["new\n"],
+        comparison_status=ComparisonStatus.CHANGED,
+    )
+    ctx.run_options = RunOptions(
+        stdin_mode=True,
+        stdin_filename="logical/input.py",
+    )
+
+    ctx = run_patcher(ctx)
+
+    diff_text: str = ctx.views.diff.text if ctx.views.diff and ctx.views.diff.text else ""
+    assert ctx.status.patch is PatchStatus.GENERATED
+    assert "--- logical/input.py (current)" in diff_text
+    assert "+++ logical/input.py (updated)" in diff_text
+    assert "materialized-stdin.py" not in diff_text

--- a/tests/presentation/test_pipeline_rendering.py
+++ b/tests/presentation/test_pipeline_rendering.py
@@ -38,10 +38,12 @@ from topmark.pipeline.status import PlanStatus
 from topmark.pipeline.status import ResolveStatus
 from topmark.pipeline.status import StripStatus
 from topmark.pipeline.views import DiffView
+from topmark.presentation.markdown.paths import render_path_display_markdown
 from topmark.presentation.markdown.pipeline import render_pipeline_apply_summary_markdown
 from topmark.presentation.markdown.pipeline import render_pipeline_output_markdown
+from topmark.presentation.shared.paths import get_display_path
+from topmark.presentation.shared.paths import render_path_display_text
 from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
-from topmark.presentation.shared.pipeline import get_display_path
 from topmark.presentation.shared.pipeline import get_file_type_label
 from topmark.presentation.text.pipeline import render_pipeline_apply_summary_text
 from topmark.presentation.text.pipeline import render_pipeline_output_text
@@ -117,6 +119,42 @@ def _add_diff(ctx: ProcessingContext) -> None:
     """Attach a deterministic unified diff to a context."""
     ctx.status.patch = PatchStatus.GENERATED
     ctx.views.diff = DiffView(text="--- old\n+++ new\n@@ -1 +1 @@\n-old\n+new\n")
+
+
+def test_render_path_display_text_uses_regular_display_path(tmp_path: Path) -> None:
+    """TEXT path labels should quote regular display paths without STDIN annotation."""
+    ctx: ProcessingContext = _make_context(tmp_path / "regular.py")
+
+    assert render_path_display_text(ctx) == f"'{ctx.path}'"
+
+
+def test_render_path_display_text_uses_stdin_filename(tmp_path: Path) -> None:
+    """TEXT path labels should show the logical stdin filename in STDIN mode."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "materialized-stdin.py",
+        stdin_mode=True,
+        stdin_filename="logical/input.py",
+    )
+
+    assert render_path_display_text(ctx) == "'logical/input.py' (via STDIN)"
+
+
+def test_render_path_display_markdown_uses_regular_display_path(tmp_path: Path) -> None:
+    """Markdown path labels should render regular display paths as code spans."""
+    ctx: ProcessingContext = _make_context(tmp_path / "regular.py")
+
+    assert render_path_display_markdown(ctx) == f"`{ctx.path}`"
+
+
+def test_render_path_display_markdown_uses_stdin_filename(tmp_path: Path) -> None:
+    """Markdown path labels should show the logical stdin filename in STDIN mode."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "materialized-stdin.py",
+        stdin_mode=True,
+        stdin_filename="logical/input.py",
+    )
+
+    assert render_path_display_markdown(ctx) == "`logical/input.py` _(via STDIN)_"
 
 
 def test_shared_display_path_uses_stdin_filename_for_stdin_context(tmp_path: Path) -> None:

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -1,0 +1,32 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_path.py
+#   file_relpath : tests/utils/test_path.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Unit tests for path utility helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from topmark.utils.path import format_header_metadata_path
+from topmark.utils.path import format_machine_path
+
+
+def test_format_header_metadata_path_uses_posix_separators() -> None:
+    """Header metadata paths should serialize using POSIX separators."""
+    path: Path = Path("src") / "topmark" / "presentation" / "shared" / "paths.py"
+
+    assert format_header_metadata_path(path) == "src/topmark/presentation/shared/paths.py"
+
+
+def test_format_machine_path_uses_posix_separators() -> None:
+    """Machine-output paths should serialize using POSIX separators."""
+    path: Path = Path("src") / "topmark" / "pipeline" / "machine" / "payloads.py"
+
+    assert format_machine_path(path) == "src/topmark/pipeline/machine/payloads.py"


### PR DESCRIPTION
## Summary

- centralizes path serialization and human-facing path presentation helpers
- adds explicit header-metadata path serialization
- moves shared display-path policy into `topmark.presentation.shared.paths`
- moves Markdown path-label rendering into `topmark.presentation.markdown.paths`
- updates unified diff labels to use human-facing display paths, including logical `--stdin-filename` values for STDIN-backed processing
- documents the boundary between machine-readable POSIX path serialization and human-facing path presentation
- adds regression coverage for header metadata paths, TEXT/Markdown path labels, and STDIN-backed diff labels

## Scope

This intentionally preserves the existing machine path contract boundaries. Config/provenance path-like values remain out of scope and are tracked separately by #89/#94.

Fixes #92.