### PR TITLE
Define filesystem identity policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ ______________________________________________________________________
 - Extended the POSIX path-serialization contract to configuration machine-output payloads,
   TOML/config provenance payloads, configuration-export serialization, and configuration diagnostic
   summaries.
+- Defined TopMark's filesystem identity policy for existing processing inputs as resolved
+  processing-target identity rather than raw invocation spelling.
+- Standardized symlink handling so file symlink spellings and their targets collapse to one selected
+  processing path before runtime probing, processing, header metadata generation, and
+  machine-readable output.
+- Defined configuration-source identity for file-backed TOML sources using the resolved
+  configuration-file target for precedence, scope applicability, layered provenance, and
+  machine-readable configuration provenance.
 
 ### Breaking Changes - Unreleased
 
@@ -106,6 +114,12 @@ ______________________________________________________________________
   provenance payloads, configuration export output, and configuration diagnostic summaries by
   normalizing real filesystem paths to POSIX-style **/** separators on all platforms while
   preserving synthetic configuration-source identifiers as stable labels.
+- Fixed undocumented symlink and filesystem-identity behavior by making resolved processing-target
+  identity explicit in file discovery, configuration resolution, pipelines, generated header
+  metadata, public API behavior, and machine-readable output.
+- Fixed ambiguity around symlinked configuration files by documenting and testing that provenance,
+  precedence, and scope applicability use the resolved configuration target rather than the symlink
+  spelling.
 
 ### Documentation - Unreleased
 
@@ -135,6 +149,13 @@ ______________________________________________________________________
   JSON/NDJSON path fields.
 - Documented and aligned the recommended VS Code workspace tooling configuration around Pylance,
   `mdformat`, Run On Save integration, and project-maintained task entry points.
+- Documented filesystem identity, processing-path selection, symlink handling, and the boundary
+  between identity selection and machine-readable path serialization across user, API, and developer
+  documentation.
+- Documented configuration-source identity and symlinked configuration-file behavior across
+  configuration discovery, configuration schema, machine-output, command, and API documentation.
+- Documented that hard-link detection and device/inode-based filesystem identity are outside the
+  current compatibility contract.
 
 ### Internal - Unreleased
 
@@ -158,6 +179,11 @@ ______________________________________________________________________
   recommendations, task definitions, and Markdown formatting integration.
 - Added lightweight pre-commit hygiene checks for documentation hygiene, code-documentation hygiene,
   and docstring link validation to better align local workflows with Nox validation.
+- Added `canonical_processing_path()` as the named helper for TopMark's resolved processing-target
+  filesystem identity policy.
+- Added regression coverage for symlinked file inputs, symlinked directory behavior, broken symlink
+  diagnostics, generated header metadata for symlinked inputs, configuration-source identity,
+  layered provenance, public machine output, and processing-path serialization.
 
 ### Notes - Unreleased
 
@@ -176,6 +202,10 @@ ______________________________________________________________________
   with code `3` instead of `2` so automation can distinguish dry-run change signals from Click
   parser-level usage errors. Existing CI jobs, shell scripts, and tests that checked for exit code
   `2` must be updated.
+- TopMark now documents resolved processing-target identity as the filesystem identity model for
+  existing processing inputs. Symlink spellings are not preserved for runtime processing identity,
+  generated filesystem-related header metadata, or machine-readable path fields; consumers that need
+  the exact invocation spelling should retain it outside TopMark's processing result payloads.
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ It helps teams avoid fragile one-off scripts by providing:
 - layered configuration and policy controls;
 - dry-run-by-default safety;
 - stable CI-friendly exit codes;
-- machine-readable output formats;
+- machine-readable output formats with stable cross-platform path serialization;
 - transparent file-type resolution diagnostics;
+- deterministic filesystem-identity and configuration-source resolution;
 - configuration, registry, and file-resolution introspection commands;
 - and a public Python API for automation and integration.
 
@@ -114,7 +115,8 @@ TopMark is useful when you need to:
 - inspect why a file was included, excluded, or matched to a specific processor;
 - integrate header checks into CI, pre-commit, Git hooks, or custom automation;
 - consume deterministic JSON or NDJSON output from scripts and tooling, with stable machine-readable
-  path serialization and canonical cross-platform registry metadata.
+  path serialization, processing-path semantics, configuration provenance, and canonical
+  cross-platform registry metadata.
 
 The goal is not to replace formatters, linters, or license scanners. TopMark focuses on one job:
 safe, deterministic, comment-aware file header management.
@@ -141,9 +143,11 @@ ______________________________________________________________________
 - Idempotent behavior designed for repeatable CI and repository automation
 - Layered configuration via `topmark.toml`, `pyproject.toml`, user config, explicit config files,
   and CLI overrides
+- Deterministic configuration-source identity and layered provenance reporting
 - Policy controls for insertion, update, empty-file behavior, file-type filtering, and content
   probing
 - Resolution diagnostics with `topmark probe`
+- Deterministic filesystem-identity normalization and processing-path selection
 - Layered configuration inspection with `topmark config dump --show-layers`
 - Registry introspection with `topmark registry filetypes`, `topmark registry processors`, and
   `topmark registry bindings`
@@ -261,6 +265,11 @@ topmark config dump --show-layers
 topmark registry filetypes
 ```
 
+TopMark normalizes filesystem identity before runtime processing. If multiple path spellings resolve
+to the same filesystem target (for example a symlink and its target), TopMark selects a processing
+path and processes the target once. Machine-readable output and generated filesystem-related header
+metadata follow this processing-path contract.
+
 All available commands, shared options, output formats, STDIN behavior, and exit codes are
 documented in:
 
@@ -307,6 +316,10 @@ Common configuration sources include:
 - explicit `--config` files
 - CLI options
 
+Configuration discovery uses configuration-source identity based on resolved configuration-file
+targets. Layered configuration provenance, applicability evaluation, and precedence therefore behave
+consistently when configuration files are accessed through symlinks.
+
 A minimal project configuration looks like this:
 
 ```toml
@@ -340,6 +353,7 @@ Detailed configuration, policy, and filtering behavior is documented in:
 - [Configuration discovery and precedence (hosted docs)](https://topmark.readthedocs.io/en/latest/configuration/discovery/)
 - [Policy guide (hosted docs)](https://topmark.readthedocs.io/en/latest/usage/policies/)
 - [Filtering (hosted docs)](https://topmark.readthedocs.io/en/latest/usage/filtering/)
+- [Machine-readable output (hosted docs)](https://topmark.readthedocs.io/en/latest/usage/machine-output/)
 - [Example TOML document](https://github.com/shutterfreak/topmark/blob/main/src/topmark/toml/topmark.example.toml)
 
 ______________________________________________________________________
@@ -370,7 +384,7 @@ topmark config check --strict
 topmark check .
 ```
 
-Exit code `2` means files would require header updates.
+Exit code `3` means files would require header updates.
 
 Detailed integration guidance is documented in:
 
@@ -388,6 +402,9 @@ discovery.
 
 Public API callers should use the functions and DTOs exposed from `topmark.api`. Runtime helpers,
 resolver internals, and pipeline contexts are implementation details.
+
+Public API operations follow the same filesystem-identity, processing-path, and configuration-source
+identity contracts as the CLI.
 
 Example dry-run check:
 

--- a/docs/_snippets/path-serialization-contract.md
+++ b/docs/_snippets/path-serialization-contract.md
@@ -15,6 +15,11 @@ topmark:header:end
 > TopMark serializes machine-readable filesystem path fields with POSIX `/` separators on all
 > platforms.
 >
+> Path serialization is a presentation contract and is distinct from filesystem identity.
+>
+> TopMark first determines a canonical processing path for the filesystem target being processed and
+> then serializes that processing path according to the machine-output contract.
+>
 > This contract applies to:
 >
 > - header metadata path fields;
@@ -22,6 +27,20 @@ topmark:header:end
 > - probe machine-output payloads;
 > - configuration machine-output payloads; and
 > - TOML/config provenance payloads.
+>
+> Examples:
+>
+> ```text
+> real/file.py
+> ./real/file.py
+> link-to-file.py
+> ```
+>
+> may refer to the same filesystem identity and therefore produce the same serialized processing
+> path.
+>
+> TopMark currently defines filesystem identity using the resolved processing target path. Hard-link
+> detection and device/inode-based identity are outside the current compatibility contract.
 >
 > Human-facing output follows display-path policy instead:
 >

--- a/docs/_snippets/runtime-configuration-model.md
+++ b/docs/_snippets/runtime-configuration-model.md
@@ -13,15 +13,26 @@ topmark:header:end
 TopMark intentionally separates:
 
 1. TOML-source loading
+1. configuration-source identity normalization
 1. staged configuration-loading validation
 1. layered configuration deserialization and merging
 1. runtime configuration resolution
 1. runtime overlay application
 1. runtime policy evaluation
+1. filesystem-identity normalization and processing-path selection
 1. runtime pipeline gatekeeping and execution
+
+Configuration-source identity and filesystem identity are intentionally distinct.
+
+File-backed configuration sources are normalized to resolved configuration targets before
+precedence, scope applicability, and layered provenance evaluation. Runtime file processing
+similarly operates on selected processing paths derived from filesystem-identity normalization and
+deduplication.
+
+These normalization stages occur before runtime policy evaluation and pipeline execution.
 
 Reporting, API surfaces, and machine-readable output expose a flattened compatibility view derived
 from these internal runtime stages.
 
-This layered runtime configuration model keeps behavior deterministic while preserving stable
-configuration, policy, diagnostics, and machine-readable compatibility contracts.
+This layered runtime model keeps behavior deterministic while preserving stable configuration,
+policy, filesystem-identity, diagnostics, and machine-readable compatibility contracts.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -39,4 +39,6 @@ ______________________________________________________________________
 
 - [API stability and snapshot policy](../dev/api-stability.md)
 - [Registry model](../dev/registry-model.md)
+- [Resolution](../dev/resolution.md)
+- [Configuration discovery](../configuration/discovery.md)
 - [Plugins and extensibility](../dev/plugins.md)

--- a/docs/api/internals.md
+++ b/docs/api/internals.md
@@ -64,6 +64,12 @@ Canonical file type identity semantics are documented in
 [Registry model](../dev/registry-model.md#qualified-vs-local-identifiers) and
 [Terminology and Canonical Vocabulary](../terminology.md).
 
+Filesystem identity, processing-path selection, symlink handling, and configuration-source identity
+semantics are documented in
+[Resolution](../dev/resolution.md#filesystem-identity-and-processing-paths),
+[Configuration discovery](../configuration/discovery.md#configuration-source-identity), and
+[Terminology and Canonical Vocabulary](../terminology.md).
+
 These pages are generated automatically during the MkDocs build and should not be edited manually.
 
 The generated reference pages reflect internal implementation structure and may evolve more

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -137,6 +137,11 @@ identical file-type identity semantics. Local identifiers such as `"python"` are
 unambiguous. Internally, TopMark normalizes identifiers to canonical qualified keys such as
 `"topmark:python"` before filtering, resolution, policy evaluation, and binding lookup.
 
+Public API execution also uses the same filesystem identity semantics as the CLI. Existing
+filesystem inputs are normalized to selected processing paths before pipeline execution. Multiple
+path spellings that resolve to the same target, such as a symlink and its target, may therefore be
+reported as a single result for the resolved processing target.
+
 For the public API, the returned view is controlled via
 `report="all" | "actionable" | "noncompliant"`. This replaces the older `skip_compliant` /
 `skip_unsupported` booleans.
@@ -175,6 +180,10 @@ The probe API is read-only and returns stable JSON-friendly DTOs:
 
 Candidates are returned in resolver order (best match first).
 
+For inputs that reach normal probing, `ProbeFileResult.path` reports the selected processing path,
+not necessarily the original invocation spelling. Missing and filtered explicit inputs still report
+explicit diagnostic input paths because they did not become normal processing paths.
+
 Unlike \[`check()`\][topmark.api.commands.pipeline.check] and
 \[`strip()`\][topmark.api.commands.pipeline.strip],
 \[`probe()`\][topmark.api.commands.pipeline.probe] does not perform content processing or mutation
@@ -200,6 +209,10 @@ The probe API explains inputs across the full discovery lifecycle:
 
 This mirrors [`topmark probe`](../usage/commands/probe.md) (CLI) behavior and provides full
 explainability without exposing resolver internals.
+
+When an input does become a normal processing path, symlink spelling is not preserved in the result
+path. This keeps public API results aligned with header metadata generation and machine-readable CLI
+output.
 
 #### Low-level probe helper
 
@@ -233,6 +246,10 @@ This process follows:
 1. Staged config-loading validation
 1. Freeze into immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig]
 1. Runtime overlays (API call arguments such as `diff`, `report`, etc.)
+
+File-backed TOML sources use configuration-source identity based on the resolved configuration-file
+target. If a configuration file is reached through a symlink, provenance and applicability are based
+on the resolved target rather than the symlink spelling.
 
 The public API operates only on the flattened immutable
 \[`FrozenConfig`\][topmark.config.model.FrozenConfig]. Staged validation logs are not exposed

--- a/docs/configuration/discovery.md
+++ b/docs/configuration/discovery.md
@@ -46,6 +46,8 @@ Configuration sources are discovered as follows, from lowest to highest preceden
      If no input paths are given (or you read from STDIN), the anchor is the **current working
      directory**.\
      Use `--no-config` to skip this layer.
+   - **Anchor spelling:** discovery anchors are resolved before walking upward, so a symlinked
+     anchor follows the resolved target path for project-chain discovery.
    - In each directory, TopMark considers both:
      - `pyproject.toml` (`[tool.topmark]`)
      - `topmark.toml`
@@ -65,6 +67,32 @@ Configuration sources are discovered as follows, from lowest to highest preceden
 > -> `--config` (in order) -> CLI.\
 > Use `--no-config` to skip project/user discovery.
 
+### Configuration-source identity
+
+File-backed configuration sources use the resolved configuration-file target as their
+configuration-source identity.
+
+This means that different path spellings can identify the same configuration source. For example:
+
+```text
+real/topmark.toml
+link-to-topmark.toml
+```
+
+may refer to the same loaded configuration file.
+
+TopMark uses configuration-source identity for:
+
+- precedence and layer ordering;
+- scope-root selection;
+- per-path applicability checks;
+- layered provenance views; and
+- machine-readable configuration provenance.
+
+Symlink spellings are therefore not preserved as configuration identity. They may be useful at the
+shell prompt, but once TopMark has loaded the configuration source, provenance and applicability are
+based on the resolved configuration-file target.
+
 ### Layered provenance (inspection)
 
 When using [`topmark config dump --show-layers`](../usage/commands/config/dump.md), this discovery
@@ -74,6 +102,10 @@ includes the original source-local TOML fragment.
 
 This layered view is inspection-oriented and does not change merge semantics; it makes the effective
 precedence and contributions of each layer explicit.
+
+For file-backed layers, the provenance `origin` and `scope_root` describe the resolved
+configuration-file target and its scope. If a configuration file was reached through a symlink, the
+layered provenance view reports the resolved target rather than the symlink spelling.
 
 The stored TOML fragments correspond to the source-local TOML view after TOML-layer validation.
 TOML-layer diagnostics may therefore already distinguish unknown entries, malformed-present
@@ -95,6 +127,9 @@ ______________________________________________________________________
 
 TopMark resolves paths relative to **where they are defined**:
 
+The definition location for file-backed configuration is the resolved configuration-source target,
+not necessarily the spelling used to reach the configuration file.
+
 | Source                                                               | Resolution base                               |
 | -------------------------------------------------------------------- | --------------------------------------------- |
 | Config-declared globs (`include_patterns`, `exclude_patterns`)       | Directory of the config file                  |
@@ -102,6 +137,10 @@ TopMark resolves paths relative to **where they are defined**:
 | Path-to-file settings (`include_from`, `exclude_from`, `files_from`) | Directory of defining config (or CWD for CLI) |
 
 Note: `relative_to` only affects metadata fields like `file_relpath`, not file matching.
+
+When a configuration file is loaded through a symlink, config-declared paths are evaluated relative
+to the resolved configuration-file target. This keeps layered configuration behavior consistent with
+TopMark's processing-path identity model.
 
 ______________________________________________________________________
 
@@ -264,6 +303,9 @@ ______________________________________________________________________
 
 `[config].root = true` stops traversal above the directory where it is defined.\
 This defines a discovery boundary similar to tools like **Black**, **isort**, or **ruff**.
+
+For symlinked configuration files, the root boundary is associated with the resolved configuration
+source target and its containing directory.
 
 - Where to put it:
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -19,6 +19,8 @@ topmark:header:end
 - **Globs declared in config files** are resolved relative to the **directory of that config file**.
 - **Globs declared via CLI** are resolved relative to the **current working directory** (invocation
   site).
+- **Configuration-source identity** is based on the resolved configuration-file target. Symlink
+  spellings are not preserved for precedence, scope, applicability, or layered provenance.
 - **Path-to-file settings** (e.g., `exclude_from`, `files_from`) are resolved relative to the
   **declaring config file** (or CWD for CLI-provided values).
 - **Merge semantics vary by field**: runtime behavioral settings usually use nearest-wins semantics,
@@ -42,6 +44,11 @@ TopMark also provides an inspection mode via
 configuration provenance. This shows how the effective runtime configuration is constructed from
 individual TOML sources and runtime CLI overrides, including their original TOML fragments.
 
+For file-backed configuration sources, layered provenance reports the resolved configuration target
+used for configuration-source identity. If a configuration file is loaded through a symlink,
+precedence, scope evaluation, and provenance operate on the resolved target rather than the symlink
+spelling.
+
 During loading, TopMark first validates each whole-source TOML fragment (unknown sections, unknown
 keys, malformed section shapes, missing known sections, etc.). Only the validated layered
 configuration fragment is then passed into layered configuration merging.
@@ -62,6 +69,9 @@ ______________________________________________________________________
 
 {% include-markdown "\_snippets/runtime-configuration-model.md" %}
 
+Configuration discovery, precedence evaluation, configuration-source identity normalization, and
+scope applicability are completed before the effective runtime configuration is frozen.
+
 ______________________________________________________________________
 
 ## Configuration flow at a glance
@@ -79,6 +89,10 @@ flowchart LR
     A --> B --> C --> D --> E --> F --> G
 ```
 
+For file-backed configuration sources, configuration-source identity is established before layered
+configuration merging. Different path spellings that resolve to the same configuration-file target
+therefore contribute to the same effective configuration source.
+
 This reflects the main distinction in TopMark's layered runtime configuration model:
 
 - TOML sources are validated first at the **whole-source TOML layer**.
@@ -93,11 +107,13 @@ ______________________________________________________________________
 ## Start here
 
 - [`Configuration discovery, precedence, and policy`](./discovery.md)
-- [`Merge semantics by field`](./discovery.md#merge-semantics-overview)
-- [`Root semantics`](./discovery.md#root-semantics) for how discovery stops at
-  `[config].root = true`
-- [`Policy resolution`](./discovery.md#policy-resolution) for understanding how runtime policy
-  settings are defined and overridden at global level and per file type.
+  - [`Configuration-source identity`](./discovery.md#configuration-source-identity)
+  - [`Layered provenance (inspection)`](./discovery.md#layered-provenance-inspection)
+  - [`Merge semantics by field`](./discovery.md#merge-semantics-overview)
+  - [`Root semantics`](./discovery.md#root-semantics) for how discovery stops at
+    `[config].root = true`
+  - [`Policy resolution`](./discovery.md#policy-resolution) for understanding how runtime policy
+    settings are defined and overridden at global level and per file type.
 - [Configuration](../usage/configuration.md) for the public TOML, CLI, and API file type identity
   contract.
 - [CLI overview](../usage/cli.md) for command-line execution and shared command options.

--- a/docs/dev/api-stability.md
+++ b/docs/dev/api-stability.md
@@ -29,6 +29,8 @@ See also:
 - [Machine-readable output](../usage/machine-output.md)
 - [Machine-readable format conventions](machine-formats.md)
 - [Configuration discovery, precedence, and policy](../configuration/index.md)
+- [Resolution](resolution.md)
+  - [Filesystem identity and processing paths](resolution.md#filesystem-identity-and-processing-paths)
 - [Release Process](release-process.md)
 - [Test and validation architecture](../ci/test-validation.md)
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -25,6 +25,8 @@ The following architectural contracts are part of the stable 1.x design:
 - CLI, API, presentation, runtime, configuration, registry, and pipeline concerns remain separated.
 - Runtime execution intent is kept separate from layered configuration state.
 - File type identity is normalized to canonical qualified keys once resolved.
+- Filesystem identity for existing processing inputs is based on the resolved processing target
+  path.
 - Registry mutation is represented as explicit overlay state.
 - Pipeline execution remains independent from presentation rendering.
 - Machine-readable output remains independent from human-facing TEXT and Markdown output.
@@ -136,7 +138,12 @@ ______________________________________________________________________
 ## File resolution diagnostics and exit-code boundaries
 
 TopMark's file selection layer separates **selected processing inputs** from **discovery
-diagnostics**. The resolver returns a structured file-list resolution result containing:
+diagnostics**. Selected processing inputs are canonical processing paths. File-list resolution
+collapses multiple path spellings that resolve to the same filesystem target (for example a symlink
+and its target) before normal pipeline execution begins. This keeps downstream pipeline steps
+idempotent and avoids processing the same target file more than once through different spellings.
+
+The resolver returns a structured file-list resolution result containing:
 
 - `selected` - concrete files that should enter the processing or probe pipeline
 - `missing_literals` - explicit literal input paths that do not exist
@@ -319,11 +326,16 @@ exit code. Consumers must inspect the process exit status separately from parsin
 Path representation follows the same separation between machine-facing serialization and
 human-facing presentation:
 
-- Internal filesystem identity is represented with `Path` objects where possible.
+- Internal filesystem identity for existing processing inputs is represented by resolved processing
+  target paths where possible.
+- Symlink spelling is not preserved for processing identity, generated filesystem-related header
+  metadata, or machine-readable path fields.
 - Machine-readable filesystem path fields are serialized with POSIX `/` separators on all platforms,
   including processing, probe, configuration, and TOML/config provenance payloads.
-- Header metadata path fields are also serialized with POSIX `/` separators when TopMark renders
-  headers.
+- Header metadata path fields describe the selected processing target and are serialized with POSIX
+  `/` separators when TopMark renders headers.
+- Path serialization is a presentation contract layered on top of processing-path selection; it does
+  not define filesystem identity by itself.
 - Registry `filenames` entries are POSIX-style matching rules, not filesystem paths.
 - Synthetic configuration-source identifiers are stable labels, not filesystem paths.
 - TEXT and Markdown output use shared display-path helpers so regular paths follow human-facing

--- a/docs/dev/configuration-schema.md
+++ b/docs/dev/configuration-schema.md
@@ -87,6 +87,28 @@ This distinction matters for
 For the canonical user-facing discovery, precedence, path-resolution, and staged validation
 contract, see [Configuration discovery, precedence, and policy](../configuration/discovery.md).
 
+For file-backed configuration sources, schema processing operates on configuration-source identity
+based on the resolved configuration-file target.
+
+Different path spellings such as:
+
+```text
+real/topmark.toml
+link-to-topmark.toml
+```
+
+may therefore identify the same configuration source.
+
+Configuration-source identity affects:
+
+- precedence and layer ordering;
+- scope-root selection;
+- applicability evaluation;
+- layered provenance exports; and
+- machine-readable configuration provenance.
+
+Symlink spellings are not preserved once a configuration source has been loaded.
+
 ## Schema validation model
 
 TopMark performs **whole-source TOML schema validation** before any layered configuration is
@@ -175,7 +197,7 @@ topmark:
     relative_to:
       type: path
       default: "."
-      description: Affects header metadata (file_relpath), not discovery.
+      description: Affects header metadata (file_relpath) for the selected processing target, not discovery.
 
   writer:
     type: table
@@ -262,27 +284,27 @@ topmark:
     include_patterns:
       type: list[str]
       default: []
-      description: Glob patterns to include (relative to declaring config source).
+      description: Glob patterns to include (resolved relative to the declaring configuration file).
 
     exclude_patterns:
       type: list[str]
       default: []
-      description: Glob patterns to exclude (relative to declaring config source).
+      description: Glob patterns to exclude (resolved relative to the declaring configuration file).
 
     include_from:
       type: list[path]
       default: []
-      description: Files containing include patterns (one per line; comments allowed).
+      description: Files containing include patterns (one per line; comments allowed; resolved relative to the declaring configuration file).
 
     exclude_from:
       type: list[path]
       default: []
-      description: Files containing exclude patterns (one per line; comments allowed).
+      description: Files containing exclude patterns (one per line; comments allowed; resolved relative to the declaring configuration file).
 
     files_from:
       type: list[path]
       default: []
-      description: Files containing explicit file lists (one path per line; comments allowed).
+      description: Files containing explicit file lists (one path per line; comments allowed; resolved relative to the declaring configuration file).
 
     include_file_types:
       type: list[str]
@@ -314,6 +336,10 @@ This normalization behavior is shared consistently across:
 - CLI options
 - API overlays
 - effective runtime policy resolution
+
+Configuration-source identity normalization follows the same model. File-backed configuration
+sources are normalized to their resolved configuration-file target before precedence, scope, and
+applicability evaluation occur.
 
 ______________________________________________________________________
 
@@ -374,3 +400,22 @@ The configuration schema intentionally does not support:
 - plugin-specific schema mutation during config loading
 
 Identifier handling intentionally remains explicit, deterministic, and ambiguity-aware.
+
+______________________________________________________________________
+
+## Configuration-source identity notes
+
+The external configuration schema does not expose a separate configuration identity field.
+
+Instead, file-backed configuration sources implicitly use the resolved configuration-file target as
+their identity.
+
+This means:
+
+- layered provenance exports report resolved configuration targets;
+- scope applicability is evaluated relative to resolved configuration targets;
+- symlink spellings are not preserved for configuration precedence; and
+- machine-readable provenance reflects configuration-source identity rather than invocation
+  spelling.
+
+This behavior mirrors TopMark's processing-path identity model for runtime file processing.

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -12,20 +12,37 @@ topmark:header:end
 
 # Development documentation
 
-This section contains maintainer-facing documentation for TopMark's architecture, compatibility
-contracts, release process, generated documentation pipeline, and post-1.0 governance model.
+This section contains maintainer-facing documentation for TopMark's architecture,
+filesystem-identity model, configuration-resolution model, compatibility contracts, release process,
+generated documentation pipeline, and post-1.0 governance model.
 
 Use these pages when changing internals, reviewing compatibility boundaries, preparing releases, or
 understanding how the stable 1.x runtime model is organized.
+
+The 1.x runtime model distinguishes several independent identity domains:
+
+- filesystem identity (processing paths);
+- configuration-source identity;
+- file type identity;
+- processor identity; and
+- machine-readable serialization identity.
+
+Understanding these distinctions is important when reviewing compatibility boundaries and runtime
+behavior.
 
 ______________________________________________________________________
 
 ## Architecture and runtime model
 
+The pages in this section define TopMark's canonical runtime behavior, including filesystem
+identity, path resolution, configuration layering, file-type resolution, runtime pipelines, and
+plugin integration.
+
 - [Terminology and canonical vocabulary](../terminology.md)
 - [Architecture](architecture.md)
-- [Registry model](registry-model.md)
-- [Resolution](resolution.md)
+- [Registry model](registry-model.md) - file-type, processor, and registry identity
+- [Resolution](resolution.md) - filesystem identity, processing paths, and configuration-source
+  identity
 - [Plugins and extensibility](plugins.md)
 - [Configuration schema](configuration-schema.md)
 - [Pipelines](pipelines.md)
@@ -34,6 +51,9 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 ## Compatibility and output contracts
+
+These documents define the stable 1.x compatibility boundaries for APIs, machine-readable output,
+filesystem path serialization, file-type identity, and configuration provenance.
 
 - [API stability and snapshot policy](api-stability.md)
 - [Machine-readable format conventions](machine-formats.md)

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -97,9 +97,10 @@ Stability guarantees:
 
 - Machine-readable payloads contain no ANSI color codes.
 - Payload shapes are JSON-safe (no Python-specific objects).
-- Machine-readable filesystem path fields are serialized with POSIX `/` separators on all platforms.
-- Header metadata path fields are also serialized with POSIX `/` separators when TopMark renders
-  headers.
+- Machine-readable filesystem path fields serialize selected processing paths with POSIX `/`
+  separators on all platforms.
+- Header metadata path fields describe the selected processing target and are serialized with POSIX
+  `/` separators when TopMark renders headers.
 - New fields may be added over time as additive 1.x evolution.
 - Existing fields are not removed or renamed without a breaking-change signal.
 - Resolved file type identities are emitted using canonical qualified keys when available.
@@ -119,10 +120,21 @@ Consumers should:
 - Prefer canonical identity fields such as `qualified_key`, `file_type_key`, and `processor_key`
   over display-oriented names or user-supplied input spellings.
 
+- Treat machine-readable filesystem path fields as processing-path fields. They are stable for the
+  selected processing target, but they do not promise to preserve the original CLI argument,
+  configuration entry, glob match, or symlink spelling.
+
 Path-like values are not all part of the same contract. Machine-readable filesystem path fields use
-POSIX path serialization, while registry `filenames` entries are POSIX-style matching rules rather
-than filesystem paths. This includes processing, probe, configuration, and TOML/config provenance
-payloads. Synthetic configuration-source identifiers are stable labels rather than filesystem paths.
+POSIX path serialization for selected processing paths, while registry `filenames` entries are
+POSIX-style matching rules rather than filesystem paths. This includes processing, probe,
+configuration, and TOML/config provenance payloads. Synthetic configuration-source identifiers are
+stable labels rather than filesystem paths.
+
+Path serialization is distinct from filesystem identity. TopMark currently identifies existing
+processing inputs by their resolved processing target path before machine output is generated. As a
+result, multiple path spellings that resolve to the same target, such as a symlink and its target,
+may produce the same serialized processing path.
+
 Human-facing path labels, including unified diff file labels, follow display policy and are not
 machine-stable path fields.
 
@@ -412,6 +424,10 @@ Per-file result payloads report the resolved file type using the canonical key w
 succeeds. Consumers should not expect the original local-or-qualified input spelling to be preserved
 in result payloads.
 
+Per-file result payloads also report the selected processing path. If a file is reached through a
+symlink, the emitted path describes the resolved processing target rather than the symlink spelling.
+This mirrors the path used by the runtime pipeline and generated filesystem-related header metadata.
+
 In **summary mode**, TopMark aggregates results by the pair `(outcome, reason)` rather than
 collapsing all reasons under a single outcome bucket.
 
@@ -483,6 +499,10 @@ quiet mode.
 
 Probe output reports canonical file type identities after identifier normalization and file-type
 filtering.
+
+Probe payloads report processing paths after discovery, filesystem-identity normalization, and
+filtering. They are diagnostic records for the paths that reach probing, not a lossless echo of the
+original invocation spelling.
 
 Filtered probe results use machine-friendly reasons to explain why an explicit file input did not
 reach probing. Missing explicit inputs use `probe_missing` with `no_resolution_probe_result` when no
@@ -565,6 +585,10 @@ contract.
 
 For [`config dump --show-layers`](../usage/commands/config/dump.md), machine-readable output
 preserves the same logical ordering as the human-facing layered export:
+
+File-backed configuration provenance uses configuration-source identity based on the resolved
+configuration-file target. Symlink spellings for configuration files are therefore not preserved for
+machine-readable provenance, precedence, scope, or applicability evaluation.
 
 - JSON includes `config_provenance` before `config` in the top-level envelope.
 - NDJSON emits a `config_provenance` record first and a `config` record second.

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -26,20 +26,32 @@ system.
 Pipelines operate on an immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig] plus runtime
 options assembled via the TOML → FrozenConfig → runtime flow.
 
+Pipelines also operate on selected processing paths. Filesystem identity normalization,
+processing-path selection, and deduplication occur before ordinary pipeline execution begins.
+Pipeline steps therefore consume processing paths rather than preserving original CLI,
+configuration, glob, or symlink spellings.
+
 See [`Architecture`](./architecture.md) for the conceptual overview.
 
 Source-local TOML options such as `[config].root` and `strict` are resolved before pipeline
 execution. They influence configuration discovery and staged config-loading validation behavior, but
 do not become layered configuration fields.
 
-Path handling responsibilities are split between pipeline processing and presentation layers:
+Path and filesystem-identity responsibilities are split between input selection, pipeline
+processing, and presentation layers:
 
 - `BuilderStep` generates header metadata path fields (`file_relpath`, `file_abspath`, `relpath`,
-  and `abspath`) using POSIX `/` serialization on all platforms.
+  and `abspath`) for the selected processing target using POSIX `/` serialization on all platforms.
+  If a file was reached through a symlink, generated metadata describes the resolved target that
+  TopMark reads and writes.
 - `PatcherStep` generates unified diffs for human review; diff file labels use human-facing display
   paths rather than machine-readable path serialization.
 - TEXT and Markdown frontends share display-path helpers so STDIN-backed processing consistently
   displays the logical `--stdin-filename` when available.
+
+Machine-readable path fields are generated from the selected processing path. Serialization and
+presentation occur after filesystem identity has been established and do not preserve invocation
+spellings.
 
 {% include-markdown "\_snippets/config-strictness.md" %}
 
@@ -114,5 +126,6 @@ ______________________________________________________________________
 - [`Pipelines (Concepts)`](./pipelines.md)
 - [`Terminology and Canonical Vocabulary`](../terminology.md)
 - [`Resolution`](./resolution.md)
+- [`Filesystem identity and processing paths`](./resolution.md#filesystem-identity-and-processing-paths)
 - [`Configuration discovery`](../configuration/discovery.md)
 - [`Machine-readable output`](../usage/machine-output.md)

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -35,6 +35,11 @@ Pipeline execution consumes an immutable \[`FrozenConfig`\][topmark.config.model
 runtime options assembled from the TOML → FrozenConfig → runtime flow documented in
 [`Architecture`](architecture.md) and [`Configuration discovery`](../configuration/discovery.md).
 
+Pipeline execution also consumes a selected **processing path**. Normal file-list resolution
+normalizes filesystem identity, deduplicates multiple path spellings for the same target, and passes
+the canonical processing path into the pipeline. Pipeline steps therefore operate on processing
+paths rather than preserving original CLI, configuration, glob, or symlink spellings.
+
 Source-local TOML options such as `[config].root` and `strict` are resolved before pipeline
 execution. They influence configuration discovery and staged config-loading validation behavior, but
 do not become layered configuration fields.
@@ -61,13 +66,20 @@ ______________________________________________________________________
 
 All pipelines are built from the same core phases:
 
-1. **Discovery** - identify file type and viability
+1. **Input selection** - discover files, normalize filesystem identity, deduplicate, and select
+   processing paths
+1. **Discovery** - identify file type and viability for each processing path
 1. **Inspection** - read content and detect existing headers
 1. **Evaluation** - generate and compare expected headers
 1. **Mutation (optional)** - plan, patch, and/or write changes
 
 The `probe` pipeline is an exception: it only executes the resolution phase and stops immediately
 after producing probe results.
+
+Input selection happens before ordinary pipeline execution. This includes symlink handling: file
+symlink spellings and their targets are collapsed to the resolved processing target before pipeline
+steps run. Synthetic probe contexts for filtered or missing explicit inputs preserve diagnostic
+input information only for those paths that never became normal processing paths.
 
 ### Unified Pipeline Flow
 
@@ -130,10 +142,15 @@ TopMark pipelines are:
 - step-ordered
 - side-effect constrained
 - idempotent
+- processing-path based
 - presentation-independent
 
 Pipeline steps mutate processing context state. CLI views, API DTOs, and machine-readable output
 classify final outcomes from accumulated statuses and hints.
+
+For filesystem inputs, the processing context path is the selected processing path. It may differ
+from the path spelling supplied on the command line or in configuration when symlinks or equivalent
+relative spellings are involved.
 
 ______________________________________________________________________
 
@@ -178,6 +195,9 @@ This pipeline powers [`topmark probe`](../usage/commands/probe.md) and
 It halts immediately after probing and does not perform inspection, comparison, or mutation.
 Discovery-level filtering is reported by orchestration via synthetic probe results for explicitly
 requested paths that did not reach probing.
+
+Probe results that do reach runtime probing report processing paths. They should not be interpreted
+as a lossless echo of the original invocation spelling.
 
 ### SCAN
 
@@ -231,8 +251,10 @@ SP --> B --> T
 - No determination yet whether changes are needed
 
 `BuilderStep` derives built-in header metadata fields such as `file_relpath`, `file_abspath`,
-`relpath`, and `abspath`. These generated header metadata path fields are serialized with POSIX `/`
-separators on all platforms.
+`relpath`, and `abspath` from the selected processing target. If a file was reached through a
+symlink, these generated fields describe the resolved target TopMark reads and writes rather than
+the symlink spelling. Header metadata path fields are serialized with POSIX `/` separators on all
+platforms.
 
 Useful for debugging header generation.
 
@@ -443,20 +465,20 @@ Each step implements the \[`Step`\][topmark.pipeline.protocols.Step] protocol an
 - May halt execution via `ctx.flow.halt`
 - Emits structured hints for diagnostics
 
-| Step                                                             | Responsibility                                                                      |
-| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| \[`ProberStep`\][topmark.pipeline.steps.prober.ProberStep]       | Run resolution probe and expose scored candidates, selection, and processor binding |
-| \[`ResolverStep`\][topmark.pipeline.steps.resolver.ResolverStep] | Determine file type and header processor (see [`Resolution`](resolution.md))        |
-| \[`SnifferStep`\][topmark.pipeline.steps.sniffer.SnifferStep]    | Fast policy and newline checks                                                      |
-| \[`ReaderStep`\][topmark.pipeline.steps.reader.ReaderStep]       | Read file content safely                                                            |
-| \[`ScannerStep`\][topmark.pipeline.steps.scanner.ScannerStep]    | Locate existing header bounds                                                       |
-| \[`BuilderStep`\][topmark.pipeline.steps.builder.BuilderStep]    | Build expected header field values and POSIX-serialized header metadata paths       |
-| \[`RendererStep`\][topmark.pipeline.steps.renderer.RendererStep] | Render header text                                                                  |
-| \[`ComparerStep`\][topmark.pipeline.steps.comparer.ComparerStep] | Compare existing vs rendered header                                                 |
-| \[`StripperStep`\][topmark.pipeline.steps.stripper.StripperStep] | Remove header content                                                               |
-| \[`PlannerStep`\][topmark.pipeline.steps.planner.PlannerStep]    | Decide insert / replace / remove plan                                               |
-| \[`PatcherStep`\][topmark.pipeline.steps.patcher.PatcherStep]    | Generate unified diff with human-facing display labels                              |
-| \[`WriterStep`\][topmark.pipeline.steps.writer.WriterStep]       | Persist changes                                                                     |
+| Step                                                             | Responsibility                                                                                            |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| \[`ProberStep`\][topmark.pipeline.steps.prober.ProberStep]       | Run resolution probe and expose scored candidates, selection, and processor binding                       |
+| \[`ResolverStep`\][topmark.pipeline.steps.resolver.ResolverStep] | Determine file type and header processor (see [`Resolution`](resolution.md))                              |
+| \[`SnifferStep`\][topmark.pipeline.steps.sniffer.SnifferStep]    | Fast policy and newline checks                                                                            |
+| \[`ReaderStep`\][topmark.pipeline.steps.reader.ReaderStep]       | Read file content safely                                                                                  |
+| \[`ScannerStep`\][topmark.pipeline.steps.scanner.ScannerStep]    | Locate existing header bounds                                                                             |
+| \[`BuilderStep`\][topmark.pipeline.steps.builder.BuilderStep]    | Build expected header field values and POSIX-serialized metadata paths for the selected processing target |
+| \[`RendererStep`\][topmark.pipeline.steps.renderer.RendererStep] | Render header text                                                                                        |
+| \[`ComparerStep`\][topmark.pipeline.steps.comparer.ComparerStep] | Compare existing vs rendered header                                                                       |
+| \[`StripperStep`\][topmark.pipeline.steps.stripper.StripperStep] | Remove header content                                                                                     |
+| \[`PlannerStep`\][topmark.pipeline.steps.planner.PlannerStep]    | Decide insert / replace / remove plan                                                                     |
+| \[`PatcherStep`\][topmark.pipeline.steps.patcher.PatcherStep]    | Generate unified diff with human-facing display labels                                                    |
+| \[`WriterStep`\][topmark.pipeline.steps.writer.WriterStep]       | Persist changes                                                                                           |
 
 ______________________________________________________________________
 
@@ -492,6 +514,8 @@ ______________________________________________________________________
 
 - **Immutability:** Pipelines are `Final[tuple[Step, ...]]`
 - **Determinism:** Same input → same outcome
+- **Processing-path identity:** pipeline steps operate on selected processing paths, not raw
+  invocation spellings
 - **Dry-run safety:** No writes without `--apply`
 - **Separation of concerns:** Steps mutate context, views classify outcomes
 - **Runtime/configuration separation:** pipeline execution consumes resolved runtime configuration
@@ -501,13 +525,16 @@ ______________________________________________________________________
 
 ## See also
 
-- [`Architecture`](./architecture.md) - TOML → FrozenConfig → runtime overview
-- [`Pipelines (Reference)`](./pipelines-reference.md) - generated API-backed reference entry points
-- [`Terminology and Canonical Vocabulary`](../terminology.md) - canonical definitions for pipeline,
+- [Architecture](./architecture.md) - TOML → FrozenConfig → runtime overview
+- [Resolution](./resolution.md)
+  - [Filesystem identity and processing paths](./resolution.md#filesystem-identity-and-processing-paths)
+    \- filesystem identity, symlink handling, and processing-path selection
+- [Pipelines (Reference)](./pipelines-reference.md) - generated API-backed reference entry points
+- [Terminology and Canonical Vocabulary](../terminology.md) - canonical definitions for pipeline,
   status, hint, runtime, and machine-readable terminology
-- [`Machine-readable output`](../usage/machine-output.md) - how pipeline results are exposed in JSON
+- [Machine-readable output](../usage/machine-output.md) - how pipeline results are exposed in JSON
   and NDJSON outputs
-- [`Configuration discovery`](../configuration/discovery.md) - source-local TOML options and
+- [Configuration discovery](../configuration/discovery.md) - source-local TOML options and
   precedence
 
 This pipeline model is the backbone of TopMark's reliability and extensibility. New behavior is

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -52,6 +52,12 @@ The detailed registry architecture is documented in [Registry model](registry-mo
 Plugin authors should treat qualified file type identifiers, such as `my_plugin:my_lang`, as the
 stable reference once custom namespaces are involved.
 
+Filesystem identity is a separate concept from registry identity.
+
+Qualified identifiers such as `my_plugin:my_lang` identify file types in the registry model. Runtime
+file processing operates on selected processing paths after filesystem-identity normalization and
+path-resolution have completed.
+
 ______________________________________________________________________
 
 ## Extension points
@@ -95,9 +101,15 @@ TopMark uses explicit base registries plus overlay registries:
 
 This means plugin-defined file types must still be available before a processor class is registered
 against them, but processor registration no longer depends on module import order or decorator side
-effects. Path-based file type selection is performed by the shared scoring resolver in
+effects.
+
+Path-based file type selection is performed by the shared scoring resolver in
 \[`topmark.resolution.filetypes`\][topmark.resolution.filetypes]. The formal selection and ambiguity
 policy is documented in [`resolution.md`](resolution.md).
+
+The resolver operates on selected processing paths after filesystem-identity normalization. File
+type plugins therefore do not participate in filesystem identity, symlink handling, processing-path
+selection, or configuration-source identity evaluation.
 
 ______________________________________________________________________
 
@@ -148,7 +160,9 @@ objects.
 
 #### Filename matching rules
 
-`FileType.filenames` entries are registry matching rules rather than filesystem paths.
+`FileType.filenames` entries are registry matching rules rather than filesystem paths. They
+participate in file-type resolution only and do not define filesystem identity, processing-path
+selection, configuration applicability, or machine-readable path reporting semantics.
 
 Supported forms:
 
@@ -157,6 +171,9 @@ Supported forms:
 
 Tail-subpath rules should use POSIX-style `/` separators. Backslash-containing rules are accepted as
 compatibility input and normalized during file-type construction.
+
+Filename rules are matched against normalized resolver inputs and should be treated as
+platform-independent matching expressions rather than literal filesystem paths.
 
 Invalid filename rules include:
 
@@ -189,9 +206,13 @@ def provide_filetypes() -> list[FileType]:
     ]
 ```
 
-TopMark stores filename rules in canonical POSIX form. Registry inspection, machine-readable output,
-and resolver diagnostics therefore always expose normalized filename-rule values regardless of
-platform.
+TopMark stores filename rules in canonical POSIX form. This normalization applies to registry
+matching rules only. Runtime processing paths, configuration-source identity, machine-readable path
+fields, and header metadata paths follow separate filesystem-identity and processing-path contracts
+documented in the resolution model.
+
+Registry inspection, machine-readable output, and resolver diagnostics therefore always expose
+normalized filename-rule values regardless of platform.
 
 ### Using the FileType factory (recommended)
 
@@ -302,6 +323,10 @@ A typical advanced integration flow is:
 
 This keeps built-in registry construction deterministic and avoids module-import side effects.
 
+Processor registration influences runtime file-type handling only. Filesystem identity,
+processing-path selection, and configuration-source identity are resolved before processor selection
+occurs.
+
 ______________________________________________________________________
 
 ## Recommended plugin scope for TopMark 1.x
@@ -361,8 +386,8 @@ These modules are useful for advanced TopMark integrations and registry extensio
 - \[`topmark.filetypes.instances`\][topmark.filetypes.instances] - base file type discovery
 - \[`topmark.processors.instances`\][topmark.processors.instances] - base processor binding
   inventory and registry construction
-- \[`topmark.resolution.filetypes`\][topmark.resolution.filetypes] - shared scoring-based path
-  resolver
+- \[`topmark.resolution.filetypes`\][topmark.resolution.filetypes] - shared scoring-based file-type
+  resolver operating on selected processing paths
 - \[`topmark.registry.filetypes`\][topmark.registry.filetypes] - composed file type registry view
   and identifier resolution
 - \[`topmark.registry.processors`\][topmark.registry.processors] - composed processor registry view
@@ -385,3 +410,5 @@ ______________________________________________________________________
 - [`Architecture`](./architecture.md) - high-level overview of registries and runtime composition
 - [`registry.md`](../usage/commands/registry.md) - CLI-facing registry inspection commands
 - [`Resolution model`](./resolution.md) - file-type scoring and ambiguity policy
+  - [`Filesystem identity and processing paths`](./resolution.md#filesystem-identity-and-processing-paths)
+    \- filesystem identity, processing paths, and symlink handling

--- a/docs/dev/registry-model.md
+++ b/docs/dev/registry-model.md
@@ -339,6 +339,23 @@ ______________________________________________________________________
 
 The resolver and probe system operate on canonical qualified file type identities.
 
+Filesystem identity is a separate concept from file type identity.
+
+Registry identifiers such as:
+
+```text
+topmark:python
+topmark:markdown
+```
+
+identify file types within the registry model.
+
+Filesystem identity, processing-path selection, symlink handling, and configuration-source identity
+are resolved before runtime probing and are documented in [Resolution](resolution.md).
+
+The registry model operates on the resulting processing path and resolved file type identity; it
+does not define filesystem identity semantics itself.
+
 This affects:
 
 - include/exclude file-type filters;
@@ -628,6 +645,7 @@ ______________________________________________________________________
 ## Related docs
 
 - [Architecture overview](architecture.md)
+- [Resolution](resolution.md)
 - [Public API](../api/public.md)
 - [API internals](../api/internals.md)
 - Registry API internals: \[`topmark.registry`\][topmark.registry]

--- a/docs/dev/resolution.md
+++ b/docs/dev/resolution.md
@@ -60,6 +60,13 @@ operations.
 Before path-based resolution runs, TopMark performs file discovery and filtering. Paths excluded at
 that stage do not participate in candidate generation or scoring.
 
+Before runtime file-type probing begins, discovery also establishes a canonical filesystem identity
+and processing path for each selected file.
+
+Multiple path spellings that resolve to the same processing target (for example a symlink and its
+target) are collapsed before pipeline execution. Runtime resolution therefore operates on processing
+paths rather than original CLI, configuration, glob, or symlink spellings.
+
 File-type filters accept both local identifiers such as `python` and canonical qualified identifiers
 such as `topmark:python`.
 
@@ -102,7 +109,7 @@ See also:
 
 ______________________________________________________________________
 
-### Resolution pipeline boundaries
+## Resolution pipeline boundaries
 
 TopMark intentionally separates:
 
@@ -120,13 +127,66 @@ stable machine-readable diagnostics, and explicit configuration/runtime boundari
 
 ______________________________________________________________________
 
+## Filesystem identity and processing paths
+
+Path-based runtime resolution is not the first stage that operates on a user path.
+
+Before a path reaches file-type probing, TopMark performs:
+
+1. discovery
+1. filtering
+1. filesystem-identity normalization
+1. deduplication
+1. processing-path selection
+
+The resulting processing path is then supplied to runtime probing and pipeline execution.
+
+```mermaid
+flowchart TD
+    input["CLI/config input"]
+    discovery["Discovery + filtering"]
+    identity["Filesystem identity<br/>normalization"]
+    dedupe["Deduplication"]
+    processing["Processing path"]
+    runtime["Runtime resolution"]
+    pipeline["Pipeline execution"]
+    serialization["Machine-readable<br/>serialization"]
+
+    input --> discovery
+    discovery --> identity
+    identity --> dedupe
+    dedupe --> processing
+    processing --> runtime
+    runtime --> pipeline
+    pipeline --> serialization
+```
+
+Machine-readable output serializes the selected processing path; it does not attempt to preserve the
+original invocation spelling.
+
+Filesystem identity is currently defined by the resolved processing target path.
+
+Examples such as:
+
+```text
+real/file.py
+./real/file.py
+link-to-file.py
+```
+
+may therefore collapse to a single processing path before runtime resolution begins.
+
+Hard-link detection and device/inode-based identity are outside the current compatibility contract.
+
+______________________________________________________________________
+
 ## Probe-based resolution (1.0 contract)
 
 TopMark 1.0 exposes a probe-first resolution model via
 \[`probe_resolution_for_path()`\][topmark.resolution.filetypes.probe_resolution_for_path].
 
-Probe-based resolution operates only after discovery filtering and configuration normalization have
-completed.
+Probe-based resolution operates only after discovery filtering, filesystem- identity normalization,
+processing-path selection, and configuration normalization have completed.
 
 This function returns a \[`ResolutionProbeResult`\][topmark.resolution.probe.ResolutionProbeResult]
 containing:
@@ -137,9 +197,9 @@ containing:
 - match signals used during resolution
 - filtered explicit inputs that did not reach file-type probing
 
-The probe result is the canonical source of truth for runtime resolution decisions once a path
-reaches file-type probing. Explicit inputs may be filtered earlier during discovery; those cases are
-represented as synthetic probe results with `status="filtered"` and one of:
+The probe result is the canonical source of truth for runtime resolution decisions once a processing
+path reaches file-type probing. Explicit inputs may be filtered earlier during discovery; those
+cases are represented as synthetic probe results with `status="filtered"` and one of:
 
 - `reason="excluded_by_path_filter"`
 - `reason="excluded_by_file_type_filter"`
@@ -376,6 +436,12 @@ This separation keeps responsibilities clear:
   file-type-to-processor relationships
 - the runtime resolver decides which file type best matches a **concrete filesystem path**
 
+The resolver deliberately does not define filesystem identity semantics.
+
+Filesystem identity, symlink handling, deduplication, and processing-path selection occur earlier
+during discovery and file-list resolution. The resolver consumes the resulting processing path and
+focuses exclusively on file-type selection.
+
 This design has several advantages:
 
 - registries remain simple and declarative
@@ -383,6 +449,24 @@ This design has several advantages:
 - runtime resolution remains deterministic and testable
 - plugin authors can define specialized file types without needing a separate override system in the
   registries
+
+______________________________________________________________________
+
+## Symlink policy
+
+The runtime resolver operates on processing paths and therefore does not preserve original symlink
+spellings.
+
+Current behavior:
+
+- file-symlink inputs are resolved to their processing target;
+- symlink and target spellings are deduplicated before runtime processing;
+- configuration-source identity is based on the resolved configuration-file target;
+- machine-readable output serializes the resulting processing path; and
+- generated filesystem-related header metadata describes the target TopMark reads and writes.
+
+This policy contributes to idempotence and prevents duplicate processing of the same target file
+through multiple spellings.
 
 ______________________________________________________________________
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,28 +22,31 @@ TopMark provides stable and consistent behavior across:
 
 - CLI execution and dry-run workflows
 - layered TOML configuration discovery and precedence
+- filesystem identity normalization and processing-path selection
+- configuration-source identity and layered provenance reporting
 - repository filtering and file-type resolution
 - probe and diagnostics workflows
 - machine-readable reporting and explainability
 - pre-commit and CI integration
-- stable public Python API overlays
+- stable public Python API overlays and runtime contracts
 
 ______________________________________________________________________
 
 ## Start here
 
-| Goal                                               | Recommended page                                      |
-| -------------------------------------------------- | ----------------------------------------------------- |
-| Install TopMark and complete a safe first run      | [Getting started](usage/getting-started.md)           |
-| Understand the CLI structure and shared behavior   | [Command overview](usage/cli.md)                      |
-| Configure layered runtime behavior and policies    | [Configuration](usage/configuration.md)               |
-| Understand repository filtering and file discovery | [Filtering](usage/filtering.md)                       |
-| Validate repositories in CI                        | [CI integration](usage/ci.md)                         |
-| Integrate TopMark with pre-commit                  | [Pre-commit integration](usage/pre-commit.md)         |
-| Understand stable exit-code behavior               | [Exit codes](usage/exit-codes.md)                     |
-| Upgrade older repositories to TopMark 1.0          | [Upgrading to TopMark 1.0](usage/upgrading-to-1.0.md) |
-| Use the public Python API                          | [Public API](api/public.md)                           |
-| Contribute to TopMark                              | [Contributing](contributing.md)                       |
+| Goal                                                                 | Recommended page                                      |
+| -------------------------------------------------------------------- | ----------------------------------------------------- |
+| Install TopMark and complete a safe first run                        | [Getting started](usage/getting-started.md)           |
+| Understand the CLI structure and shared behavior                     | [Command overview](usage/cli.md)                      |
+| Configure layered runtime behavior and policies                      | [Configuration](usage/configuration.md)               |
+| Understand repository filtering and file discovery                   | [Filtering](usage/filtering.md)                       |
+| Understand machine-readable output, processing paths, and provenance | [Machine-readable output](usage/machine-output.md)    |
+| Validate repositories in CI                                          | [CI integration](usage/ci.md)                         |
+| Integrate TopMark with pre-commit                                    | [Pre-commit integration](usage/pre-commit.md)         |
+| Understand stable exit-code behavior                                 | [Exit codes](usage/exit-codes.md)                     |
+| Upgrade older repositories to TopMark 1.0                            | [Upgrading to TopMark 1.0](usage/upgrading-to-1.0.md) |
+| Use the public Python API                                            | [Public API](api/public.md)                           |
+| Contribute to TopMark                                                | [Contributing](contributing.md)                       |
 
 ______________________________________________________________________
 
@@ -56,7 +59,10 @@ ______________________________________________________________________
 - Supports pre-commit and CI integration
 - Explains repository filtering, file-type resolution, and processor selection via
   [`topmark probe`](usage/commands/probe.md)
+- Uses deterministic filesystem-identity normalization and processing-path selection across CLI,
+  API, CI, and machine-readable workflows
 - Exposes layered configuration provenance via `topmark config dump --show-layers`
+- Uses deterministic configuration-source identity for layered configuration evaluation
 - Provides stable machine-readable JSON and NDJSON output together with canonical registry metadata
   suitable for automation and reporting
 - Supports canonical qualified file type identifiers such as `topmark:python`
@@ -66,7 +72,11 @@ ______________________________________________________________________
 
 ## Commands
 
-TopMark exposes a small set of dry-run-first CLI commands:
+TopMark exposes a small set of dry-run-first CLI commands.
+
+Filesystem-processing commands normalize filesystem identity before runtime processing. Multiple
+path spellings that resolve to the same filesystem target (for example a symlink and its target) are
+treated as a single processing target.
 
 For command structure, shared options, applicability rules, and common workflows, see:
 
@@ -125,6 +135,9 @@ The [`registry`](usage/commands/registry.md) command has the following subcomman
 
 {% include-markdown "\_snippets/output-contract.md" %}
 
+Machine-readable filesystem path fields report selected processing paths. Configuration provenance
+reports resolved configuration sources. Both contracts remain stable across supported platforms.
+
 Use [`config dump --show-layers`](usage/commands/config/dump.md) to inspect how configuration is
 built from individual sources and how precedence is applied.
 
@@ -152,6 +165,8 @@ ______________________________________________________________________
 Common reference pages:
 
 - [Exit codes](usage/exit-codes.md)
+- [Machine-readable output](usage/machine-output.md)
+- [Configuration discovery](configuration/discovery.md)
 - [CI integration](usage/ci.md)
 - [Release workflow](ci/release-workflow.md)
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -126,6 +126,30 @@ filtering, runtime policy lookup, registry composition, and resolution.
 
 Examples include qualified file-type identities and canonicalized registry matching rules.
 
+### Filesystem identity
+
+The canonical filesystem object identity used by TopMark when processing existing files,
+configuration sources, and runtime inputs.
+
+For ordinary filesystem processing, identity is based on the resolved processing target rather than
+the original invocation spelling.
+
+Examples:
+
+```text
+real/file.py
+link-to-file.py
+./real/file.py
+```
+
+may all refer to the same filesystem identity.
+
+> [!NOTE]
+>
+> Filesystem identity is distinct from machine-readable path serialization. TopMark first determines
+> filesystem identity and then serializes the selected processing path according to the
+> machine-output contract.
+
 ### Namespace
 
 A logical ownership boundary for file type identities.
@@ -141,6 +165,9 @@ ______________________________________________________________________
 ### Resolution
 
 The process of selecting the most appropriate file type for a path or input.
+
+Resolution may normalize multiple path spellings to a single filesystem identity before runtime
+processing begins.
 
 ### Filename rule
 
@@ -238,6 +265,13 @@ Example:
 The fully resolved runtime configuration applicable to a specific path, command invocation, or
 execution context.
 
+### Configuration source identity
+
+The normalized identity assigned to a loaded TOML configuration source.
+
+Configuration-source identity is based on the resolved processing target of the loaded configuration
+file. Symlink spellings are not preserved for precedence, scope, or applicability evaluation.
+
 ______________________________________________________________________
 
 ## Pipeline terminology
@@ -262,6 +296,9 @@ A mutating execution mode that performs filesystem writes.
 ### Idempotence
 
 The guarantee that repeated runs without source changes converge to the same result.
+
+Filesystem-identity normalization contributes to idempotence by preventing the same target file from
+being processed multiple times through different path or symlink spellings.
 
 ### Mutation planning
 
@@ -294,6 +331,9 @@ Formats:
 
 The compatibility guarantees governing machine-readable schemas, record kinds, field naming, payload
 structure, and semantic stability.
+
+The machine-readable contract governs path serialization but does not define filesystem identity
+semantics.
 
 ### Payload
 
@@ -356,6 +396,19 @@ A command that does not operate on filesystem paths or content-processing pipeli
 
 A command that processes filesystem paths through discovery, filtering, resolution, or runtime
 pipelines.
+
+### Processing path
+
+The canonical path selected by TopMark for runtime processing.
+
+A processing path represents the resolved filesystem target chosen after path normalization,
+discovery, filtering, and deduplication. It is the path exposed to runtime pipelines, header
+generation, and machine-readable output.
+
+> [!NOTE]
+>
+> A processing path is not necessarily identical to the original CLI argument, configuration entry,
+> glob match, or symlink spelling supplied by the user.
 
 ______________________________________________________________________
 

--- a/docs/usage/ci.md
+++ b/docs/usage/ci.md
@@ -41,6 +41,10 @@ topmark check .
 This validates the selected files and exits with `WOULD_CHANGE (3)` when headers would need to be
 inserted, updated, or removed.
 
+TopMark normalizes filesystem identity before runtime processing. If multiple path spellings resolve
+to the same filesystem target (for example a symlink and its target), CI validation operates on the
+selected processing path and processes the target once.
+
 If you also want to validate the TopMark configuration, either provide `--strict` to `topmark check`
 or add a dedicated configuration validation step:
 
@@ -105,6 +109,8 @@ Notes:
 - Explicit missing literal paths are hard input errors and produce `FILE_NOT_FOUND (66)`.
 - Unmatched glob patterns are soft discovery diagnostics and do not fail `check`.
 - In mixed-result runs, hard input and filesystem errors take precedence over `WOULD_CHANGE (3)`.
+- Filesystem-identity normalization and processing-path selection do not affect exit-code semantics.
+  Equivalent path spellings contribute to the same runtime processing outcome.
 
 ### `topmark config check`
 
@@ -268,8 +274,15 @@ Machine-readable output can expose structured CI diagnostics such as:
 - layered configuration information where supported by the selected command;
 - stable fields for automation-friendly reporting.
 
+For filesystem-processing commands, machine-readable path fields report selected processing paths
+rather than preserving the original CLI argument spelling. If a file is reached through a symlink,
+JSON and NDJSON output describe the resolved processing target used by TopMark.
+
 This makes JSON and NDJSON output useful for CI annotations, dashboards, repository audits, policy
 validation, and custom reporting pipelines.
+
+This behavior helps keep CI annotations, dashboards, and automation pipelines stable across
+platforms and repository layouts.
 
 Further reading:
 
@@ -296,4 +309,6 @@ ______________________________________________________________________
 - [Pre-commit integration](pre-commit.md)
 - [Exit codes](exit-codes.md)
 - [Configuration](configuration.md)
+- [Filesystem identity and processing paths](../dev/resolution.md#filesystem-identity-and-processing-paths)
+- [Filtering](filtering.md)
 - [Machine-readable output](../usage/machine-output.md)

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -26,6 +26,7 @@ The CLI is intentionally conservative:
 
 - commands default to dry-run behavior
 - mutations require `--apply`
+- filesystem identity is normalized before runtime processing
 - unsupported files are skipped diagnostically
 - repeated runs converge to stable results
 - command help and shell completion are available across supported platforms
@@ -43,6 +44,10 @@ ______________________________________________________________________
 | Remove TopMark headers               | `topmark strip --apply src/`        | [`topmark strip`](commands/strip.md), [Header placement](header-placement.md)                          |
 | Inspect file type resolution         | `topmark probe README.md`           | [`topmark probe`](commands/probe.md), [Filtering](filtering.md)                                        |
 | Inspect effective configuration      | `topmark config dump --show-layers` | [`topmark config dump`](commands/config/dump.md), [Configuration](configuration.md)                    |
+
+Filesystem inputs are normalized to selected processing paths before runtime processing. If multiple
+path spellings resolve to the same filesystem target (for example a symlink and its target), TopMark
+processes the target once and reports the selected processing path in machine-readable output.
 
 ______________________________________________________________________
 
@@ -91,6 +96,10 @@ topmark check --apply src/
 ```bash
 topmark strip --apply src/
 ```
+
+For commands that operate on filesystem inputs (`check`, `strip`, and `probe`), positional paths
+participate in TopMark's discovery, filtering, filesystem-identity normalization, and
+processing-path selection pipeline before runtime processing begins.
 
 ______________________________________________________________________
 
@@ -230,6 +239,10 @@ Common shared options include the following, where supported by the selected com
 For command applicability, output, verbosity, and formatting options, see
 [Shared options](shared-options.md).
 
+Machine-readable filesystem path fields report selected processing paths rather than preserving the
+original CLI argument spelling. See [Machine-readable output](machine-output.md) for the full
+contract.
+
 {% include-markdown "\_snippets/option-spelling.md" %}
 
 ______________________________________________________________________
@@ -260,6 +273,8 @@ File type filters behave consistently across:
 - TOML configuration
 - API overlays
 - resolution and probe filtering
+
+File type filtering operates after filesystem-identity normalization and processing-path selection.
 
 For canonical file-type identifier semantics and layered configuration behavior, see
 [Configuration](configuration.md).
@@ -340,6 +355,8 @@ ______________________________________________________________________
 - [Exit codes](exit-codes.md)
 - [Pre-commit integration](pre-commit.md)
 - [Configuration discovery, precedence, and policy](../configuration/discovery.md)
+  - [Configuration source identity](../configuration/discovery.md#configuration-source-identity)
+- [Machine-readable output](machine-output.md)
 
 ______________________________________________________________________
 
@@ -356,4 +373,5 @@ The CLI reports:
 - ambiguous or malformed file type identifiers
 
 Diagnostics are designed to remain deterministic and compatible with the stable machine-readable
-output contracts.
+output contracts. This includes stable processing-path reporting for runtime filesystem inputs and
+stable configuration-source identity reporting for file-backed configuration provenance.

--- a/docs/usage/commands/check.md
+++ b/docs/usage/commands/check.md
@@ -106,6 +106,11 @@ working directory; path-based filters run before file-type filters, and exclude 
 precedence. See [Filtering](../filtering.md#path-based-filtering) for the full path discovery
 contract.
 
+During discovery, TopMark normalizes filesystem identity and selects processing paths. If multiple
+path spellings resolve to the same filesystem target (for example a symlink and its target), `check`
+processes the resolved target once. Downstream filtering, probing, header generation, and
+machine-readable output operate on the selected processing path rather than the original spelling.
+
 ### File type filters
 
 - `--include-file-types / -t` Restrict processing to the given file type identifiers. May be
@@ -142,6 +147,9 @@ Notes:
 - Patterns in `--include`, `--exclude`, and the files passed to `--include-from` / `--exclude-from`
   are also resolved **relative to CWD**. Absolute patterns are not supported.
 - Path-based filters are evaluated **before** file-type filters.
+- Existing filesystem inputs are normalized to selected processing paths before runtime processing.
+- Symlink spellings are not preserved for runtime identity, generated filesystem-related header
+  metadata, or machine-readable `result.path` fields.
 - Exclude rules win over include rules when both match a path.
 - File-type filters are applied after path-based include/exclude filtering.
 - File-type filters are normalized to canonical qualified file type identities before filtering,
@@ -241,6 +249,9 @@ ______________________________________________________________________
     detection.
 - Newline/BOM preservation: preserved across all paths (insert/replace). Reader normalizes in
   memory; updater reattaches BOM and keeps line endings.
+- Header metadata path fields: generated from the selected processing target. If a file is reached
+  through a symlink, `file_relpath`, `file_abspath`, `relpath`, and `abspath` describe the resolved
+  target TopMark reads and writes rather than the symlink spelling.
 - Idempotency: running `topmark check` again on a file that already has a correct header produces no
   diff and exit code 0 (unless other files would change).
 
@@ -289,9 +300,11 @@ For the canonical schema, stable `kind` values, and shared conventions, see:
 
 {% include-markdown "\_snippets/output-contract.md" %}
 
-Machine-readable output emits processing result paths with POSIX `/` separators and resolved file
-type identities using canonical qualified identity strings when available. Configuration payloads
-also emit normalized file type filters and `policy_by_type` keys.
+Machine-readable output emits selected processing paths with POSIX `/` separators and resolved file
+type identities using canonical qualified identity strings when available. If a checked file is
+reached through a symlink, per-file `result.path` describes the resolved processing target rather
+than the symlink spelling. Configuration payloads also emit normalized file type filters and
+`policy_by_type` keys.
 
 Notes:
 
@@ -299,8 +312,9 @@ Notes:
 - The `config` payload in JSON and NDJSON is the resolved runtime configuration snapshot after
   per-source TOML validation, layered configuration merge, staged configuration-loading validation,
   and CLI override application.
-- Per-file `result.path` values use POSIX `/` separators on all platforms. This path serialization
-  contract applies to processing result payloads; human TEXT output remains display-oriented.
+- Per-file `result.path` values are selected processing paths serialized with POSIX `/` separators
+  on all platforms. This path serialization contract applies to processing result payloads; human
+  TEXT output remains display-oriented.
 
 ### JSON schema (detail mode)
 
@@ -496,6 +510,9 @@ ______________________________________________________________________
   detailed TEXT rendering; use logging options for internal debug logs.
 - **Patterns do not match**: Remember that include/exclude patterns are **relative to CWD**. `cd`
   into the project root before running.
+- **Symlink path not shown in output**: `check` processes selected processing paths. If a symlink
+  and its target resolve to the same file, machine-readable output and generated header metadata
+  describe the resolved target rather than the symlink spelling.
 - **File type filter does not match**: use [`topmark probe`](probe.md) to inspect resolution
   decisions, and prefer qualified identifiers such as `topmark:python` when local identifiers may be
   ambiguous.

--- a/docs/usage/commands/config/check.md
+++ b/docs/usage/commands/config/check.md
@@ -87,7 +87,12 @@ ______________________________________________________________________
   configuration-loading validation.
 
 TopMark resolves configuration from defaults, user config, the project chain, explicit `--config`
-files, and CLI overrides before staged validation produces the effective runtime configuration. See
+files, and CLI overrides before staged validation produces the effective runtime configuration.
+
+For file-backed configuration sources, TopMark determines configuration-source identity using the
+resolved configuration-file target. If a configuration file is reached through a symlink,
+precedence, scope evaluation, applicability checks, and provenance operate on the resolved target
+rather than the symlink spelling. See
 [Configuration discovery, precedence, and policy](../../../configuration/discovery.md) for the full
 configuration-loading and validation contract.
 
@@ -122,6 +127,10 @@ file-processing inputs:
 
 Use `--config PATH` to validate an explicit config file, or rely on normal config discovery to
 validate the effective runtime configuration for the current working directory.
+
+When `--config PATH` refers to a symlinked configuration file, validation uses the resolved
+configuration target as the configuration source. This mirrors the configuration-source identity
+model used throughout configuration discovery and layered provenance reporting.
 
 ______________________________________________________________________
 
@@ -203,6 +212,10 @@ The canonical schema, stable `kind` values, and shared conventions are documente
 Machine-readable configuration snapshots emit normalized canonical qualified file type identities
 after configuration normalization.
 
+Machine-readable configuration provenance uses configuration-source identity based on the resolved
+configuration-file target. Configuration-source paths reported by machine-readable output therefore
+describe the resolved configuration target rather than a symlink spelling used to reach it.
+
 {% include-markdown "\_snippets/path-serialization-contract.md" %}
 
 Notes:
@@ -216,6 +229,8 @@ Notes:
   validity decision is evaluated across these staged configuration-loading validation logs
   collectively. Identifier normalization and runtime applicability evaluation participate in this
   staged validation flow.
+- Configuration provenance, scope applicability, and precedence evaluation use configuration-source
+  identity based on resolved configuration-file targets.
 
 Example (`[config].strict = true` resolved from TOML, with no CLI override):
 
@@ -360,3 +375,7 @@ ______________________________________________________________________
   [`topmark config dump`](./dump.md).
 - **Unexpected validation failures**: use `-vv` or machine-readable output to inspect staged
   validation diagnostics.
+- **Configuration path differs from invocation spelling**: configuration provenance reports the
+  resolved configuration target. If a configuration file is loaded through a symlink,
+  machine-readable provenance and layered configuration views may show the resolved target rather
+  than the symlink spelling.

--- a/docs/usage/commands/config/dump.md
+++ b/docs/usage/commands/config/dump.md
@@ -112,16 +112,25 @@ strict = false
 
 Each layer includes:
 
-- `origin` - where the configuration came from (e.g. `<defaults>`, file path)
+- `origin` - where the configuration came from (e.g. `<defaults>`, resolved configuration-file path)
 - `kind` - layer type (e.g. `default`, `discovered`)
 - `precedence` - merge order
-- `scope_root` - optional root for discovered configs
+- `scope_root` - optional applicability root associated with the configuration source
 - `toml` - the source-local TopMark TOML fragment after TOML-layer validation
+
+For file-backed layers, `origin` and `scope_root` describe the resolved configuration-file target
+used for configuration-source identity. If a configuration file is loaded through a symlink, layered
+provenance reports the resolved target rather than the symlink spelling.
 
 The second TOML document is identical to the standard flattened runtime configuration output.
 
 TopMark resolves configuration from defaults, user config, the project chain, explicit `--config`
-files, and CLI overrides before staged validation produces the effective runtime configuration. See
+files, and CLI overrides before staged validation produces the effective runtime configuration.
+
+For file-backed configuration sources, TopMark determines configuration-source identity using the
+resolved configuration-file target. If a configuration file is reached through a symlink,
+precedence, scope evaluation, applicability checks, and layered provenance operate on the resolved
+target rather than the symlink spelling. See
 [Configuration discovery, precedence, and policy](../../../configuration/discovery.md) for the full
 configuration-loading and validation contract.
 
@@ -141,6 +150,10 @@ ______________________________________________________________________
 - **`--files-from`** is accepted for compatibility, but listed paths do not affect the dumped
   configuration. File lists are inputs for file-processing commands, not runtime configuration
   state.
+
+When `--config PATH` refers to a symlinked configuration file, configuration loading and layered
+provenance use the resolved configuration target as the configuration source. This mirrors the
+configuration-source identity model used throughout configuration discovery.
 
 Positional PATH arguments are rejected as invalid CLI usage. `config dump` explains configuration
 state; it does not process source files.
@@ -182,6 +195,10 @@ The canonical schema, stable `kind` values, and shared conventions are documente
 Machine-readable configuration snapshots emit normalized canonical qualified file type identities
 after configuration normalization.
 
+Machine-readable configuration provenance uses configuration-source identity based on the resolved
+configuration-file target. Configuration-source paths reported by machine-readable output therefore
+describe the resolved configuration target rather than a symlink spelling used to reach it.
+
 {% include-markdown "\_snippets/path-serialization-contract.md" %}
 
 Notes:
@@ -191,6 +208,9 @@ Notes:
   validation performed per source before layered configuration merging.
 - With `--show-layers`, machine-readable output also includes a `config_provenance` payload before
   the flattened runtime configuration snapshot.
+- File-backed provenance entries use configuration-source identity based on resolved configuration
+  targets. `origin` and `scope_root` therefore describe resolved configuration targets rather than
+  symlink spellings.
 - Diagnostics are not emitted for this command; it is an inspection view of the effective runtime
   configuration.
 
@@ -214,6 +234,9 @@ With `--show-layers`, the JSON envelope becomes:
   "config": { /* ConfigPayload */ }
 }
 ```
+
+The `config_provenance` payload reports configuration layers using configuration-source identity.
+For file-backed layers, provenance paths describe resolved configuration targets.
 
 ### NDJSON schema
 
@@ -326,3 +349,6 @@ ______________________________________________________________________
   configuration.
 - **Unexpected configuration layering**: use `--show-layers` to inspect layered provenance and
   validated TOML fragments.
+- **Configuration path differs from invocation spelling**: layered provenance and machine-readable
+  provenance report resolved configuration targets. If a configuration file is loaded through a
+  symlink, `origin` and `scope_root` may differ from the path spelling supplied on the command line.

--- a/docs/usage/commands/probe.md
+++ b/docs/usage/commands/probe.md
@@ -25,7 +25,7 @@ Instead, it exposes the resolution decision process, including:
 - the runtime-resolution status and reason
 - all scored candidate file types
 - match signals (extension, filename, pattern, content probing)
-- explicit inputs filtered during discovery before file-type resolution
+- explicit inputs filtered during discovery before runtime probing
 
 {% include-markdown "\_snippets/terminology.md" %}
 
@@ -105,6 +105,14 @@ working directory; path-based filters run before file-type filters, and exclude 
 precedence. See [Filtering](../filtering.md#path-based-filtering) for the full path discovery
 contract.
 
+During discovery, TopMark normalizes filesystem identity and selects processing paths before runtime
+probing begins. If multiple path spellings resolve to the same filesystem target (for example a
+symlink and its target), `probe` operates on the selected processing path rather than preserving the
+original spelling.
+
+Filtered and missing explicit inputs remain diagnostic records because they never became normal
+processing paths.
+
 Unlike processing commands, `probe` may report explicitly requested files as filtered diagnostic
 results instead of silently omitting them.
 
@@ -143,6 +151,13 @@ topmark probe --exclude-file-types topmark:python src/
 See [Filtering](../filtering.md#path-based-filtering) for CWD-resolution rules, missing vs unmatched
 input behavior, include/exclude precedence, and STDIN interactions.
 
+Notes:
+
+- Existing filesystem inputs are normalized to selected processing paths before runtime probing.
+- Symlink spellings are not preserved for runtime identity or machine-readable probe-path fields.
+- Missing and filtered explicit inputs may still report the original diagnostic input path because
+  no processing path was selected.
+
 ### Example
 
 ```bash
