### PR TITLE
Expand cross-platform path and discovery regression coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,9 @@ ______________________________________________________________________
 - Refreshed locked dependencies including Ruff, Hypothesis, and uv.
 - Added shared machine-path formatting helpers and regression coverage for Windows-style processing
   machine-output path serialization.
+- Expanded cross-platform filesystem regression coverage for machine-readable path serialization,
+  Windows and UNC path formatting, symlink discovery and deduplication, `--files-from -` processing,
+  configuration path resolution, and include-pattern discovery seeding behavior.
 - Centralized POSIX path-formatting helpers for machine-readable payloads, configuration/provenance
   serialization, and synthetic configuration-source formatting.
 - Added centralized filename-rule normalization and validation helpers.

--- a/tests/cli/machine/test_path_contracts_machine.py
+++ b/tests/cli/machine/test_path_contracts_machine.py
@@ -1,0 +1,214 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_path_contracts_machine.py
+#   file_relpath : tests/cli/machine/test_path_contracts_machine.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Cross-command machine path serialization contract tests.
+
+These tests complement the command-specific machine-output tests by checking
+the shared filesystem contract across representative CLI surfaces. Machine
+output must serialize path-like fields with stable POSIX separators, regardless
+of host platform or nested filesystem layout.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.cli.conftest import assert_SUCCESS
+from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
+from tests.cli.conftest import run_cli_in
+from tests.helpers.json import parse_json_object
+from tests.helpers.ndjson import parse_ndjson_records
+from tests.helpers.ndjson import record_payload
+from tests.helpers.paths import assert_machine_path
+from tests.helpers.paths import assert_machine_path_fields_are_posix
+from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
+from topmark.core.formats import OutputFormat
+from topmark.core.typing_guards import as_object_dict
+from topmark.core.typing_guards import is_any_list
+from topmark.core.typing_guards import is_mapping
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+
+def _write_python_file(path: Path) -> None:
+    """Write a tiny Python file at `path` for processing and probe tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("print('hello')\n", encoding="utf-8")
+
+
+def _write_minimal_config(path: Path) -> None:
+    """Write a minimal valid TopMark config file for config-dump tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        textwrap.dedent(
+            """\
+            [fields]
+            project = "Demo"
+
+            [header]
+            fields = ["project"]
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _processing_json_paths(payload: dict[str, object]) -> list[str]:
+    """Return validated per-result paths from a processing JSON payload."""
+    results_obj: object | None = payload.get("results")
+    assert is_any_list(results_obj)
+
+    paths: list[str] = []
+    for result_obj in results_obj:
+        assert is_mapping(result_obj)
+        result: dict[str, object] = as_object_dict(result_obj)
+        paths.append(assert_machine_path(result.get("path")))
+    return paths
+
+
+def _processing_ndjson_paths(records: list[dict[str, object]]) -> list[str]:
+    """Return validated per-result paths from processing NDJSON records."""
+    paths: list[str] = []
+    for record in records:
+        if record.get("kind") != "result":
+            continue
+        payload: dict[str, object] = record_payload(record)
+        paths.append(assert_machine_path(payload.get("path")))
+    return paths
+
+
+def _probe_json_paths(payload: dict[str, object]) -> list[str]:
+    """Return validated probe paths from a probe JSON payload."""
+    probes_obj: object | None = payload.get("probes")
+    assert is_any_list(probes_obj)
+
+    paths: list[str] = []
+    for probe_obj in probes_obj:
+        assert is_mapping(probe_obj)
+        probe: dict[str, object] = as_object_dict(probe_obj)
+        paths.append(assert_machine_path(probe.get("path")))
+    return paths
+
+
+def _probe_ndjson_paths(records: list[dict[str, object]]) -> list[str]:
+    """Return validated probe paths from probe NDJSON records."""
+    paths: list[str] = []
+    for record in records:
+        if record.get("kind") != "probe":
+            continue
+        payload: dict[str, object] = record_payload(record)
+        paths.append(assert_machine_path(payload.get("path")))
+    return paths
+
+
+@pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP])
+@pytest.mark.parametrize("output_format", [OutputFormat.JSON, OutputFormat.NDJSON])
+def test_processing_machine_output_serializes_nested_result_paths_as_posix(
+    tmp_path: Path,
+    command: str,
+    output_format: OutputFormat,
+) -> None:
+    """Processing JSON/NDJSON result paths should use POSIX nested paths."""
+    relative_path = "src/pkg/example.py"
+    _write_python_file(tmp_path / relative_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            CliOpt.OUTPUT_FORMAT,
+            output_format.value,
+            relative_path,
+        ],
+    )
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+
+    if output_format is OutputFormat.JSON:
+        payload: dict[str, object] = parse_json_object(result.output)
+        assert_machine_path_fields_are_posix(payload)
+        paths: list[str] = _processing_json_paths(payload)
+    else:
+        records: list[dict[str, object]] = parse_ndjson_records(result.output)
+        assert_machine_path_fields_are_posix(records)
+        paths = _processing_ndjson_paths(records)
+
+    assert paths == [relative_path]
+
+
+@pytest.mark.parametrize("output_format", [OutputFormat.JSON, OutputFormat.NDJSON])
+def test_probe_machine_output_serializes_nested_probe_paths_as_posix(
+    tmp_path: Path,
+    output_format: OutputFormat,
+) -> None:
+    """Probe JSON/NDJSON paths should preserve nested POSIX spellings."""
+    relative_path = "src/pkg/example.py"
+    _write_python_file(tmp_path / relative_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.PROBE,
+            relative_path,
+            CliOpt.OUTPUT_FORMAT,
+            output_format.value,
+        ],
+    )
+    assert_SUCCESS(result)
+
+    if output_format is OutputFormat.JSON:
+        payload: dict[str, object] = parse_json_object(result.output)
+        assert_machine_path_fields_are_posix(payload)
+        paths: list[str] = _probe_json_paths(payload)
+    else:
+        records: list[dict[str, object]] = parse_ndjson_records(result.output)
+        assert_machine_path_fields_are_posix(records)
+        paths = _probe_ndjson_paths(records)
+
+    assert paths == [relative_path]
+
+
+@pytest.mark.parametrize("output_format", [OutputFormat.JSON, OutputFormat.NDJSON])
+def test_config_dump_machine_output_serializes_nested_config_paths_as_posix(
+    tmp_path: Path,
+    output_format: OutputFormat,
+) -> None:
+    """Config dump JSON/NDJSON should serialize config provenance paths POSIX-style."""
+    relative_config = "config/workspace/topmark.toml"
+    _write_minimal_config(tmp_path / relative_config)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CONFIG,
+            CliCmd.CONFIG_DUMP,
+            CliOpt.CONFIG_FILES,
+            relative_config,
+            CliOpt.SHOW_CONFIG_LAYERS,
+            CliOpt.OUTPUT_FORMAT,
+            output_format.value,
+        ],
+    )
+    assert_SUCCESS(result)
+
+    if output_format is OutputFormat.JSON:
+        payload: dict[str, object] = parse_json_object(result.output)
+        paths: list[str] = assert_machine_path_fields_are_posix(payload)
+    else:
+        records: list[dict[str, object]] = parse_ndjson_records(result.output)
+        paths = assert_machine_path_fields_are_posix(records)
+
+    assert any(path.endswith(relative_config) for path in paths)

--- a/tests/cli/test_stdin_lists.py
+++ b/tests/cli/test_stdin_lists.py
@@ -20,22 +20,85 @@ Invalid STDIN mode combinations are covered in `tests/cli/test_stdin_errors.py`.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from click.testing import Result
 
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_WOULD_CHANGE
 from tests.cli.conftest import run_cli_in
+from tests.helpers.json import parse_json_object
+from tests.helpers.ndjson import parse_ndjson_records
+from tests.helpers.ndjson import record_payload
+from tests.helpers.paths import assert_machine_path
+from tests.helpers.paths import assert_machine_path_fields_are_posix
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
+from topmark.core.formats import OutputFormat
+from topmark.core.typing_guards import as_object_dict
+from topmark.core.typing_guards import is_any_list
+from topmark.core.typing_guards import is_mapping
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from click.testing import Result
+
+# --- helpers ---
+
+
+def _write_python_file(path: Path) -> None:
+    """Write a tiny Python source file at `path`."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("print('hello')\n", encoding="utf-8")
+
+
+def _json_result_paths(payload: dict[str, object]) -> list[str]:
+    """Return validated result paths from a processing JSON payload."""
+    results_obj: object | None = payload.get("results")
+    assert is_any_list(results_obj)
+
+    paths: list[str] = []
+    for result_obj in results_obj:
+        assert is_mapping(result_obj)
+        result: dict[str, object] = as_object_dict(result_obj)
+        paths.append(assert_machine_path(result.get("path")))
+    return paths
+
+
+def _ndjson_result_paths(records: list[dict[str, object]]) -> list[str]:
+    """Return validated result paths from processing NDJSON records."""
+    paths: list[str] = []
+    for record in records:
+        if record.get("kind") != "result":
+            continue
+        payload: dict[str, object] = record_payload(record)
+        paths.append(assert_machine_path(payload.get("path")))
+    return paths
+
+
+def _json_probe_paths(payload: dict[str, object]) -> list[str]:
+    """Return validated probe paths from a probe JSON payload."""
+    probes_obj: object | None = payload.get("probes")
+    assert is_any_list(probes_obj)
+
+    paths: list[str] = []
+    for probe_obj in probes_obj:
+        assert is_mapping(probe_obj)
+        probe: dict[str, object] = as_object_dict(probe_obj)
+        paths.append(assert_machine_path(probe.get("path")))
+    return paths
+
+
+def _ndjson_probe_paths(records: list[dict[str, object]]) -> list[str]:
+    """Return validated probe paths from probe NDJSON records."""
+    paths: list[str] = []
+    for record in records:
+        if record.get("kind") != "probe":
+            continue
+        payload: dict[str, object] = record_payload(record)
+        paths.append(assert_machine_path(payload.get("path")))
+    return paths
 
 
 # --- File-list STDIN mode ---
@@ -69,6 +132,82 @@ def test_files_from_stdin_reads_newline_delimited_paths(
         assert_WOULD_CHANGE(result)
     else:
         assert_SUCCESS(result)
+
+
+# --- Machine output path serialization tests ---
+
+
+@pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP])
+@pytest.mark.parametrize("output_format", [OutputFormat.JSON, OutputFormat.NDJSON])
+def test_files_from_stdin_machine_output_serializes_nested_paths_as_posix(
+    tmp_path: Path,
+    command: str,
+    output_format: OutputFormat,
+) -> None:
+    """Machine output for `--files-from -` should keep nested paths POSIX-style."""
+    relative_path = "src/pkg/listed.py"
+    _write_python_file(tmp_path / relative_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            CliOpt.FILES_FROM,
+            "-",
+            CliOpt.OUTPUT_FORMAT,
+            output_format.value,
+        ],
+        input_text=f"{relative_path}\n",
+    )
+    if command == CliCmd.CHECK:
+        assert_WOULD_CHANGE(result)
+    else:
+        assert_SUCCESS(result)
+
+    if output_format is OutputFormat.JSON:
+        payload: dict[str, object] = parse_json_object(result.output)
+        assert_machine_path_fields_are_posix(payload)
+        paths: list[str] = _json_result_paths(payload)
+    else:
+        records: list[dict[str, object]] = parse_ndjson_records(result.output)
+        assert_machine_path_fields_are_posix(records)
+        paths = _ndjson_result_paths(records)
+
+    assert paths == [relative_path]
+
+
+@pytest.mark.parametrize("output_format", [OutputFormat.JSON, OutputFormat.NDJSON])
+def test_probe_files_from_stdin_machine_output_serializes_nested_paths_as_posix(
+    tmp_path: Path,
+    output_format: OutputFormat,
+) -> None:
+    """Probe machine output should serialize paths loaded from STDIN as POSIX."""
+    relative_path = "src/pkg/listed.py"
+    _write_python_file(tmp_path / relative_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.PROBE,
+            CliOpt.FILES_FROM,
+            "-",
+            CliOpt.OUTPUT_FORMAT,
+            output_format.value,
+        ],
+        input_text=f"{relative_path}\n",
+    )
+    assert_SUCCESS(result)
+
+    if output_format is OutputFormat.JSON:
+        payload: dict[str, object] = parse_json_object(result.output)
+        assert_machine_path_fields_are_posix(payload)
+        paths: list[str] = _json_probe_paths(payload)
+    else:
+        records: list[dict[str, object]] = parse_ndjson_records(result.output)
+        assert_machine_path_fields_are_posix(records)
+        paths = _ndjson_probe_paths(records)
+
+    assert paths == [relative_path]
 
 
 # --- Pattern-list STDIN mode: include filters ---