@@ -163,6 +178,8 @@ ______________________________________________________________________
   [`strip`](strip.md), while preserving filtered explicit inputs as diagnostic probe results.
 - Shared runtime resolution: uses the same normalization, scoring, and runtime resolution logic as
   [`check`](check.md) and [`strip`](strip.md).
+- Processing-path identity: runtime probing operates on selected processing paths. Multiple path
+  spellings that resolve to the same target are collapsed before ordinary probe execution.
 - Candidate visibility: exposes selected file type, processor, candidate scores, match signals,
   runtime-resolution status, and runtime-resolution reason.
 - Idempotency: repeated runs produce identical output for unchanged inputs.
@@ -203,8 +220,10 @@ For the canonical schema, see:
 - [Machine-readable output](../machine-output.md)
 - [Machine-readable format conventions](../../dev/machine-formats.md)
 
-Probe machine-readable output emits probe paths with POSIX `/` separators and resolved file type
-identities using canonical qualified identity strings when available.
+Probe machine-readable output emits processing paths with POSIX `/` separators and resolved file
+type identities using canonical qualified identity strings when available. For probe results that
+reach runtime probing, the emitted path describes the selected processing target rather than the
+original symlink or invocation spelling.
 
 ### Shared output controls
 
@@ -252,6 +271,10 @@ ______________________________________________________________________
 
 Only explicit inputs that actually fail selection are represented as filtered probe payloads.
 
+Probe payloads that reach runtime probing report the selected processing path. Filtered and missing
+explicit inputs may instead report the original diagnostic input path because no processing path was
+selected.
+
 Directories that successfully expand to selected files are not emitted as additional filtered probe
 results. Explicit missing paths are represented as missing-input probe results rather than filtered
 probe results.
@@ -286,8 +309,12 @@ Filtered probe results may use one of the following reasons:
 Canonical file type identities in machine-readable output use normalized qualified-key identities
 such as `topmark:python`.
 
-Probe payload `path` values use POSIX `/` separators on all platforms. Human TEXT output remains
-display-oriented and may use the host platform's native path representation.
+Probe payload `path` values represent selected processing paths serialized with POSIX `/` separators
+on all platforms. Human TEXT output remains display-oriented and may use the host platform's native
+path representation.
+
+Filtered and missing explicit-input probe results are an exception: they may report the original
+diagnostic input path because runtime processing-path selection never occurred.
 
 ______________________________________________________________________
 
@@ -397,6 +424,9 @@ ______________________________________________________________________
 
 - **Unsupported file**: ensure file type patterns, bindings, or extensions are configured correctly.
 - **Unexpected resolution result**: use `-vv` to inspect candidate scores and match signals.
+- **Symlink path not shown in output**: `probe` reports selected processing paths for inputs that
+  reach runtime probing. If a symlink and its target resolve to the same file, the emitted probe
+  path describes the resolved processing target rather than the symlink spelling.
 - **File type filter does not match**: prefer qualified identifiers such as `topmark:python` when
   local identifiers may be ambiguous.
 - **No processor**: check that a processor binding exists for the selected file type.