--- a/tests/config/test_config_resolution_paths.py
+++ b/tests/config/test_config_resolution_paths.py
@@ -21,6 +21,9 @@ These tests exercise:
 
 from __future__ import annotations
 
+import os
+import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -34,8 +37,6 @@ from topmark.config.resolution.bridge import resolve_toml_sources_and_build_muta
 from topmark.resolution.files import resolve_file_list_with_diagnostics
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from topmark.config.model import MutableConfig
     from topmark.config.resolution.bridge import ResolvedConfigDraft
     from topmark.config.types import PatternSource
@@ -301,6 +302,44 @@ def test_config_seeding_globs_when_no_inputs_and_cwd_differs(
 
 
 @pytest.mark.config
+def test_include_patterns_seed_candidates_when_no_files_are_configured(
+    tmp_path: Path,
+) -> None:
+    """Config include patterns should seed discovery without explicit files.
+
+    include_patterns should seed candidates even when no files are configured.
+    """
+    proj: Path = tmp_path / "proj"
+    src: Path = proj / "src"
+    src.mkdir(parents=True)
+    py: Path = src / "seeded.py"
+    txt: Path = src / "ignored.txt"
+    py.write_text("print('ok')\n", encoding="utf-8")
+    txt.write_text("ignored\n", encoding="utf-8")
+
+    write_toml_document(
+        path=proj / "pyproject.toml",
+        content="""
+            [tool.topmark.header]
+            relative_to = "."
+
+            [tool.topmark.files]
+            include_patterns = ["src/**/*.py"]
+        """,
+    )
+
+    resolved_config: ResolvedConfigDraft = resolve_toml_sources_and_build_mutable_config(
+        input_paths=[],
+        extra_config_files=[proj / "pyproject.toml"],
+    )
+    resolution: FileListResolution = resolve_file_list_with_diagnostics(
+        resolved_config.draft.freeze()
+    )
+
+    assert list(resolution.selected) == [py.resolve()]
+
+
+@pytest.mark.config
 def test_files_from_declared_in_config_normalizes_to_patternsource(
     tmp_path: Path,
 ) -> None:
@@ -323,3 +362,110 @@ def test_files_from_declared_in_config_normalizes_to_patternsource(
     ps: PatternSource = draft.files_from[0]
     assert ps.path == lst.resolve()
     assert ps.base == proj.resolve()
+
+
+@pytest.mark.config
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows drive semantics only")
+def test_cli_path_options_resolve_from_windows_drive_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI path-to-file options should resolve against a Windows drive CWD."""
+    cwd: Path = tmp_path / "work"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    pattern_file: Path = cwd / "files.txt"
+    pattern_file.write_text("src/a.py\n", encoding="utf-8")
+
+    draft: MutableConfig = mutable_config_from_defaults()
+    overrides = ConfigOverrides(
+        files_from=["files.txt"],
+        include_from=["files.txt"],
+        exclude_from=["files.txt"],
+    )
+    apply_config_overrides(draft, overrides)
+
+    assert draft.files_from
+    assert draft.include_from
+    assert draft.exclude_from
+    for pattern_source in (*draft.files_from, *draft.include_from, *draft.exclude_from):
+        assert pattern_source.path == pattern_file.resolve()
+        assert pattern_source.base == cwd.resolve()
+        assert pattern_source.path.drive == cwd.resolve().drive
+
+
+@pytest.mark.config
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows drive semantics only")
+def test_relative_to_resolves_against_windows_config_drive(
+    tmp_path: Path,
+) -> None:
+    """`relative_to` should resolve against the config file's Windows drive."""
+    proj: Path = tmp_path / "proj"
+    workspace: Path = proj / "workspace"
+    workspace.mkdir(parents=True)
+
+    write_toml_document(
+        path=proj / "pyproject.toml",
+        content="""
+            [tool.topmark.header]
+            relative_to = "workspace"
+        """,
+    )
+
+    draft: MutableConfig = draft_from_topmark_toml_file(proj / "pyproject.toml")
+
+    assert draft.relative_to == workspace.resolve()
+    assert draft.relative_to is not None
+    assert draft.relative_to.drive == workspace.resolve().drive
+
+
+@pytest.mark.config
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows drive semantics only")
+def test_config_file_discovery_accepts_windows_absolute_input_path(
+    tmp_path: Path,
+) -> None:
+    """Config discovery should accept absolute Windows input paths."""
+    proj: Path = tmp_path / "proj"
+    src: Path = proj / "src"
+    src.mkdir(parents=True)
+
+    write_toml_document(
+        path=proj / "pyproject.toml",
+        content="""
+            [tool.topmark.header]
+            relative_to = "."
+        """,
+    )
+
+    resolved_config: ResolvedConfigDraft = resolve_toml_sources_and_build_mutable_config(
+        input_paths=[src.resolve()],
+    )
+
+    assert resolved_config.draft.relative_to == proj.resolve()
+    assert resolved_config.draft.relative_to is not None
+    assert resolved_config.draft.relative_to.drive == proj.resolve().drive
+
+
+@pytest.mark.config
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows absolute path semantics only")
+def test_config_resolution_preserves_absolute_cli_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Absolute CLI path options should not be rebased onto the invocation CWD."""
+    cwd: Path = tmp_path / "work"
+    absolute_file: Path = (
+        Path(os.environ.get("SYSTEMDRIVE", cwd.drive)) / "topmark-test" / "patterns.txt"
+    )
+    monkeypatch.chdir(cwd)
+
+    draft: MutableConfig = mutable_config_from_defaults()
+    overrides = ConfigOverrides(include_from=[str(absolute_file)])
+    apply_config_overrides(draft, overrides)
+
+    assert draft.include_from
+    ps: PatternSource = draft.include_from[0]
+    assert ps.path == absolute_file.resolve(strict=False)
+    assert ps.path.is_absolute()
+    assert ps.path.drive == absolute_file.drive

--- a/tests/config/test_config_resolution_paths.py
+++ b/tests/config/test_config_resolution_paths.py
@@ -21,9 +21,7 @@ These tests exercise:
 
 from __future__ import annotations
 
-import os
 import sys
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -37,6 +35,8 @@ from topmark.config.resolution.bridge import resolve_toml_sources_and_build_muta
 from topmark.resolution.files import resolve_file_list_with_diagnostics
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from topmark.config.model import MutableConfig
     from topmark.config.resolution.bridge import ResolvedConfigDraft
     from topmark.config.types import PatternSource
@@ -455,9 +455,10 @@ def test_config_resolution_preserves_absolute_cli_path(
 ) -> None:
     """Absolute CLI path options should not be rebased onto the invocation CWD."""
     cwd: Path = tmp_path / "work"
-    absolute_file: Path = (
-        Path(os.environ.get("SYSTEMDRIVE", cwd.drive)) / "topmark-test" / "patterns.txt"
-    )
+    cwd.mkdir()
+    absolute_file: Path = tmp_path / "absolute" / "patterns.txt"
+    absolute_file.parent.mkdir(parents=True)
+    absolute_file.write_text("src/a.py\n", encoding="utf-8")
     monkeypatch.chdir(cwd)
 
     draft: MutableConfig = mutable_config_from_defaults()

--- a/tests/helpers/paths.py
+++ b/tests/helpers/paths.py
@@ -1,0 +1,130 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : paths.py
+#   file_relpath : tests/helpers/paths.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Shared path assertions for machine-readable output tests.
+
+The helpers in this module keep path-contract tests focused on behavior while
+still validating nested JSON/NDJSON payloads recursively. They intentionally
+assert only the stable machine-output contract: path-like string fields must be
+serialized with POSIX separators and must therefore not contain backslashes.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from topmark.core.typing_guards import as_object_dict
+from topmark.core.typing_guards import is_any_list
+from topmark.core.typing_guards import is_mapping
+
+MACHINE_PATH_FIELD_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "path",
+        "config_files",
+        "origin",
+        "scope_root",
+    }
+)
+
+
+def assert_machine_path(value: object, *, expected: str | None = None) -> str:
+    """Assert that a machine path string uses POSIX separators.
+
+    Args:
+        value: Candidate machine-path value.
+        expected: Optional exact string expected for the path.
+
+    Returns:
+        The validated path string.
+
+    Raises:
+        AssertionError: If `value` is not a string, contains a backslash, or
+            does not equal `expected` when an expected value is supplied.
+    """
+    assert isinstance(value, str), f"machine path must be a string, got {value!r}"
+    assert "\\" not in value, f"machine path must use POSIX separators: {value!r}"
+
+    if expected is not None:
+        assert value == expected
+
+    return value
+
+
+def assert_machine_path_value(value: object) -> list[str]:
+    """Assert one path-like machine value and return all path strings found.
+
+    Path-like fields may either be a single string or a list of strings, for
+    example `path` versus `config_files`.
+
+    Args:
+        value: Candidate path-like value.
+
+    Returns:
+        Validated path strings found in `value`.
+
+    Raises:
+        AssertionError: If the value is neither a string nor a list of path
+            strings, or if any path string uses non-POSIX separators.
+    """
+    if isinstance(value, str):
+        return [assert_machine_path(value)]
+
+    assert is_any_list(value), f"machine path field must be a string or list: {value!r}"
+
+    paths: list[str] = []
+    for item in value:
+        paths.append(assert_machine_path(item))
+    return paths
+
+
+def assert_machine_path_fields_are_posix(
+    payload: object,
+    *,
+    path_field_names: frozenset[str] = MACHINE_PATH_FIELD_NAMES,
+) -> list[str]:
+    """Assert POSIX serialization for path-like fields in a machine payload.
+
+    The traversal is recursive and intentionally schema-light so that it can be
+    reused across processing, probe, config, and registry machine-output tests.
+
+    Args:
+        payload: Parsed JSON/NDJSON payload object to inspect.
+        path_field_names: Field names whose values should be treated as
+            machine-path strings or lists of machine-path strings.
+
+    Returns:
+        All validated path strings found under matching path-like field names.
+
+    Raises:
+        AssertionError: If a matching path-like field contains an invalid value
+            or a string with non-POSIX separators.
+    """
+    paths: list[str] = []
+    _collect_machine_path_fields(payload, path_field_names, paths)
+    return paths
+
+
+def _collect_machine_path_fields(
+    value: object,
+    path_field_names: frozenset[str],
+    paths: list[str],
+) -> None:
+    """Collect and validate path-like fields from a parsed machine payload."""
+    if is_mapping(value):
+        mapping: dict[str, object] = as_object_dict(value)
+        for key, item in mapping.items():
+            if key in path_field_names and item is not None:
+                paths.extend(assert_machine_path_value(item))
+            _collect_machine_path_fields(item, path_field_names, paths)
+        return
+
+    if is_any_list(value):
+        for item in value:
+            _collect_machine_path_fields(item, path_field_names, paths)

--- a/tests/unit/test_resolve_file_list.py
+++ b/tests/unit/test_resolve_file_list.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 import topmark.resolution.files as file_resolver_mod
 
 # Import the module under test
@@ -31,8 +33,6 @@ from topmark.registry.filetypes import FileTypeRegistry
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    import pytest
 
     from topmark.config.model import FrozenConfig
     from topmark.filetypes.model import FileType
@@ -85,6 +85,30 @@ def write(p: Path, text: str = "") -> Path:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(text, encoding="utf-8")
     return p
+
+
+def symlink_or_skip(
+    link: Path,
+    target: Path,
+    *,
+    target_is_directory: bool = False,
+) -> Path:
+    """Create a symlink or skip when the platform disallows symlinks.
+
+    Args:
+        link: Symlink path to create.
+        target: Symlink target.
+        target_is_directory: Whether `target` is a directory.
+
+    Returns:
+        The created symlink path.
+    """
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation is not available in this test environment: {exc}")
+    return link
 
 
 def resolve_selected(config: FrozenConfig) -> list[Path]:
@@ -700,6 +724,64 @@ def test_deduplicates_mixed_absolute_and_relative(
     rel: list[str] = [p.as_posix() for p in resolve_selected(cfg)]
     # Only one instance should remain
     assert rel == ["pkg/a.py"]
+
+
+def test_symlinked_file_input_resolves_to_canonical_target_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A symlinked file input should dedupe by real path and report the target."""
+    target: Path = write(tmp_path / "real" / "source.py", "x")
+    symlink_or_skip(tmp_path / "links" / "source-link.py", target)
+
+    monkeypatch.chdir(tmp_path)
+    cfg: FrozenConfig = make_frozen_config(files=["links/source-link.py"])
+
+    rel: list[str] = [p.as_posix() for p in resolve_selected(cfg)]
+
+    assert rel == ["real/source.py"]
+
+
+def test_symlinked_directory_input_resolves_descendants_to_canonical_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A symlinked directory input should report discovered target paths."""
+    target_dir: Path = tmp_path / "real-src"
+    write(target_dir / "pkg" / "module.py", "x")
+    symlink_or_skip(
+        tmp_path / "linked-src",
+        target_dir,
+        target_is_directory=True,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    cfg: FrozenConfig = make_frozen_config(files=["linked-src"])
+
+    rel: list[str] = [p.as_posix() for p in resolve_selected(cfg)]
+
+    assert rel == ["real-src/pkg/module.py"]
+
+
+def test_real_file_and_symlink_input_are_deduplicated_by_real_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real and symlink spellings of the same file should select one target."""
+    target: Path = write(tmp_path / "real" / "source.py", "x")
+    symlink_or_skip(tmp_path / "links" / "source-link.py", target)
+
+    monkeypatch.chdir(tmp_path)
+    cfg: FrozenConfig = make_frozen_config(
+        files=[
+            "real/source.py",
+            "links/source-link.py",
+        ],
+    )
+
+    rel: list[str] = [p.as_posix() for p in resolve_selected(cfg)]
+
+    assert rel == ["real/source.py"]
 
 
 def test_multiple_unknown_file_types_warn_once(

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -13,7 +13,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
+from typing import cast
 
 import pytest
 
@@ -83,6 +85,37 @@ def test_format_posix_path_uses_posix_separators(path: Path, expected: str) -> N
 
 
 @pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        pytest.param(
+            PureWindowsPath(r"C:\Repo\src\topmark\pipeline\machine\payloads.py"),
+            "C:/Repo/src/topmark/pipeline/machine/payloads.py",
+            id="drive-absolute",
+        ),
+        pytest.param(
+            PureWindowsPath(r"D:\Workspace\docs\usage\machine-output.md"),
+            "D:/Workspace/docs/usage/machine-output.md",
+            id="different-drive-absolute",
+        ),
+        pytest.param(
+            PureWindowsPath(r"\\server\share\project\src\example.py"),
+            "//server/share/project/src/example.py",
+            id="unc-share",
+        ),
+    ],
+)
+def test_format_posix_path_handles_windows_path_spellings(
+    path: PureWindowsPath,
+    expected: str,
+) -> None:
+    """Generic POSIX formatting should handle Windows-native path spellings."""
+    # `format_posix_path()` intentionally requires only the Path.as_posix()
+    # behavior. Cast the pure Windows path so this contract is exercised on
+    # every host platform without requiring a real Windows filesystem path.
+    assert format_posix_path(cast("Path", path)) == expected
+
+
+@pytest.mark.parametrize(
     ("formatter", "path", "expected"),
     [
         (
@@ -107,11 +140,72 @@ def test_semantic_path_formatters_use_posix_separators(
     assert formatter(path) == expected
 
 
+@pytest.mark.parametrize(
+    ("formatter", "path", "expected"),
+    [
+        pytest.param(
+            format_header_metadata_path,
+            PureWindowsPath(r"C:\Repo\src\topmark\__main__.py"),
+            "C:/Repo/src/topmark/__main__.py",
+            id="header-metadata-drive-path",
+        ),
+        pytest.param(
+            format_machine_path,
+            PureWindowsPath(r"D:\Workspace\pkg\module.py"),
+            "D:/Workspace/pkg/module.py",
+            id="machine-different-drive-path",
+        ),
+        pytest.param(
+            format_machine_path,
+            PureWindowsPath(r"\\server\share\pkg\module.py"),
+            "//server/share/pkg/module.py",
+            id="machine-unc-path",
+        ),
+    ],
+)
+def test_semantic_path_formatters_handle_windows_path_spellings(
+    formatter: Callable[[Path], str],
+    path: PureWindowsPath,
+    expected: str,
+) -> None:
+    """Semantic path formatters should normalize Windows spellings to POSIX."""
+    # `format_machine_path()` and `format_header_metadata_path()` delegate to
+    # `.as_posix()`. Cast the pure Windows path to cover cross-platform
+    # serialization without requiring host-specific path objects.
+    assert formatter(cast("Path", path)) == expected
+
+
 def test_format_config_source_path_uses_posix_separators_for_real_paths() -> None:
     """Real config source paths should serialize using POSIX separators."""
     path: Path = Path("config") / "workspace" / "topmark.toml"
 
     assert format_config_source_path(path) == "config/workspace/topmark.toml"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        pytest.param(
+            PureWindowsPath(r"C:\Repo\topmark.toml"),
+            "C:/Repo/topmark.toml",
+            id="drive-absolute",
+        ),
+        pytest.param(
+            PureWindowsPath(r"\\server\share\topmark.toml"),
+            "//server/share/topmark.toml",
+            id="unc-share",
+        ),
+    ],
+)
+def test_format_config_source_path_handles_windows_path_spellings(
+    path: PureWindowsPath,
+    expected: str,
+) -> None:
+    """Real config source paths should normalize Windows spellings to POSIX."""
+    # `format_config_source_path()` accepts real filesystem paths and synthetic
+    # labels. Cast the pure Windows path so Windows serialization is covered on
+    # every host platform.
+    assert format_config_source_path(cast("Path", path)) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Addresses #91 by expanding regression coverage around TopMark's documented
cross-platform filesystem and path-handling contracts.

This PR is intentionally tests-only and does not modify production behavior.

## Added coverage

### Machine-readable path serialization

Added dedicated machine-output contract tests covering:

- `check` JSON and NDJSON output
- `strip` JSON and NDJSON output
- `probe` JSON and NDJSON output
- `config dump` JSON and NDJSON output
- `--files-from -` processing and probe workflows

These tests verify stable POSIX-style machine path serialization regardless of
host platform.

### Shared path assertion helpers

Added:

- `tests/helpers/paths.py`

to centralize machine-path contract assertions and reduce duplication across
machine-output tests.

### Windows and UNC path formatting

Extended path formatter coverage for:

- Windows drive-letter paths
- alternate drive paths
- UNC-style path spellings
- machine path formatting
- header metadata path formatting
- config source path formatting

### Resolver and discovery behavior

Added coverage for:

- symlinked file inputs
- symlinked directory inputs
- real-path and symlink deduplication
- include-pattern discovery seeding without explicit file inputs

### Configuration path resolution

Added Windows-specific tests covering:

- CLI path-option resolution
- `relative_to` resolution
- config discovery from absolute paths
- preservation of absolute CLI path options

## Notes

- No production code changes.
- No user-visible behavior changes.
- Focused entirely on regression protection for documented filesystem and
  path-serialization contracts.

Closes #91.