--- a/docs/usage/commands/strip.md
+++ b/docs/usage/commands/strip.md
@@ -105,6 +105,11 @@ working directory; path-based filters run before file-type filters, and exclude 
 precedence. See [Filtering](../filtering.md#path-based-filtering) for the full path discovery
 contract.
 
+During discovery, TopMark normalizes filesystem identity and selects processing paths. If multiple
+path spellings resolve to the same filesystem target (for example a symlink and its target), `strip`
+processes the resolved target once. Downstream filtering, probing, stripping, and machine-readable
+output operate on the selected processing path rather than the original spelling.
+
 ### File type filters
 
 - `--include-file-types / -t` Restrict processing to the given file type identifiers. May be
@@ -134,6 +139,11 @@ topmark strip --exclude-file-types topmark:markdown docs/
 
 See [Filtering](../filtering.md#path-based-filtering) for CWD-resolution rules, missing vs unmatched
 input behavior, include/exclude precedence, and STDIN interactions.
+
+Notes:
+
+- Existing filesystem inputs are normalized to selected processing paths before runtime processing.
+- Symlink spellings are not preserved for runtime identity or machine-readable `result.path` fields.
 
 {% include-markdown "\_snippets/report-scope.md" %}
 
@@ -179,6 +189,8 @@ ______________________________________________________________________
   intentional blank as needed.
 - Markdown processor: ignores code fences for detection; header-like text inside fences is not
   removed.
+- Processing-path identity: if a file is reached through a symlink, stripping operates on the
+  resolved target TopMark reads and writes rather than the symlink spelling used to reach it.
 
 ______________________________________________________________________
 
@@ -225,9 +237,11 @@ For the canonical schema, stable `kind` values, and shared conventions, see:
 
 {% include-markdown "\_snippets/output-contract.md" %}
 
-Machine-readable output emits processing result paths with POSIX `/` separators and resolved file
-type identities using canonical qualified identity strings when available. Configuration payloads
-also emit normalized file type filters and `policy_by_type` keys.
+Machine-readable output emits selected processing paths with POSIX `/` separators and resolved file
+type identities using canonical qualified identity strings when available. If a stripped file is
+reached through a symlink, per-file `result.path` describes the resolved processing target rather
+than the symlink spelling. Configuration payloads also emit normalized file type filters and
+`policy_by_type` keys.
 
 Notes:
 
@@ -236,8 +250,9 @@ Notes:
 - The `config` payload in JSON and NDJSON is the resolved runtime configuration snapshot after
   per-source TOML validation, layered configuration merge, staged configuration-loading validation,
   and CLI override application.
-- Per-file `result.path` values use POSIX `/` separators on all platforms. This path serialization
-  contract applies to processing result payloads; human TEXT output remains display-oriented.
+- Per-file `result.path` values are selected processing paths serialized with POSIX `/` separators
+  on all platforms. This path serialization contract applies to processing result payloads; human
+  TEXT output remains display-oriented.
 
 ### JSON schema (detail mode)
 
@@ -431,6 +446,9 @@ ______________________________________________________________________
   detailed TEXT rendering; use logging options for internal debug logs.
 - **Patterns do not match**: Remember that include/exclude patterns are **relative to CWD**. `cd`
   into the project root before running.
+- **Symlink path not shown in output**: `strip` operates on selected processing paths. If a symlink
+  and its target resolve to the same file, machine-readable output reports the resolved processing
+  target rather than the symlink spelling.
 - **File type filter does not match**: use [`topmark probe`](probe.md) to inspect resolution
   decisions, and prefer qualified identifiers such as `topmark:python` when local identifiers may be
   ambiguous.

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -22,7 +22,35 @@ TopMark runtime configuration may be provided through:
 Configuration is resolved through layered discovery, normalization, and precedence rules.
 Higher-precedence layers override lower-precedence layers.
 
+For file-backed configuration sources, TopMark determines configuration-source identity using the
+resolved configuration-file target. Symlink spellings are not preserved for precedence, scope, or
+applicability evaluation.
+
 {% include-markdown "\_snippets/terminology.md" %}
+
+______________________________________________________________________
+
+## Configuration-source identity
+
+TopMark evaluates file-backed configuration sources using configuration-source identity rather than
+invocation spelling.
+
+Examples such as:
+
+```text
+real/topmark.toml
+link-to-topmark.toml
+```
+
+may refer to the same configuration source.
+
+Configuration precedence, scope evaluation, layered configuration export, and machine-readable
+configuration provenance operate on the resolved configuration-file target.
+
+> [!NOTE]
+>
+> This behavior mirrors the processing-path contract used for runtime file processing. TopMark
+> normalizes filesystem identity before configuration applicability and runtime evaluation.
 
 ______________________________________________________________________
 
@@ -210,10 +238,17 @@ ______________________________________________________________________
 
 {% include-markdown "\_snippets/runtime-configuration-model.md" %}
 
+Runtime evaluation consumes the effective configuration produced after discovery, precedence,
+normalization, and configuration-source identity resolution have completed.
+
+For configuration files loaded through symlinks, the effective configuration is associated with the
+resolved configuration target rather than the symlink spelling used to reach it.
+
 ______________________________________________________________________
 
 ## See also
 
+- [Machine-readable output](machine-output.md#tomlprovenancepayload)
 - [Filtering recipes and behavior](filtering.md)
 - [Configuration overview](../configuration/index.md)
 - [Configuration discovery, precedence, and policy](../configuration/discovery.md)

--- a/docs/usage/exit-codes.md
+++ b/docs/usage/exit-codes.md
@@ -69,6 +69,9 @@ Notes:
   configuration-loading or runtime-resolution outcomes depending on command behavior.
 - Explicit missing literal paths are treated as hard input errors (66). Unmatched glob patterns are
   soft diagnostics and do not produce 66.
+- Filesystem identity normalization and processing-path selection do not affect exit-code semantics.
+  Different path spellings that resolve to the same filesystem target contribute to the same runtime
+  processing outcome.
 
 ______________________________________________________________________
 
@@ -85,6 +88,10 @@ Exit codes communicate:
 
 Machine-readable JSON and NDJSON output communicate structured diagnostics, semantic outcomes,
 runtime-resolution details, and processing metadata.
+
+For filesystem inputs, machine-readable path fields report selected processing paths. Exit codes are
+derived from runtime outcomes and do not depend on whether a file was reached through a symlink or
+another equivalent path spelling.
 
 This separation keeps automation deterministic while preserving stable machine-readable output
 contracts independently from process exit semantics.
@@ -113,6 +120,8 @@ Notes:
 - Explicit missing input paths are reported as errors (66), even if no files are selected for
   processing.
 - Unmatched glob patterns are treated as discovery diagnostics and do not cause failure.
+- Files reached through symlinks contribute to the same runtime outcome as their selected processing
+  target and do not introduce additional exit-code states.
 
 ______________________________________________________________________
 
@@ -135,6 +144,8 @@ Notes:
 - Unmatched glob patterns are treated as discovery diagnostics and do not cause failure.
 - `3` is a semantic change signal, not a runtime failure: it indicates that headers would be
   stripped.
+- Files reached through symlinks contribute to the same runtime outcome as their selected processing
+  target and do not introduce additional exit-code states.
 
 ______________________________________________________________________
 
@@ -157,6 +168,8 @@ Notes:
   probe outcomes.
 - Unmatched glob patterns are reported as filtered semantic outcomes and result in exit code 69.
 - Ambiguous or unresolved file-type filtering may also contribute to semantic resolution outcomes.
+- Filesystem-identity normalization occurs before runtime probing. Exit-code semantics are based on
+  probe outcomes for selected processing paths rather than the original input spelling.
 
 ______________________________________________________________________
 
@@ -266,6 +279,9 @@ semantic outcomes occur during a single invocation.
 This ensures that hard runtime or environment failures take precedence over informational, semantic,
 or availability-oriented outcomes.
 
+Filesystem-identity normalization and processing-path selection occur before exit-code evaluation
+and do not introduce additional priority levels.
+
 Example:
 
 ```sh
@@ -308,3 +324,5 @@ ______________________________________________________________________
 - [Pre-commit integration](pre-commit.md)
 - [Configuration](configuration.md)
 - [Configuration discovery, precedence, and policy](../configuration/discovery.md)
+- [Machine-readable output](machine-output.md)
+- [Filesystem identity and processing paths](../dev/resolution.md#filesystem-identity-and-processing-paths)

--- a/docs/usage/filtering.md
+++ b/docs/usage/filtering.md
@@ -44,6 +44,9 @@ TopMark applies filtering in a deterministic order:
 
 Exclude rules take precedence over include rules.
 
+Filesystem-identity normalization and processing-path selection occur during path discovery before
+runtime applicability evaluation and processor resolution.
+
 For canonical file-type identifier semantics, see [File-type filtering](#file-type-filtering). For
 layered configuration behavior, see [Configuration](configuration.md).
 
@@ -60,6 +63,8 @@ TopMark intentionally separates:
 
 1. path discovery
 1. path filtering
+1. filesystem-identity normalization
+1. deduplication and processing-path selection
 1. file-type filtering
 1. runtime applicability evaluation
 1. runtime probing and processor resolution
@@ -68,6 +73,11 @@ Each stage consumes the finalized results of the previous stage.
 
 This layered filtering model keeps runtime behavior deterministic while preserving stable probe
 diagnostics and machine-readable filtering semantics.
+
+When multiple path spellings resolve to the same filesystem target (for example a symlink and its
+target), TopMark selects a canonical processing path before runtime filtering continues. Downstream
+filtering, probing, header generation, and machine-readable output operate on that processing path
+rather than the original spelling used to reach the file.
 
 ______________________________________________________________________
 
@@ -105,6 +115,9 @@ Stable path-filtering semantics:
 - Absolute patterns are not supported.
 - Exclude rules take precedence over include rules.
 - Path-based filtering occurs before file-type filtering.
+- Existing filesystem inputs are normalized to canonical processing paths before runtime processing.
+- Symlink spellings are not preserved for runtime identity, generated filesystem-related header
+  metadata, or machine-readable path fields.
 
 ______________________________________________________________________
 
@@ -135,6 +148,7 @@ This includes:
 - file-type filtering
 - canonical file-type identifier normalization and resolution
 - ambiguity handling
+- filesystem-identity normalization and processing-path selection
 
 However, unlike processing commands ([`check`](commands/check.md), [`strip`](commands/strip.md)),
 [`probe`](commands/probe.md) also reports \*\*explicit inputs that were filtered out before runtime
@@ -183,6 +197,10 @@ Filtered probe results may use one of the following reasons:
 
 Only explicitly requested runtime inputs (CLI paths or `--files-from`) are reported this way. Files
 excluded implicitly during recursive discovery are not enumerated.
+
+For probe records that reach runtime probing, reported filesystem paths describe the selected
+processing path. They do not guarantee preservation of the original CLI argument, glob match, or
+symlink spelling.
 
 ______________________________________________________________________
 

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -131,6 +131,12 @@ Check if the files have TopMark headers compliant with the settings defined.
 topmark check .
 ```
 
+> [!NOTE]
+>
+> TopMark normalizes filesystem identity before processing files. If a file is reachable through
+> multiple path spellings (for example a symlink and its target), TopMark selects a canonical
+> processing path and processes the target once.
+
 ______________________________________________________________________
 
 ## 4. Preview changes (unified diff)
@@ -151,6 +157,12 @@ You can add / update the TopMark headers in files by specifying `--apply`:
 ```bash
 topmark check --apply .
 ```
+
+> [!TIP]
+>
+> Generated filesystem-related header fields such as `file_relpath` and `file_abspath` describe the
+> selected processing target. If a file is reached through a symlink, header metadata reflects the
+> resolved target TopMark reads and writes.
 
 ______________________________________________________________________
 
@@ -210,6 +222,7 @@ Continue with:
 
 - [Configuration discovery and precedence](./configuration.md)
 - [Filtering](./filtering.md)
+- [Machine-readable output](./machine-output.md)
 - [Pre-commit integration](./pre-commit.md)
 - [CI integration](./ci.md)
 - [Exit codes](./exit-codes.md)

--- a/docs/usage/header-placement.md
+++ b/docs/usage/header-placement.md
@@ -58,6 +58,9 @@ TopMark intentionally separates:
 Header placement semantics are determined by the selected header processor after runtime probing,
 policy evaluation, and processor resolution have completed.
 
+The generated header metadata describes the selected processing target rather than the original
+invocation spelling used to reach that target.
+
 This layered runtime model keeps placement behavior deterministic while preserving stable
 processor-specific comment syntax and insertion semantics.
 
@@ -96,8 +99,6 @@ Example (Python / shell-style line comments):
 
 echo "Hello, World!"
 ```
-
-Note that header path fields such as `file_relpath` use POSIX `/` separators on all platforms.
 
 ______________________________________________________________________
 
@@ -198,9 +199,6 @@ topmark:header:end
 </configuration>
 ```
 
-Header metadata path fields are serialized with POSIX `/` separators regardless of the host
-operating system.
-
 ______________________________________________________________________
 
 ## Markdown files
@@ -237,7 +235,7 @@ ______________________________________________________________________
 ## Placement guarantees
 
 - Path serialization: generated header path fields (`file_relpath`, `file_abspath`, `relpath`, and
-  `abspath`) use POSIX `/` separators on all platforms.
+  `abspath`) describe the selected processing target and use POSIX `/` separators on all platforms.
 - Newline preservation: the inserted header uses the same newline style as the file (LF/CRLF/CR).
 - BOM preservation: if a UTF-8 BOM is present, it is preserved.
 - Idempotency: re-running TopMark on a file with a compliant header produces no runtime changes.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -16,7 +16,7 @@ This section contains the user-facing documentation for installing, running, con
 integrating TopMark.
 
 The pages in this section focus on practical CLI usage, repository workflows, configuration,
-validation, and automation.
+validation, automation, filesystem identity, file discovery, and machine-readable integration.
 
 Start here if you want to:
 
@@ -24,6 +24,7 @@ Start here if you want to:
 - run TopMark from the CLI;
 - upgrade an existing repository to TopMark 1.0;
 - configure header fields, policies, filtering, and file discovery;
+- understand filesystem identity, processing paths, and symlink behavior;
 - integrate TopMark with pre-commit or CI;
 - understand exit codes, reports, and machine-readable output.
 
@@ -39,6 +40,8 @@ ______________________________________________________________________
   output selection.
 - [Configuration](configuration.md) - configure layered runtime behavior and policy settings.
 - [Filtering](filtering.md) - include, exclude, and constrain file processing.
+- [Machine-readable output](machine-output.md) - understand processing paths, configuration
+  provenance, and stable automation contracts.
 - [Policies](policies.md) - control insertion, update, validation, and stripping behavior.
 - [Header placement](header-placement.md) - understand how TopMark locates and inserts headers.
 - [Pre-commit integration](pre-commit.md) - integrate TopMark into local developer workflows.

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -223,6 +223,31 @@ comparisons and joins across payloads.
 See [Registry model](../dev/registry-model.md#qualified-vs-local-identifiers) for the full identity
 contract.
 
+### Filesystem path fields
+
+Machine-readable filesystem path fields expose TopMark's selected processing paths.
+
+A processing path is selected after discovery, filtering, filesystem-identity normalization, and
+deduplication. It is not necessarily the original CLI argument, configuration entry, glob match, or
+symlink spelling supplied by the user.
+
+TopMark currently identifies existing processing inputs by resolved processing target path. For
+example, if both of these paths refer to the same target:
+
+```text
+real/source.py
+links/source-link.py
+```
+
+machine-readable output may report only:
+
+```text
+real/source.py
+```
+
+The emitted path is still serialized with POSIX `/` separators on all platforms, as documented in
+the path-representation contract above.
+
 ______________________________________________________________________
 
 ## Resolution diagnostics ([`probe`](../usage/commands/probe.md))
@@ -233,6 +258,10 @@ not compute header changes, diffs, strip plans, or write plans.
 
 Probe output reports canonical file type identities after identifier normalization and file-type
 filtering.
+
+Probe output also reports processing paths after discovery and filesystem-identity normalization.
+When a symlinked input reaches probing, the emitted path describes the resolved processing target
+rather than preserving the symlink spelling.
 
 Probe machine-readable output is unaffected by TEXT verbosity or quiet mode. The JSON and NDJSON
 formats expose the same resolution evidence used by the human-facing probe renderers:
@@ -395,8 +424,10 @@ Filtered probe payloads may use one of these reasons:
 
 Fields:
 
-- `path`: probed or explicitly requested filesystem path, serialized with POSIX `/` separators. For
-  filtered and missing explicit inputs, this is the path supplied to the command.
+- `path`: probed filesystem processing path, serialized with POSIX `/` separators. For normal probe
+  payloads, this is the selected processing path after filesystem-identity normalization. For
+  filtered and missing explicit inputs, this remains the explicit path supplied to the command
+  because no normal processing path was selected.
 - `status`: probe status, currently one of:
   - `resolved` - a file type and processor were selected.
   - `unsupported` - no file type candidate matched.
@@ -597,10 +628,15 @@ The canonical builders and typing live under:
 - \[`topmark.pipeline.machine.serializers`\][topmark.pipeline.machine.serializers] (JSON/NDJSON
   serialization)
 
+Per-file result payloads report the selected processing path. If a file is reached through a
+symlink, the emitted `path` describes the resolved processing target rather than the symlink
+spelling. This is the same path identity used by runtime pipeline processing and generated
+filesystem-related header metadata.
+
 At a high level, per-file results include:
 
 - identity:
-  - `path` (serialized with POSIX `/` separators)
+  - `path` (selected processing path, serialized with POSIX `/` separators)
   - `file_type` (resolved canonical TopMark file type key, for example `topmark:python`)
 - pipeline execution:
   - executed step names
@@ -846,6 +882,11 @@ TopMark TOML fragments.
 
 Real filesystem `origin` and `scope_root` values use POSIX `/` separators on all platforms.
 Synthetic layer origins such as built-in defaults are stable labels rather than filesystem paths.
+
+File-backed configuration provenance uses configuration-source identity based on the resolved
+configuration-file target. If a configuration file is loaded through a symlink, `origin` and
+`scope_root` describe the resolved configuration target and its scope rather than the symlink
+spelling.
 
 The outer `config_layers` container key belongs to the config machine-readable output domain, while
 the inner provenance-layer fragment keys (`origin`, `kind`, `precedence`, `toml`, `scope_root`) are
@@ -1176,6 +1217,8 @@ Consumers should:
 - Assume additive fields may appear over time within the 1.x compatibility model.
 - Prefer canonical identity fields such as `qualified_key`, `file_type_key`, and `processor_key`
   over display-oriented names.
+- Treat filesystem `path`, `origin`, and `scope_root` fields as serialized processing/provenance
+  paths, not as lossless echoes of the original invocation spelling.
 
 Breaking machine-readable output changes should be signaled through Conventional Commits using the
 `!` marker and documented in the changelog.

--- a/docs/usage/policies.md
+++ b/docs/usage/policies.md
@@ -45,6 +45,9 @@ Policy semantics behave consistently across:
 - API overlays
 - effective runtime policy evaluation and runtime resolution
 
+Runtime policy evaluation operates on selected processing paths after filesystem-identity
+normalization and processing-path selection have completed.
+
 Policy values shown here are part of the public configuration surface.
 
 > [!NOTE]
@@ -78,6 +81,11 @@ TopMark resolves policy in this order:
 1. discovered config files
 1. explicit config overlays
 1. CLI or API overrides
+
+For file-backed configuration sources, policy layering uses configuration-source identity based on
+the resolved configuration-file target. If a policy-bearing configuration file is loaded through a
+symlink, precedence, applicability, and layered provenance are evaluated using the resolved
+configuration target rather than the symlink spelling.
 
 These runtime policy layers are constructed after staged TOML-layer validation. Source-local TOML
 sections (e.g. `[config]`) do not participate in runtime policy layering.
@@ -252,6 +260,11 @@ are supported when the local identifier is unambiguous.
 Internally, TopMark resolves per-file-type runtime policy using canonical qualified file type
 identities.
 
+> [!NOTE] **File-type identity and filesystem identity**
+>
+> File-type identity and filesystem identity are separate concepts. File-type policy resolution
+> operates on the selected processing target after filesystem identity normalization has completed.
+
 Example:
 
 ```toml
@@ -369,3 +382,5 @@ ______________________________________________________________________
 - [CLI overview](cli.md)
 - [Shared options](shared-options.md)
 - [Configuration discovery, precedence, and policy](../configuration/discovery.md)
+- [Machine-readable output](machine-output.md)
+- [Filesystem identity and processing paths](../dev/resolution.md#filesystem-identity-and-processing-paths)

--- a/docs/usage/pre-commit.md
+++ b/docs/usage/pre-commit.md
@@ -28,6 +28,10 @@ setup, recommended patterns, and troubleshooting.
 Hook execution uses the same runtime-resolution, filtering, policy-evaluation, and runtime
 configuration semantics as normal CLI execution.
 
+Hook execution also uses the same filesystem-identity normalization and processing-path selection
+semantics as normal CLI execution. If multiple path spellings resolve to the same filesystem target
+(for example a symlink and its target), TopMark processes the selected processing target once.
+
 ______________________________________________________________________
 
 ## Quick start (consumer repos)
@@ -40,7 +44,7 @@ Add TopMark to a project's `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/shutterfreak/topmark
-    rev: v1.0.0   # pin to a released tag
+    rev: v1.0.1   # pin to a released tag
     hooks:
       - id: topmark-check
         # Optional: limit scope to supported text types
@@ -115,6 +119,10 @@ pass policy options such as `--header-mutation-mode`, `--allow-header-in-empty-f
 These options follow the same runtime policy-resolution and file type identity semantics as normal
 CLI execution.
 
+Filesystem-processing hooks also follow the same processing-path identity semantics as normal CLI
+execution. Runtime processing operates on selected processing paths rather than preserving the
+original filename spelling supplied by pre-commit.
+
 Invoke the manual hook locally:
 
 ```bash
@@ -137,12 +145,18 @@ multiple times per invocation (for different batches). This is expected.
 
 TopMark applies the same layered runtime filtering pipeline during hook execution:
 
+1. filesystem-identity normalization and processing-path selection
 1. path filtering
 1. file-type filtering
 1. runtime-resolution and probe evaluation
 1. runtime policy evaluation
 
 {% include-markdown "\_snippets/output-contract.md" %}
+
+For filesystem-backed hook execution, machine-readable path fields and generated filesystem-related
+header metadata describe the selected processing target. If a file is reached through a symlink,
+output and generated metadata reflect the resolved target TopMark reads and writes rather than the
+symlink spelling.
 
 **Run once per repository** by setting `pass_filenames: false` in the hook manifest and letting
 TopMark perform its own file discovery from config:
@@ -166,7 +180,7 @@ Example (consumer repo):
 ```yaml
 repos:
   - repo: https://github.com/shutterfreak/topmark
-    rev: v0.10.1
+    rev: v1.0.1
     hooks:
       - id: topmark-check
         args: ["--report", "noncompliant", "--output-format=ndjson"]
@@ -245,6 +259,10 @@ topmark check --report actionable --strict
 
 You can also pass `--summary` to receive only a summary instead of per-file diagnostics.
 
+Machine-readable output emitted from pre-commit hooks follows the same processing-path contract as
+normal CLI execution. JSON and NDJSON path fields therefore report selected processing paths rather
+than preserving original pre-commit filename spellings.
+
 ### Narrow file scope in consuming repos
 
 ______________________________________________________________________
@@ -283,6 +301,8 @@ Notes:
 - Use `--quiet` in CI to suppress human-readable TEXT output and rely solely on exit status.
 - Use `topmark-probe` when a hook appears to skip, include, or classify files with unexpected
   semantic runtime outcomes.
+- Filesystem-identity normalization and processing-path selection do not affect exit-code semantics.
+  Equivalent path spellings contribute to the same runtime processing outcome.
 - For full details and edge cases (mixed-result runs, precedence), see:
   - [`Exit codes`](./exit-codes.md)
   - [`check` command](./commands/check.md)
@@ -319,6 +339,19 @@ and that the file is included as package data. In `pyproject.toml`:
 "topmark.toml" = ["topmark-example.toml"]
 ```
 
+### Symlink path differs from reported path
+
+TopMark reports selected processing paths during runtime processing.
+
+If a hook receives a symlink path from pre-commit, machine-readable output, runtime probing, and
+generated filesystem-related header metadata may report the resolved processing target rather than
+the original symlink spelling.
+
+See:
+
+- [Machine-readable output](machine-output.md)
+- [Filesystem identity and processing paths](../dev/resolution.md#filesystem-identity-and-processing-paths)
+
 ### Test your hook locally
 
 ```bash
@@ -343,3 +376,5 @@ ______________________________________________________________________
 - [Shared options](shared-options.md)
 - [CI integration](ci.md)
 - [Exit codes](exit-codes.md)
+- [Machine-readable output](machine-output.md)
+- [Filesystem identity and processing paths](../dev/resolution.md#filesystem-identity-and-processing-paths)

--- a/docs/usage/shared-options.md
+++ b/docs/usage/shared-options.md
@@ -59,6 +59,9 @@ TopMark intentionally separates:
 - machine-readable JSON and NDJSON serialization;
 - process exit-code semantics.
 
+For filesystem-processing commands, machine-readable path fields report selected processing paths
+rather than preserving the original CLI path spelling.
+
 > [!NOTE] Verbosity, quiet mode and color rendering affect only human-facing TEXT rendering.
 
 ______________________________________________________________________
@@ -171,6 +174,10 @@ Runtime file-processing commands ([`check`](commands/check.md), [`strip`](comman
 These modes are mutually exclusive: do not mix `-` (content mode) with `--files-from -`,
 `--include-from -`, or `--exclude-from -` (list mode).
 
+For filesystem-backed inputs, TopMark normalizes filesystem identity and selects processing paths
+before runtime processing begins. Multiple path spellings that resolve to the same filesystem target
+(for example a symlink and its target) are treated as a single processing target.
+
 > [!NOTE] **STDIN input**
 >
 > TopMark does not provide a `--stdin` option flag. Use the POSIX-style `-` PATH sentinel together
@@ -180,6 +187,10 @@ These modes are mutually exclusive: do not mix `-` (content mode) with `--files-
 
 In content STDIN mode, `--stdin-filename` is required so TopMark can resolve file type, processor
 binding, and path-sensitive policy exactly as it would for a real file path.
+
+Because content mode does not reference an existing filesystem object, filesystem-identity
+normalization and processing-path selection do not apply. The supplied `--stdin-filename` acts only
+as a virtual path for runtime resolution and policy evaluation.
 
 For mutation commands (`check` and `strip`), `--apply` in content mode writes transformed content to
 STDOUT and routes diagnostics to STDERR. This ensures consistent file-type resolution and runtime
@@ -199,6 +210,11 @@ Layered configuration loading and discovery behavior do not apply to:
 - registry commands
 - [`version`](commands/version.md)
 
+For file-backed configuration sources, configuration discovery uses configuration-source identity
+based on the resolved configuration-file target. Layered provenance, applicability evaluation, and
+configuration precedence are therefore based on resolved configuration targets rather than symlink
+spellings.
+
 ______________________________________________________________________
 
 ## See also
@@ -209,4 +225,5 @@ ______________________________________________________________________
 - [Policies](policies.md)
 - [Exit codes](exit-codes.md)
 - [Pre-commit integration](pre-commit.md)
+- [Filesystem identity and processing paths](../dev/resolution.md#filesystem-identity-and-processing-paths)
 - [Machine-readable output](../usage/machine-output.md)

--- a/src/topmark/config/model.py
+++ b/src/topmark/config/model.py
@@ -70,7 +70,6 @@ from topmark.core.errors import AmbiguousFileTypeIdentifierError
 from topmark.core.errors import ConfigValidationError
 from topmark.core.errors import InvalidRegistryIdentityError
 from topmark.core.logging import get_logger
-from topmark.filetypes.model import FileType
 from topmark.toml.keys import Toml
 
 if TYPE_CHECKING:

--- a/src/topmark/config/resolution/layers.py
+++ b/src/topmark/config/resolution/layers.py
@@ -27,6 +27,7 @@ from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.config.io.deserializers import mutable_config_from_layered_toml_table
 from topmark.config.resolution.synthetic import SyntheticConfigSource
 from topmark.core.logging import get_logger
+from topmark.utils.path import canonical_processing_path
 
 if TYPE_CHECKING:
     from topmark.config.model import MutableConfig
@@ -84,36 +85,48 @@ class ConfigLayer:
 
 def _make_config_layer(
     *,
-    origin: Path | SyntheticConfigSource,
+    origin: SyntheticConfigSource,
     kind: ConfigLayerKind,
     precedence: int,
     config: MutableConfig,
-    scope_root: Path | None = None,
 ) -> ConfigLayer:
-    """Return a normalized config provenance layer.
+    """Return a config provenance layer for a synthetic origin.
 
-    Real filesystem origins and scope roots are resolved eagerly so downstream
-    precedence and applicability logic can compare normalized filesystem
-    locations. Synthetic origins are preserved as typed provenance markers and
+    File-backed TOML sources are handled by `_make_layer_from_layered_toml_table()`
+    so it can distinguish strict processing identity from best-effort provenance
+    normalization. Synthetic origins are preserved as typed provenance markers and
     never normalized as paths.
     """
-    normalized_origin: Path | SyntheticConfigSource = (
-        origin.resolve() if isinstance(origin, Path) else origin
-    )
-    normalized_scope_root: Path | None = scope_root
-
-    if normalized_scope_root is None and isinstance(normalized_origin, Path):
-        normalized_scope_root = normalized_origin.parent.resolve()
-    elif normalized_scope_root is not None:
-        normalized_scope_root = normalized_scope_root.resolve()
-
     return ConfigLayer(
-        origin=normalized_origin,
-        scope_root=normalized_scope_root,
+        origin=origin,
+        scope_root=None,
         precedence=precedence,
         kind=kind,
         config=config,
     )
+
+
+def _best_effort_provenance_path(path: Path) -> Path:
+    """Return a normalized provenance path without requiring the file to exist.
+
+    Resolved TOML source records normally point to existing files because loaded
+    sources were canonicalized by `resolve_topmark_toml_sources()`. Some machine
+    payload and bridge tests intentionally construct provenance-only paths that
+    do not exist on disk. For those records, use non-strict resolution so layer
+    construction can still preserve stable provenance without pretending the path
+    is a processable filesystem target.
+
+    Args:
+        path: File-backed provenance path.
+
+    Returns:
+        Canonical processing path when the file exists, otherwise a non-strict
+        resolved path suitable for provenance-only records.
+    """
+    try:
+        return canonical_processing_path(path)
+    except FileNotFoundError:
+        return path.resolve()
 
 
 def _make_default_config_layer() -> ConfigLayer:
@@ -122,7 +135,6 @@ def _make_default_config_layer() -> ConfigLayer:
         origin=SyntheticConfigSource(label=DEFAULT_LAYER_ORIGIN),
         kind=ConfigLayerKind.DEFAULT,
         precedence=DEFAULT_LAYER_PRECEDENCE,
-        scope_root=None,
         config=mutable_config_from_defaults(),
     )
 
@@ -149,12 +161,16 @@ def _make_layer_from_layered_toml_table(
         fragment.
     """
     if isinstance(path, Path):
-        resolved_path: Path = path.resolve()
+        # This path is provenance for a TOML layer, not necessarily a file that
+        # TopMark will process. Use best-effort normalization here; strict
+        # processing identity belongs to loaded source resolution and target-file
+        # applicability checks.
+        resolved_path: Path = _best_effort_provenance_path(path)
         config: MutableConfig = mutable_config_from_layered_toml_table(
             data,
             config_file=resolved_path,
         )
-        return _make_config_layer(
+        return ConfigLayer(
             origin=resolved_path,
             kind=kind,
             precedence=precedence,
@@ -170,7 +186,6 @@ def _make_layer_from_layered_toml_table(
         origin=path,
         kind=kind,
         precedence=precedence,
-        scope_root=None,
         config=config,
     )
 

--- a/src/topmark/config/resolution/merge.py
+++ b/src/topmark/config/resolution/merge.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 
 from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.core.logging import get_logger
+from topmark.utils.path import canonical_processing_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -40,16 +41,17 @@ logger: TopmarkLogger = get_logger(__name__)
 
 def _is_within_scope(path: Path, scope_root: Path) -> bool:
     """Return whether `path` is within the given layer scope root."""
-    resolved_path: Path = path.resolve()
+    resolved_path: Path = canonical_processing_path(path)
+    # The target path is an existing file selected for processing, so strict
+    # canonical processing identity is appropriate. Scope roots, however, may be
+    # provenance-only roots from synthetic or test config layers; normalize them
+    # non-strictly so applicability can still be evaluated.
     resolved_scope_root: Path = scope_root.resolve()
-    result: bool
     try:
         resolved_path.relative_to(resolved_scope_root)
-        result = True
     except ValueError:
-        result = False
-
-    return result
+        return False
+    return True
 
 
 # ---- Layer merge / applicability helpers ----
@@ -94,7 +96,7 @@ def select_applicable_layers(
     Returns:
         Applicable layers in their original precedence order.
     """
-    resolved_path: Path = path.resolve()
+    resolved_path: Path = canonical_processing_path(path)
     layer_list: list[ConfigLayer] = list(layers)
     applicable: list[ConfigLayer] = []
 
@@ -133,6 +135,9 @@ def build_effective_config_for_path(
     """
     applicable: list[ConfigLayer] = select_applicable_layers(layers, path)
     draft: MutableConfig = merge_layers_globally(applicable)
+    # Logging should not introduce stricter filesystem requirements than layer
+    # selection itself. Keep this non-strict so synthetic or missing-path tests
+    # fail only at the behavior under test, not while formatting diagnostics.
     logger.debug(
         "Built effective config for %s from %d applicable layer(s)",
         path.resolve(),

--- a/src/topmark/diagnostic/model.py
+++ b/src/topmark/diagnostic/model.py
@@ -279,14 +279,17 @@ class MutableDiagnosticLog:
         """
         return compute_diagnostic_stats(self.items)
 
+    @property
     def has_info(self) -> bool:
         """Return True if the `MutableDiagnosticLog` contains info diagnostics."""
         return any(d.level == DiagnosticLevel.INFO for d in self.items)
 
+    @property
     def has_warning(self) -> bool:
         """Return True if the `MutableDiagnosticLog` contains warning diagnostics."""
         return any(d.level == DiagnosticLevel.WARNING for d in self.items)
 
+    @property
     def has_error(self) -> bool:
         """Return True if the `MutableDiagnosticLog` contains error diagnostics."""
         return any(d.level == DiagnosticLevel.ERROR for d in self.items)

--- a/src/topmark/pipeline/context/model.py
+++ b/src/topmark/pipeline/context/model.py
@@ -108,7 +108,10 @@ class ProcessingContext:
     Attributes:
         config: Effective layered configuration for this file.
         run_options: Invocation-wide execution-only runtime options for the current run.
-        path: The file path to process (absolute or relative to the working directory).
+        path: The processing path for the file, absolute or relative to the working directory.
+            Normal file-list resolution supplies TopMark's canonical processing path rather than
+            preserving the original CLI/config spelling. For filesystem inputs, symlink spellings
+            may therefore already be collapsed to their resolved target before pipeline steps run.
         policy_registry: The policy registry (global + file type specific overrides).
         timestamp: The file path's modification timestamp. This is distinct from
             `run_options.started_at`, which records when the invocation began.
@@ -158,7 +161,9 @@ class ProcessingContext:
     config: FrozenConfig  # Effective layered config for this file
     run_options: RunOptions  # Invocation-wide runtime options for the current run
 
-    path: Path  # The file path to process (absolute or relative to working directory)
+    # Processing path for this file. Normal file-list resolution passes the canonical
+    # processing path here, so symlink spellings may already be collapsed before steps run.
+    path: Path
 
     policy_registry: PolicyRegistry
 
@@ -462,7 +467,9 @@ class ProcessingContext:
         """Create a fresh context with no derived state.
 
         Args:
-            path: File system path for the file to process.
+            path: Processing path for the file. In normal CLI/API file-list processing this is
+                TopMark's canonical processing path; tests and lower-level callers may still pass
+                an invocation spelling directly.
             config: Effective layered configuration to attach to the context.
             run_options: Invocation-wide execution-only runtime options.
             policy_registry_override: Optional precomputed policy registry for the

--- a/src/topmark/pipeline/steps/builder.py
+++ b/src/topmark/pipeline/steps/builder.py
@@ -42,6 +42,7 @@ from topmark.pipeline.status import GenerationStatus
 from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import BuilderView
 from topmark.utils.file import compute_relpath
+from topmark.utils.path import canonical_processing_path
 from topmark.utils.path import canonicalize_existing_path
 from topmark.utils.path import format_header_metadata_path
 
@@ -120,11 +121,16 @@ class BuilderStep(BaseStep):
             `FrozenConfig.field_values`.
 
         Path semantics:
-            - `file_path` is `ctx.path` as provided by config resolution.
-              It may be relative or absolute depending on how the file was discovered.
+            - `file_path` is `ctx.path` as supplied when the processing context was bootstrapped.
+              In normal file-list processing this is TopMark's canonical processing path, not
+              necessarily the original CLI/config spelling. Lower-level callers may still pass a
+              symlink spelling directly; the builder canonicalizes filesystem metadata again.
             - For regular filesystem input, `file`, `file_relpath`, and `file_abspath`
-              are derived from the canonical filesystem spelling of the resolved path.
-              This avoids casing-only metadata drift on case-insensitive filesystems.
+              are derived from the canonical filesystem spelling of the resolved
+              processing target. Symlink spelling is not preserved in generated
+              header metadata. This keeps repeated runs idempotent when a symlink
+              and its target are both selected, and avoids casing-only metadata drift
+              on case-insensitive filesystems.
             - In stdin mode, `file`, `file_relpath`, and `file_abspath` are derived from
               the logical `stdin_filename`, not the materialized temporary file path.
             - `file_relpath` and `relpath` are computed by calling
@@ -179,11 +185,16 @@ class BuilderStep(BaseStep):
 
         # In stdin mode, use `stdin_filename` (if provided) for logical header metadata.
         # Otherwise, use the canonical filesystem spelling of the existing content path.
-        # This keeps generated metadata tied to filesystem identity instead of invocation spelling.
+        # This keeps generated metadata tied to the resolved processing target instead of
+        # invocation spelling. In particular, symlinked filesystem inputs generate path
+        # metadata for the target that TopMark will actually read/write. A separate warning
+        # about original symlink spelling would require retaining that spelling before file-list
+        # resolution canonicalizes `ctx.path`, so this step deliberately documents rather than
+        # diagnoses that policy.
         header_path: Path = (
             Path(ctx.run_options.stdin_filename)
             if (ctx.run_options.stdin_mode and ctx.run_options.stdin_filename)
-            else canonicalize_existing_path(content_path)
+            else canonical_processing_path(content_path)
         )
 
         # File absolute path is derived from the logical header path so stdin mode reports the

--- a/src/topmark/pipeline/steps/resolver.py
+++ b/src/topmark/pipeline/steps/resolver.py
@@ -161,6 +161,11 @@ class ResolverStep(BaseStep):
     shared resolver applies a deterministic precedence and tie-break policy and
     returns at most one effective winner.
 
+    The resolver consumes `ctx.path` as the pipeline's processing path. It does
+    not retain or compare the original CLI/config spelling. Symlink-aware identity
+    decisions therefore belong to file-list/config resolution before the pipeline
+    context is bootstrapped.
+
     Axes written:
       - resolve
 

--- a/src/topmark/resolution/files.py
+++ b/src/topmark/resolution/files.py
@@ -25,6 +25,12 @@ Globs declared in configuration files are expanded relative to the directory of
 each declaring config file. Paths loaded from `files_from` sources are resolved
 against their declaring source base directory.
 
+For regular filesystem inputs, file-list resolution uses the resolved target path
+as the processing identity. Multiple spellings that resolve to the same target
+(such as a symlink and its target) are processed once. The selected path returned
+to the pipeline is the canonical processing path, preferably made relative to the
+current working directory for presentation and machine-output stability.
+
 The module also provides discovery-level probe helpers for `topmark probe`.
 Those helpers explain why explicitly requested paths did not reach file-type
 probing, without enumerating every recursively discovered file excluded during
@@ -50,6 +56,7 @@ from topmark.registry.filetypes import FileTypeRegistry
 from topmark.resolution.discovery import FileSelectionProbeResult
 from topmark.resolution.discovery import FileSelectionReason
 from topmark.resolution.discovery import FileSelectionStatus
+from topmark.utils.path import canonical_processing_path
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -258,36 +265,36 @@ def _explicit_input_paths(config: FrozenConfig) -> list[Path]:
     return paths
 
 
-def _real_paths(paths: Sequence[Path]) -> set[Path]:
-    """Return normalized real paths for filesystem entries.
+def _processing_identity_paths(paths: Sequence[Path]) -> set[Path]:
+    """Return canonical processing identity paths for filesystem entries.
 
     Args:
         paths: Filesystem paths to normalize.
 
     Returns:
-        Set of resolved paths. Paths that cannot be resolved are kept as
-        provided so comparison remains best-effort and non-fatal.
+        Set of canonical processing paths. Paths that cannot be resolved are kept
+        as provided so comparison remains best-effort and non-fatal.
     """
     resolved: set[Path] = set()
     for path in paths:
         try:
-            resolved.add(path.resolve())
+            resolved.add(canonical_processing_path(path))
         except OSError:
             resolved.add(path)
     return resolved
 
 
-def _selected_real_paths(selected_files: Sequence[Path]) -> set[Path]:
-    """Return normalized real paths for selected file-list entries.
+def _selected_processing_identity_paths(selected_files: Sequence[Path]) -> set[Path]:
+    """Return canonical processing identity paths for selected file-list entries.
 
     Args:
         selected_files: File-list results returned by `resolve_file_list()`.
 
     Returns:
-        Set of resolved selected paths. Paths that cannot be resolved are kept
-        as provided so comparison remains best-effort and non-fatal.
+        Set of selected processing identity paths. Paths that cannot be resolved
+        are kept as provided so comparison remains best-effort and non-fatal.
     """
-    return _real_paths(selected_files)
+    return _processing_identity_paths(selected_files)
 
 
 # --- Explicit-input selection helpers ---
@@ -295,26 +302,26 @@ def _selected_real_paths(selected_files: Sequence[Path]) -> set[Path]:
 
 def _has_selected_descendant(
     directory: Path,
-    selected_real: set[Path],
+    selected_identities: set[Path],
 ) -> bool:
     """Return whether `directory` contains at least one selected file.
 
     Args:
         directory: Explicit directory input to check.
-        selected_real: Resolved selected file paths returned by
-            [_selected_real_paths][topmark.resolution.files._selected_real_paths].
+        selected_identities: Selected canonical processing paths returned by
+            [_selected_processing_identity_paths][topmark.resolution.files._selected_processing_identity_paths].
 
     Returns:
         True if at least one selected file is below `directory`.
     """
     try:
-        directory_real: Path = directory.resolve()
+        directory_identity: Path = canonical_processing_path(directory)
     except OSError:
-        directory_real = directory
+        directory_identity = directory
 
-    for selected in selected_real:
+    for selected in selected_identities:
         try:
-            selected.relative_to(directory_real)
+            selected.relative_to(directory_identity)
         except ValueError:
             continue
         else:
@@ -435,17 +442,18 @@ def probe_explicit_file_selection(
         Discovery-level probe results for explicit inputs that did not reach
         file-type probing.
     """
-    selected_real: set[Path] = _selected_real_paths(selected_files)
-    missing_real: set[Path] = _real_paths(missing_literals)
+    selected_identities: set[Path] = _selected_processing_identity_paths(selected_files)
+    missing_identities: set[Path] = _processing_identity_paths(missing_literals)
+
     results: list[FileSelectionProbeResult] = []
 
     for explicit in _explicit_input_paths(config):
         try:
-            real: Path = explicit.resolve()
+            identity: Path = canonical_processing_path(explicit)
         except OSError:
-            real = explicit
+            identity = explicit
 
-        if real in selected_real or real in missing_real:
+        if identity in selected_identities or identity in missing_identities:
             continue
 
         if not explicit.exists():
@@ -459,7 +467,7 @@ def probe_explicit_file_selection(
             continue
 
         if not explicit.is_file():
-            if explicit.is_dir() and _has_selected_descendant(explicit, selected_real):
+            if explicit.is_dir() and _has_selected_descendant(explicit, selected_identities):
                 continue
 
             results.append(
@@ -567,7 +575,12 @@ def resolve_file_list_with_diagnostics(
          are given, remove any files matching the exclusion patterns from the set.
       5. **File type filter**: If `include_file_types` or `exclude_file_types` are specified,
          further restrict to files matching those types.
-      6. Returns a **sorted** list of Path objects for deterministic output.
+      6. **Processing identity**: Dedupe selected files by resolved target path.
+         If a file is reachable through both a symlink and its target, process
+         the resolved target once.
+      7. Returns a **sorted** list of Path objects for deterministic output.
+         Selected paths represent TopMark's canonical processing paths, not
+         necessarily the original CLI/config spelling.
 
     Args:
         config: Effective layered configuration.
@@ -646,8 +659,8 @@ def resolve_file_list_with_diagnostics(
         but is applied to directory paths so we can avoid descending into subtrees
         that would be entirely excluded anyway.
         """
-        real: Path = path.resolve()
-        return _matches_any(exclude_specs_all, real)
+        identity: Path = canonical_processing_path(path)
+        return _matches_any(exclude_specs_all, identity)
 
     def _expand_path(p: Path) -> list[Path]:
         """Expand a base path into a list of files and directories.
@@ -740,7 +753,7 @@ def resolve_file_list_with_diagnostics(
             for pat in grp.patterns:
                 for hit in base_dir.glob(pat):
                     if hit.is_file():
-                        expanded_from_includes.add(hit.resolve())
+                        expanded_from_includes.add(canonical_processing_path(hit))
         if expanded_from_includes:
             input_paths.extend(sorted(expanded_from_includes))
             logger.debug(
@@ -840,19 +853,22 @@ def resolve_file_list_with_diagnostics(
             if not _matches_any_file_type(file_path, selected_exclude_types)
         }
 
-    # Step 6 (Finalize): dedupe by real path, prefer CWD-relative presentation
-    out_by_real: dict[Path, Path] = {}
+    # Step 6 (Finalize): dedupe by resolved processing identity, then prefer
+    # CWD-relative spelling for the selected processing path when possible.
+    # This intentionally collapses symlink spellings onto their resolved target
+    # so later pipeline steps generate stable metadata and avoid duplicate writes.
+    out_by_identity: dict[Path, Path] = {}
     for p in filtered_paths:
-        real: Path = p.resolve()
+        identity: Path = canonical_processing_path(p)
         try:
-            rel_to_cwd: Path = real.relative_to(cwd.resolve())
+            rel_to_cwd: Path = identity.relative_to(cwd.resolve())
             rep: Path = rel_to_cwd
         except (OSError, ValueError):
-            rep = real  # keep absolute if not within CWD
-        if real not in out_by_real:
-            out_by_real[real] = rep
+            rep = identity  # keep absolute if not within CWD
+        if identity not in out_by_identity:
+            out_by_identity[identity] = rep
 
-    result: list[Path] = sorted(out_by_real.values(), key=lambda q: q.as_posix())
+    result: list[Path] = sorted(out_by_identity.values(), key=lambda q: q.as_posix())
     logger.trace("Files to process: %d -- %s", len(result), result)
     return FileListResolution(
         selected=tuple(result),

--- a/src/topmark/toml/resolution.py
+++ b/src/topmark/toml/resolution.py
@@ -49,6 +49,7 @@ from typing import TypeAlias
 from topmark.core.logging import get_logger
 from topmark.diagnostic.model import MutableDiagnosticLog
 from topmark.toml.loaders import load_topmark_toml_source
+from topmark.utils.path import canonical_processing_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -84,7 +85,8 @@ class ResolvedTopmarkTomlSource:
     options or `strict`.
 
     Attributes:
-        path: Resolved filesystem path of the TOML source.
+        path: Resolved processing-target path of the TOML source. Symlink spelling
+            is not preserved for config-source identity.
         parsed: Split-parsed TOML source contents, or `None` when loading or
             parsing failed.
         kind: Discovery class of the source. Allowed values are `"user"`,
@@ -133,7 +135,7 @@ def _append_loaded_source(
     kind: TomlSourceKind,
 ) -> None:
     """Load one TOML source and append it with preserved source diagnostics."""
-    resolved_path: Path = path.resolve()
+    resolved_path: Path = canonical_processing_path(path)
     parsed: ParsedTopmarkToml | None = load_topmark_toml_source(resolved_path)
     if parsed is None:
         logger.debug(
@@ -214,15 +216,20 @@ def _discover_local_config_files(start: Path) -> list[Path]:
         `pyproject.toml` is returned before `topmark.toml` so the latter has
         higher same-directory precedence.
     """
-    # Collect per-directory entries preserving same-dir precedence (pyproject → topmark)
-    per_dir: list[list[Path]] = []
-    cur: Path = start.resolve()  # Resolve symlinks and get absolute path
+    # Discovery anchors may be missing explicit file inputs or unmatched glob roots.
+    # Use non-strict path resolution here so config discovery remains tolerant and
+    # later file resolution can report user-facing diagnostics such as NOT_FOUND.
+    # Strict canonical_processing_path() is only appropriate once an existing TOML
+    # source has been selected for loading.
+    cur: Path = start.resolve()
     seen: set[Path] = set()
 
     # Ensure we start from a directory anchor
     if cur.is_file():
         cur = cur.parent
 
+    # Collect per-directory entries preserving same-dir precedence (pyproject → topmark)
+    per_dir: list[list[Path]] = []
     # Walk up to filesystem root, recording entries per directory
     while True:
         root_stop_here = False
@@ -356,6 +363,10 @@ def resolve_topmark_toml_sources(
     anchor: Path = input_path_list[0] if input_path_list else Path.cwd()
     if anchor.is_file():
         anchor = anchor.parent
+    # Keep project discovery tolerant of missing file inputs. A missing target path
+    # must not make config discovery fail before the file-resolution pipeline can
+    # classify it. Existing config sources are canonicalized later in
+    # _append_loaded_source().
     anchor = anchor.resolve()
 
     if not no_config:

--- a/src/topmark/utils/path.py
+++ b/src/topmark/utils/path.py
@@ -64,6 +64,22 @@ def canonicalize_existing_path(path: Path) -> Path:
     return current
 
 
+def canonical_processing_path(path: Path) -> Path:
+    """Return the canonical path used as TopMark's filesystem identity.
+
+    Existing filesystem inputs are identified by their resolved processing
+    target. Symlink spelling is therefore not preserved for processing identity
+    or for generated filesystem-related header metadata.
+
+    Args:
+        path: Existing filesystem path selected for processing.
+
+    Returns:
+        The canonical processing path for the filesystem target.
+    """
+    return canonicalize_existing_path(path)
+
+
 # ---- POSIX path representation ----
 
 

--- a/tests/cli/machine/test_probe_machine.py
+++ b/tests/cli/machine/test_probe_machine.py
@@ -31,6 +31,7 @@ from tests.helpers.json import parse_json_object
 from tests.helpers.ndjson import parse_ndjson_records
 from tests.helpers.ndjson import record_kinds
 from tests.helpers.ndjson import record_payload
+from tests.helpers.paths import symlink_or_skip
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.cli.main import cli
@@ -86,6 +87,43 @@ def test_probe_json_output_shape(tmp_path: Path) -> None:
     assert "selected_file_type" in probe
     assert "selected_processor" in probe
     assert "candidates" in probe
+
+
+def test_probe_json_symlink_input_serializes_canonical_target_path(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Probe JSON paths should use the canonical processing target for symlinked inputs."""
+    monkeypatch.chdir(tmp_path)
+    target: Path = tmp_path / "real" / "source.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("print('hello')\n", encoding="utf-8")
+    link: Path = symlink_or_skip(tmp_path / "links" / "source-link.py", target)
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            str(link.relative_to(tmp_path)),
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+        ],
+    )
+
+    assert_SUCCESS(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    probes_obj: object = payload["probes"]
+    assert is_any_list(probes_obj)
+    probes: list[object] = probes_obj
+    assert len(probes) == 1
+
+    probe_obj: object = probes[0]
+    assert is_mapping(probe_obj)
+    probe: dict[str, object] = as_object_dict(probe_obj)
+
+    assert probe["path"] == "real/source.py"
 
 
 def test_probe_json_candidate_structure(tmp_path: Path) -> None:
@@ -337,6 +375,40 @@ def test_probe_ndjson_output_shape(tmp_path: Path) -> None:
 
     # Ensure no double wrapping (regression test)
     assert "probe" not in payload
+
+
+def test_probe_ndjson_symlink_input_serializes_canonical_target_path(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Probe NDJSON paths should use the canonical processing target for symlinked inputs."""
+    monkeypatch.chdir(tmp_path)
+    target: Path = tmp_path / "real" / "source.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("print('hello')\n", encoding="utf-8")
+    link: Path = symlink_or_skip(tmp_path / "links" / "source-link.py", target)
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            CliCmd.PROBE,
+            str(link.relative_to(tmp_path)),
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
+        ],
+    )
+
+    assert_SUCCESS(result)
+
+    records: list[dict[str, object]] = parse_ndjson_records(result.output)
+    probe_records: list[dict[str, object]] = [
+        record for record in records if record["kind"] == "probe"
+    ]
+    assert len(probe_records) == 1
+
+    payload: dict[str, object] = record_payload(probe_records[0])
+    assert payload["path"] == "real/source.py"
 
 
 def test_probe_ndjson_reports_explicit_filtered_input(

--- a/tests/cli/machine/test_processing_machine.py
+++ b/tests/cli/machine/test_processing_machine.py
@@ -51,6 +51,7 @@ from tests.helpers.json import parse_json_object
 from tests.helpers.ndjson import assert_ndjson_meta
 from tests.helpers.ndjson import parse_ndjson_records
 from tests.helpers.ndjson import record_kinds
+from tests.helpers.paths import symlink_or_skip
 from tests.helpers.pipeline import make_pipeline_context
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
@@ -295,6 +296,50 @@ def test_processing_json_detail_path_serializes_windows_style_path_as_posix(
     assert first.get("path") == "C:/Repo/src/example.py"
 
 
+# --- Symlink canonical path serialization tests ---
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        CliCmd.CHECK,
+        CliCmd.STRIP,
+    ],
+)
+def test_processing_json_detail_symlink_input_serializes_canonical_target_path(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Processing JSON detail paths should use the canonical processing target."""
+    target: Path = tmp_path / "real" / "source.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("print('hello')\n", encoding="utf-8")
+    link: Path = symlink_or_skip(tmp_path / "links" / "source-link.py", target)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+            str(link.relative_to(tmp_path)),
+        ],
+    )
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    results_obj: object = payload["results"]
+    assert is_any_list(results_obj)
+    results: list[object] = results_obj
+    assert len(results) == 1
+
+    first_obj: object = results[0]
+    assert is_mapping(first_obj)
+    first: dict[str, object] = as_object_dict(first_obj)
+
+    assert first.get("path") == "real/source.py"
+
+
 @pytest.mark.parametrize(
     "command",
     [
@@ -534,6 +579,47 @@ def test_processing_ndjson_detail_path_serializes_windows_style_path_as_posix(
     result: dict[str, object] = as_object_dict(result_obj)
 
     assert result.get("path") == "C:/Repo/src/example.py"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        CliCmd.CHECK,
+        CliCmd.STRIP,
+    ],
+)
+def test_processing_ndjson_detail_symlink_input_serializes_canonical_target_path(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Processing NDJSON detail paths should use the canonical processing target."""
+    target: Path = tmp_path / "real" / "source.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("print('hello')\n", encoding="utf-8")
+    link: Path = symlink_or_skip(tmp_path / "links" / "source-link.py", target)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
+            str(link.relative_to(tmp_path)),
+        ],
+    )
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+
+    records: list[dict[str, object]] = parse_ndjson_records(result.output)
+    result_records: list[dict[str, object]] = [
+        record for record in records if record.get("kind") == "result"
+    ]
+    assert len(result_records) == 1
+
+    result_obj: object | None = result_records[0].get("result")
+    assert is_mapping(result_obj)
+    result_payload: dict[str, object] = as_object_dict(result_obj)
+
+    assert result_payload.get("path") == "real/source.py"
 
 
 @pytest.mark.parametrize(

--- a/tests/config/resolution/test_bridge.py
+++ b/tests/config/resolution/test_bridge.py
@@ -14,13 +14,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tests.helpers.paths import symlink_or_skip
 from topmark.config.resolution.bridge import resolve_default_table_and_build_mutable_config
 from topmark.config.resolution.bridge import resolve_default_template_and_build_mutable_config
 from topmark.config.resolution.synthetic import SyntheticConfigSource
 from topmark.core.constants import EXAMPLE_TOPMARK_TOML_NAME
 from topmark.core.constants import EXAMPLE_TOPMARK_TOML_PACKAGE
+from topmark.toml.resolution import resolve_topmark_toml_sources
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from topmark.config.resolution.bridge import ResolvedConfigDraft
     from topmark.diagnostic.model import MutableDiagnosticLog
 
@@ -31,7 +35,7 @@ def test_default_template_resolves_without_errors() -> None:
 
     assert len(resolved_config.resolved.sources) == 1
     diagnostics: MutableDiagnosticLog = resolved_config.draft.validation_logs.flattened()
-    assert not diagnostics.has_error(), (
+    assert not diagnostics.has_error, (
         f"An error occurred during parsing of the built-in TOML resource "
         f"in {EXAMPLE_TOPMARK_TOML_PACKAGE}/{EXAMPLE_TOPMARK_TOML_NAME}: "
         f"{diagnostics}"
@@ -50,7 +54,7 @@ def test_builtin_defaults_resolve_without_errors() -> None:
 
     assert len(resolved_config.resolved.sources) == 1
     diagnostics: MutableDiagnosticLog = resolved_config.draft.validation_logs.flattened()
-    assert not diagnostics.has_error(), (
+    assert not diagnostics.has_error, (
         f"An error occurred during parsing of the built-in TOML defaults: {diagnostics}"
     )
     assert resolved_config.draft.config_files == [
@@ -59,3 +63,23 @@ def test_builtin_defaults_resolve_without_errors() -> None:
         ),
     ]
     assert resolved_config.resolved.writer_options is not None
+
+
+def test_explicit_config_symlink_resolves_to_target_path(tmp_path: Path) -> None:
+    """Explicit config sources use the resolved target path as source identity."""
+    target_config: Path = tmp_path / "real" / "topmark.toml"
+    target_config.parent.mkdir(parents=True)
+    target_config.write_text("[config]\nstrict = true\n", encoding="utf-8")
+    link_config: Path = symlink_or_skip(tmp_path / "links" / "topmark.toml", target_config)
+
+    resolved = resolve_topmark_toml_sources(
+        input_paths=[tmp_path],
+        extra_config_files=[link_config],
+        no_config=True,
+    )
+
+    assert len(resolved.sources) == 1
+    assert resolved.sources[0].kind == "explicit"
+    assert resolved.sources[0].path == target_config.resolve()
+    assert resolved.sources[0].path != link_config
+    assert resolved.strict is True

--- a/tests/config/resolution/test_layers.py
+++ b/tests/config/resolution/test_layers.py
@@ -1,0 +1,166 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_layers.py
+#   file_relpath : tests/config/resolution/test_layers.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Regression tests for config provenance layer construction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers.paths import symlink_or_skip
+from topmark.config.resolution.layers import ConfigLayerKind
+from topmark.config.resolution.layers import build_config_layers_from_resolved_toml_sources
+from topmark.config.resolution.merge import select_applicable_layers
+from topmark.diagnostic.model import MutableDiagnosticLog
+from topmark.toml.parse import ParsedTopmarkToml
+from topmark.toml.parse import SourceConfigLoadingOptions
+from topmark.toml.parse import SourceTomlOptions
+from topmark.toml.resolution import ResolvedTopmarkTomlSource
+
+if TYPE_CHECKING:
+    from topmark.config.resolution.layers import ConfigLayer
+    from topmark.toml.resolution import TomlSourceKind
+    from topmark.toml.types import TomlTable
+
+
+def _parsed_empty_toml() -> ParsedTopmarkToml:
+    """Return an empty parsed TOML source for layer construction tests."""
+    empty_table: TomlTable = {}
+    return ParsedTopmarkToml(
+        config_loading_options=SourceConfigLoadingOptions(),
+        layered_config=empty_table,
+        writer_options=None,
+        source_options=SourceTomlOptions(),
+        toml_fragment=empty_table,
+        validation_issues=(),
+    )
+
+
+def test_config_layer_from_symlink_origin_uses_target_scope_root(tmp_path: Path) -> None:
+    """File-backed config layers scope to the resolved target directory."""
+    target_config: Path = tmp_path / "real" / "topmark.toml"
+    target_config.parent.mkdir(parents=True)
+    target_config.write_text("[config]\nstrict = true\n", encoding="utf-8")
+    link_config: Path = symlink_or_skip(tmp_path / "links" / "topmark.toml", target_config)
+
+    source = ResolvedTopmarkTomlSource(
+        path=link_config,
+        parsed=_parsed_empty_toml(),
+        kind="explicit",
+        validation_issues=(),
+        load_diagnostics=MutableDiagnosticLog().freeze(),
+    )
+
+    layers: list[ConfigLayer] = build_config_layers_from_resolved_toml_sources([source])
+    explicit_layers: list[ConfigLayer] = [
+        layer for layer in layers if layer.kind.value == "explicit"
+    ]
+
+    assert len(explicit_layers) == 1
+    layer: ConfigLayer = explicit_layers[0]
+    assert layer.origin == target_config.resolve()
+    assert layer.scope_root == target_config.parent.resolve()
+    assert layer.scope_root != link_config.parent
+
+
+def test_config_layer_scope_uses_resolved_processing_target(tmp_path: Path) -> None:
+    """Config applicability compares resolved processing paths and scope roots."""
+    target_config: Path = tmp_path / "real" / "topmark.toml"
+    target_config.parent.mkdir(parents=True)
+    target_config.write_text("[config]\nstrict = true\n", encoding="utf-8")
+    link_config: Path = symlink_or_skip(tmp_path / "links" / "topmark.toml", target_config)
+    target_file: Path = tmp_path / "real" / "pkg" / "module.py"
+    target_file.parent.mkdir(parents=True)
+    target_file.write_text("print('hello')\n", encoding="utf-8")
+    link_file: Path = symlink_or_skip(tmp_path / "linked-module.py", target_file)
+
+    source = ResolvedTopmarkTomlSource(
+        path=link_config,
+        parsed=_parsed_empty_toml(),
+        kind="explicit",
+        validation_issues=(),
+        load_diagnostics=MutableDiagnosticLog().freeze(),
+    )
+
+    layers: list[ConfigLayer] = build_config_layers_from_resolved_toml_sources([source])
+    explicit_layers: list[ConfigLayer] = [
+        layer for layer in layers if layer.kind.value == "explicit"
+    ]
+
+    assert len(explicit_layers) == 1
+    layer: ConfigLayer = explicit_layers[0]
+    assert select_applicable_layers([layer], link_file) == [layer]
+
+
+def test_config_layer_preserves_missing_provenance_path_non_strictly(tmp_path: Path) -> None:
+    """Provenance-only paths need not exist to build a stable config layer."""
+    missing_config: Path = tmp_path / "generated" / "topmark.toml"
+    source = ResolvedTopmarkTomlSource(
+        path=missing_config,
+        parsed=_parsed_empty_toml(),
+        kind="explicit",
+        validation_issues=(),
+        load_diagnostics=MutableDiagnosticLog().freeze(),
+    )
+
+    layers: list[ConfigLayer] = build_config_layers_from_resolved_toml_sources([source])
+    explicit_layers: list[ConfigLayer] = [
+        layer for layer in layers if layer.kind.value == "explicit"
+    ]
+
+    assert len(explicit_layers) == 1
+    layer: ConfigLayer = explicit_layers[0]
+    assert layer.origin == missing_config.resolve()
+    assert layer.scope_root == missing_config.parent.resolve()
+    assert not missing_config.exists()
+
+
+def test_invalid_resolved_toml_source_is_skipped() -> None:
+    """Unreadable or invalid TOML sources should not produce config layers."""
+    source = ResolvedTopmarkTomlSource(
+        path=Path("topmark.toml"),
+        parsed=None,
+        kind="explicit",
+        validation_issues=(),
+        load_diagnostics=MutableDiagnosticLog().freeze(),
+    )
+
+    layers: list[ConfigLayer] = build_config_layers_from_resolved_toml_sources([source])
+
+    assert [layer.kind.value for layer in layers] == ["default"]
+
+
+@pytest.mark.parametrize(
+    ("source_kind", "expected"),
+    [
+        pytest.param("user", ConfigLayerKind.USER, id="user-source"),
+        pytest.param("explicit", ConfigLayerKind.EXPLICIT, id="explicit-source"),
+        pytest.param("discovered", ConfigLayerKind.DISCOVERED, id="discovered-source"),
+    ],
+)
+def test_resolved_source_kind_maps_to_layer_kind(
+    source_kind: TomlSourceKind,
+    expected: ConfigLayerKind,
+) -> None:
+    """Resolved TOML source kinds should map to matching config layer kinds."""
+    source = ResolvedTopmarkTomlSource(
+        path=Path("topmark.toml"),
+        parsed=_parsed_empty_toml(),
+        kind=source_kind,
+        validation_issues=(),
+        load_diagnostics=MutableDiagnosticLog().freeze(),
+    )
+
+    layers: list[ConfigLayer] = build_config_layers_from_resolved_toml_sources([source])
+
+    assert [layer.kind for layer in layers] == [ConfigLayerKind.DEFAULT, expected]

--- a/tests/helpers/paths.py
+++ b/tests/helpers/paths.py
@@ -18,11 +18,16 @@ serialized with POSIX separators and must therefore not contain backslashes.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Final
 
 from topmark.core.typing_guards import as_object_dict
 from topmark.core.typing_guards import is_any_list
 from topmark.core.typing_guards import is_mapping
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 MACHINE_PATH_FIELD_NAMES: Final[frozenset[str]] = frozenset(
     {
@@ -84,6 +89,25 @@ def assert_machine_path_value(value: object) -> list[str]:
     return paths
 
 
+def _collect_machine_path_fields(
+    value: object,
+    path_field_names: frozenset[str],
+    paths: list[str],
+) -> None:
+    """Collect and validate path-like fields from a parsed machine payload."""
+    if is_mapping(value):
+        mapping: dict[str, object] = as_object_dict(value)
+        for key, item in mapping.items():
+            if key in path_field_names and item is not None:
+                paths.extend(assert_machine_path_value(item))
+            _collect_machine_path_fields(item, path_field_names, paths)
+        return
+
+    if is_any_list(value):
+        for item in value:
+            _collect_machine_path_fields(item, path_field_names, paths)
+
+
 def assert_machine_path_fields_are_posix(
     payload: object,
     *,
@@ -111,20 +135,27 @@ def assert_machine_path_fields_are_posix(
     return paths
 
 
-def _collect_machine_path_fields(
-    value: object,
-    path_field_names: frozenset[str],
-    paths: list[str],
-) -> None:
-    """Collect and validate path-like fields from a parsed machine payload."""
-    if is_mapping(value):
-        mapping: dict[str, object] = as_object_dict(value)
-        for key, item in mapping.items():
-            if key in path_field_names and item is not None:
-                paths.extend(assert_machine_path_value(item))
-            _collect_machine_path_fields(item, path_field_names, paths)
-        return
+def symlink_or_skip(
+    link: Path,
+    target: Path,
+    *,
+    target_is_directory: bool = False,
+) -> Path:
+    """Create a symlink or skip when the platform disallows symlinks.
 
-    if is_any_list(value):
-        for item in value:
-            _collect_machine_path_fields(item, path_field_names, paths)
+    Args:
+        link: Symlink path to create.
+        target: Symlink target.
+        target_is_directory: Whether `target` is a directory.
+
+    Returns:
+        The created symlink path.
+    """
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except (NotImplementedError, OSError) as exc:
+        import pytest
+
+        pytest.skip(f"symlink creation is not available in this test environment: {exc}")
+    return link

--- a/tests/pipeline/steps/test_builder.py
+++ b/tests/pipeline/steps/test_builder.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.helpers.paths import symlink_or_skip
 from tests.helpers.pipeline import make_pipeline_context
 from tests.helpers.pipeline import run_builder
 from topmark.config.io.deserializers import mutable_config_from_defaults
@@ -134,3 +135,79 @@ def test_builder_generates_relpath_from_canonical_filesystem_spelling_with_relat
     assert ctx.views.build.builtins["file"] == "README.md"
     assert ctx.views.build.builtins["file_relpath"] == "Docs/README.md"
     assert ctx.views.build.builtins["file_abspath"] == actual_file.resolve().as_posix()
+
+
+def test_builder_generates_path_fields_from_symlink_target(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Generate filesystem metadata for the resolved target of a symlinked input."""
+    monkeypatch.chdir(tmp_path)
+
+    target_path: Path = tmp_path / "real" / "source.py"
+    target_path.parent.mkdir(parents=True)
+    target_path.write_text("print('hello')\n", encoding="utf-8")
+    link_path: Path = symlink_or_skip(tmp_path / "links" / "source-link.py", target_path)
+
+    cfg: FrozenConfig = mutable_config_from_defaults().freeze()
+    ctx: ProcessingContext = _build_for_path(link_path, cfg)
+
+    assert ctx.status.generation is GenerationStatus.GENERATED
+    assert ctx.views.build is not None
+    assert ctx.views.build.builtins is not None
+    assert ctx.views.build.builtins["file"] == "source.py"
+    assert ctx.views.build.builtins["file_relpath"] == "real/source.py"
+    assert ctx.views.build.builtins["file_abspath"] == target_path.resolve().as_posix()
+    assert ctx.views.build.builtins["relpath"] == "real"
+    assert ctx.views.build.builtins["abspath"] == (tmp_path / "real").resolve().as_posix()
+    assert ctx.diagnostics.has_error is False
+    assert ctx.diagnostics.has_warning is False
+
+
+def test_builder_generates_same_path_fields_for_symlink_and_target(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Generate stable metadata when a target is reached through a symlink spelling."""
+    monkeypatch.chdir(tmp_path)
+
+    target_path: Path = tmp_path / "real" / "source.py"
+    target_path.parent.mkdir(parents=True)
+    target_path.write_text("print('hello')\n", encoding="utf-8")
+    link_path: Path = symlink_or_skip(tmp_path / "links" / "source-link.py", target_path)
+
+    cfg: FrozenConfig = mutable_config_from_defaults().freeze()
+    target_ctx: ProcessingContext = _build_for_path(target_path, cfg)
+    link_ctx: ProcessingContext = _build_for_path(link_path, cfg)
+
+    assert target_ctx.status.generation is GenerationStatus.GENERATED
+    assert link_ctx.status.generation is GenerationStatus.GENERATED
+    assert target_ctx.views.build is not None
+    assert link_ctx.views.build is not None
+    assert target_ctx.views.build.builtins == link_ctx.views.build.builtins
+
+
+def test_builder_does_not_warn_when_given_symlink_spelling_directly(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Avoid pretending the builder can diagnose original symlink spelling reliably.
+
+    Normal file-list resolution already collapses symlink spellings before the
+    processing context is bootstrapped. Lower-level callers may still pass a
+    symlink path directly, but warning consistently would require retaining the
+    original invocation spelling as separate context state.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    target_path: Path = tmp_path / "real" / "source.py"
+    target_path.parent.mkdir(parents=True)
+    target_path.write_text("print('hello')\n", encoding="utf-8")
+    link_path: Path = symlink_or_skip(tmp_path / "links" / "source-link.py", target_path)
+
+    cfg: FrozenConfig = mutable_config_from_defaults().freeze()
+    ctx: ProcessingContext = _build_for_path(link_path, cfg)
+
+    assert ctx.status.generation is GenerationStatus.GENERATED
+    assert ctx.diagnostics.has_error is False
+    assert ctx.diagnostics.has_warning is False

--- a/tests/unit/test_resolve_file_list.py
+++ b/tests/unit/test_resolve_file_list.py
@@ -20,12 +20,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pytest
-
 import topmark.resolution.files as file_resolver_mod
 
 # Import the module under test
 from tests.helpers.config import make_frozen_config
+from tests.helpers.paths import symlink_or_skip
 from tests.helpers.registry import make_file_type
 from topmark.config.types import PatternGroup
 from topmark.filetypes.model import ContentGate
@@ -33,6 +32,8 @@ from topmark.registry.filetypes import FileTypeRegistry
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    import pytest
 
     from topmark.config.model import FrozenConfig
     from topmark.filetypes.model import FileType
@@ -85,30 +86,6 @@ def write(p: Path, text: str = "") -> Path:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(text, encoding="utf-8")
     return p
-
-
-def symlink_or_skip(
-    link: Path,
-    target: Path,
-    *,
-    target_is_directory: bool = False,
-) -> Path:
-    """Create a symlink or skip when the platform disallows symlinks.
-
-    Args:
-        link: Symlink path to create.
-        target: Symlink target.
-        target_is_directory: Whether `target` is a directory.
-
-    Returns:
-        The created symlink path.
-    """
-    link.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        link.symlink_to(target, target_is_directory=target_is_directory)
-    except (NotImplementedError, OSError) as exc:
-        pytest.skip(f"symlink creation is not available in this test environment: {exc}")
-    return link
 
 
 def resolve_selected(config: FrozenConfig) -> list[Path]:
@@ -761,6 +738,49 @@ def test_symlinked_directory_input_resolves_descendants_to_canonical_targets(
     rel: list[str] = [p.as_posix() for p in resolve_selected(cfg)]
 
     assert rel == ["real-src/pkg/module.py"]
+
+
+def test_nested_directory_symlink_is_not_traversed_during_directory_walk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Directory traversal should not recurse into nested directory symlinks."""
+    root: Path = tmp_path / "root"
+    target_dir: Path = tmp_path / "external-target"
+    write(root / "direct.py", "x")
+    write(target_dir / "nested.py", "x")
+    symlink_or_skip(
+        root / "linked-target",
+        target_dir,
+        target_is_directory=True,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    cfg: FrozenConfig = make_frozen_config(files=["root"])
+
+    rel: list[str] = [p.as_posix() for p in resolve_selected(cfg)]
+
+    assert rel == ["root/direct.py"]
+
+
+def test_broken_symlink_literal_is_reported_as_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken symlink literal should be reported as a missing input path."""
+    link: Path = symlink_or_skip(tmp_path / "links" / "missing.py", tmp_path / "missing.py")
+
+    monkeypatch.chdir(tmp_path)
+    cfg: FrozenConfig = make_frozen_config(files=["links/missing.py"])
+
+    result: file_resolver_mod.FileListResolution = (
+        file_resolver_mod.resolve_file_list_with_diagnostics(cfg)
+    )
+
+    assert result.selected == ()
+    assert result.unmatched_patterns == ()
+    assert result.missing_literals == (Path("links/missing.py"),)
+    assert link.is_symlink()
 
 
 def test_real_file_and_symlink_input_are_deduplicated_by_real_path(

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -19,10 +19,12 @@ from typing import cast
 
 import pytest
 
+from tests.helpers.paths import symlink_or_skip
 from topmark.config.resolution.synthetic import BUILTIN_DEFAULTS_TOML_SOURCE
 from topmark.config.resolution.synthetic import BUNDLED_TEMPLATE_TOML_SOURCE
 from topmark.config.resolution.synthetic import DEFAULT_CONFIG_SOURCE
 from topmark.config.resolution.synthetic import SyntheticConfigSource
+from topmark.utils.path import canonical_processing_path
 from topmark.utils.path import canonicalize_existing_path
 from topmark.utils.path import format_config_source_path
 from topmark.utils.path import format_header_metadata_path
@@ -33,7 +35,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-# ---- path canonalization tests ----
+# ---- path canonicalization tests ----
 
 
 @pytest.mark.parametrize(
@@ -61,6 +63,16 @@ def test_canonicalize_existing_path_requires_existing_path(tmp_path: Path) -> No
 
     with pytest.raises(FileNotFoundError):
         canonicalize_existing_path(path)
+
+
+def test_canonical_processing_path_uses_symlink_target_identity(tmp_path: Path) -> None:
+    """Processing identity should collapse symlink spelling to the target path."""
+    target: Path = tmp_path / "real" / "source.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("print('hello')\n", encoding="utf-8")
+    link: Path = symlink_or_skip(tmp_path / "links" / "source-link.py", target)
+
+    assert canonical_processing_path(link) == target.resolve()
 
 
 # ---- path POSIX rendering tests ----


### PR DESCRIPTION
## Summary

- Defines TopMark's filesystem identity policy as resolved processing-target identity.
- Documents that symlink spellings are not preserved for runtime processing identity, generated filesystem-related header metadata, public API result paths, or machine-readable path fields.
- Defines configuration-source identity for file-backed TOML sources using the resolved configuration-file target.
- Adds `canonical_processing_path()` and uses it where TopMark means processing-target identity.
- Adds regression coverage for symlinked files/directories, broken symlinks, builder metadata, config-source identity, layered provenance, and machine-output path behavior.
- Updates user, API, developer, command, configuration, CI, pre-commit, README, and changelog documentation.

## Related issues

Closes #90.

This also builds on the path serialization, formatting, filename-rule normalization, path/config consistency, and cross-platform regression work from #88, #91, #92, #93, and #94.

## Validation

- Existing test suite remains green.
- `layers.py` coverage improved to 100%.