### PR TITLE
Block hard-linked processing targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,14 +48,15 @@ ______________________________________________________________________
 - Extended the POSIX path-serialization contract to configuration machine-output payloads,
   TOML/config provenance payloads, configuration-export serialization, and configuration diagnostic
   summaries.
-- Defined TopMark's filesystem identity policy for existing processing inputs as resolved
-  processing-target identity rather than raw invocation spelling.
-- Standardized symlink handling so file symlink spellings and their targets collapse to one selected
-  processing path before runtime probing, processing, header metadata generation, and
-  machine-readable output.
+- Defined TopMark's filesystem-identity evaluation model for existing processing inputs by
+  separating filesystem-identity normalization from processing-target eligibility checks.
+- Standardized symlink handling so file symlink spellings resolve to the target path before runtime
+  probing, processing, header metadata generation, and machine-readable output.
 - Defined configuration-source identity for file-backed TOML sources using the resolved
   configuration-file target for precedence, scope applicability, layered provenance, and
   machine-readable configuration provenance.
+- Added a hard-link filesystem-identity guard: selected paths sharing `(st_dev, st_ino)` are all
+  blocked as hard-linked processing targets while unrelated files continue processing normally.
 
 ### Breaking Changes - Unreleased
 
@@ -120,6 +121,9 @@ ______________________________________________________________________
 - Fixed ambiguity around symlinked configuration files by documenting and testing that provenance,
   precedence, and scope applicability use the resolved configuration target rather than the symlink
   spelling.
+- Fixed ambiguous hard-linked processing-target behavior by blocking every selected path that shares
+  `(st_dev, st_ino)` identity with another selected path instead of choosing a source, target,
+  winner, or loser path.
 
 ### Documentation - Unreleased
 
@@ -149,13 +153,13 @@ ______________________________________________________________________
   JSON/NDJSON path fields.
 - Documented and aligned the recommended VS Code workspace tooling configuration around Pylance,
   `mdformat`, Run On Save integration, and project-maintained task entry points.
-- Documented filesystem identity, processing-path selection, symlink handling, and the boundary
-  between identity selection and machine-readable path serialization across user, API, and developer
-  documentation.
+- Documented filesystem-identity evaluation, filesystem-identity normalization, processing-path
+  selection, symlink handling, hard-link policy, and the boundary between identity evaluation and
+  machine-readable path serialization across user, API, and developer documentation.
 - Documented configuration-source identity and symlinked configuration-file behavior across
   configuration discovery, configuration schema, machine-output, command, and API documentation.
-- Documented that hard-link detection and device/inode-based filesystem identity are outside the
-  current compatibility contract.
+- Documented the TopMark 1.1.0 hard-link compatibility contract for processing and probe machine
+  output.
 
 ### Internal - Unreleased
 
@@ -184,6 +188,9 @@ ______________________________________________________________________
 - Added regression coverage for symlinked file inputs, symlinked directory behavior, broken symlink
   diagnostics, generated header metadata for symlinked inputs, configuration-source identity,
   layered provenance, public machine output, and processing-path serialization.
+- Added regression coverage for hard-linked selected processing paths across pipeline execution,
+  `check`, `strip`, `probe`, JSON output, NDJSON output, and mixed hard-linked plus unrelated file
+  selections.
 
 ### Notes - Unreleased
 
@@ -206,6 +213,9 @@ ______________________________________________________________________
   existing processing inputs. Symlink spellings are not preserved for runtime processing identity,
   generated filesystem-related header metadata, or machine-readable path fields; consumers that need
   the exact invocation spelling should retain it outside TopMark's processing result payloads.
+- Hard-linked selected processing paths are now treated as unsupported processing targets. TopMark
+  reports each affected path independently and does not choose a source, target, winner, or loser
+  path from the hard-link group.
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It helps teams avoid fragile one-off scripts by providing:
 - stable CI-friendly exit codes;
 - machine-readable output formats with stable cross-platform path serialization;
 - transparent file-type resolution diagnostics;
-- deterministic filesystem-identity and configuration-source resolution;
+- deterministic filesystem-identity evaluation and configuration-source resolution;
 - configuration, registry, and file-resolution introspection commands;
 - and a public Python API for automation and integration.
 
@@ -147,7 +147,7 @@ ______________________________________________________________________
 - Policy controls for insertion, update, empty-file behavior, file-type filtering, and content
   probing
 - Resolution diagnostics with `topmark probe`
-- Deterministic filesystem-identity normalization and processing-path selection
+- Deterministic filesystem-identity evaluation, processing-path selection, and hard-link safety
 - Layered configuration inspection with `topmark config dump --show-layers`
 - Registry introspection with `topmark registry filetypes`, `topmark registry processors`, and
   `topmark registry bindings`
@@ -265,10 +265,12 @@ topmark config dump --show-layers
 topmark registry filetypes
 ```
 
-TopMark normalizes filesystem identity before runtime processing. If multiple path spellings resolve
-to the same filesystem target (for example a symlink and its target), TopMark selects a processing
-path and processes the target once. Machine-readable output and generated filesystem-related header
-metadata follow this processing-path contract.
+TopMark evaluates filesystem identity before runtime processing. Filesystem-identity normalization
+resolves equivalent path spellings, such as symlink spellings, to the selected processing path used
+for runtime processing, machine-readable output, and generated filesystem-related header metadata.
+Hard-link policy is evaluated as a processing-target eligibility check: if multiple selected paths
+refer to the same filesystem object through hard links, TopMark reports each affected path
+independently and blocks processing for the hard-link group.
 
 All available commands, shared options, output formats, STDIN behavior, and exit codes are
 documented in:
@@ -403,8 +405,8 @@ discovery.
 Public API callers should use the functions and DTOs exposed from `topmark.api`. Runtime helpers,
 resolver internals, and pipeline contexts are implementation details.
 
-Public API operations follow the same filesystem-identity, processing-path, and configuration-source
-identity contracts as the CLI.
+Public API operations follow the same filesystem-identity evaluation, processing-path, and
+configuration-source identity contracts as the CLI.
 
 Example dry-run check:
 

--- a/docs/_snippets/path-serialization-contract.md
+++ b/docs/_snippets/path-serialization-contract.md
@@ -39,8 +39,14 @@ topmark:header:end
 > may refer to the same filesystem identity and therefore produce the same serialized processing
 > path.
 >
-> TopMark currently defines filesystem identity using the resolved processing target path. Hard-link
-> detection and device/inode-based identity are outside the current compatibility contract.
+> TopMark's machine-readable path fields remain path-based and are derived from the canonical
+> processing path selected for each processing target.
+>
+> Filesystem identity policy is a separate concern from path serialization. TopMark may apply
+> additional filesystem-identity rules when determining whether a processing target is eligible for
+> processing. For example, selected hard-linked files are detected using device/inode identity and
+> are reported as unsupported processing targets. Such checks do not alter the serialized path
+> values emitted in machine-readable output.
 >
 > Human-facing output follows display-path policy instead:
 >

--- a/docs/_snippets/runtime-configuration-model.md
+++ b/docs/_snippets/runtime-configuration-model.md
@@ -19,15 +19,21 @@ TopMark intentionally separates:
 1. runtime configuration resolution
 1. runtime overlay application
 1. runtime policy evaluation
-1. filesystem-identity normalization and processing-path selection
+1. filesystem-identity evaluation
+1. processing-path selection
 1. runtime pipeline gatekeeping and execution
 
 Configuration-source identity and filesystem identity are intentionally distinct.
 
 File-backed configuration sources are normalized to resolved configuration targets before
 precedence, scope applicability, and layered provenance evaluation. Runtime file processing
-similarly operates on selected processing paths derived from filesystem-identity normalization and
-deduplication.
+similarly operates on selected processing paths derived from filesystem-identity evaluation.
+
+Filesystem-identity evaluation includes:
+
+- filesystem-identity normalization (for example symlink-path normalization and processing-path
+  selection); and
+- filesystem-identity eligibility checks (for example hard-link policy enforcement).
 
 These normalization stages occur before runtime policy evaluation and pipeline execution.
 

--- a/docs/_snippets/runtime-validation-model.md
+++ b/docs/_snippets/runtime-validation-model.md
@@ -14,6 +14,7 @@ TopMark intentionally separates:
 
 1. staged configuration-loading validation
 1. layered runtime configuration resolution
+1. filesystem-identity evaluation
 1. runtime applicability evaluation
 1. runtime probing and processor resolution
 1. runtime policy evaluation
@@ -21,3 +22,12 @@ TopMark intentionally separates:
 
 Machine-readable diagnostics and runtime behavior expose a flattened compatibility view derived from
 these internal runtime stages while preserving deterministic stable 1.x runtime behavior.
+
+Filesystem-identity evaluation occurs before runtime processing begins and includes:
+
+- filesystem-identity normalization (for example processing-path selection for equivalent path
+  spellings such as symlinks); and
+- filesystem-identity eligibility checks (for example hard-link policy enforcement).
+
+Configuration-source identity is evaluated independently during configuration loading and layered
+configuration resolution.

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -137,10 +137,17 @@ identical file-type identity semantics. Local identifiers such as `"python"` are
 unambiguous. Internally, TopMark normalizes identifiers to canonical qualified keys such as
 `"topmark:python"` before filtering, resolution, policy evaluation, and binding lookup.
 
-Public API execution also uses the same filesystem identity semantics as the CLI. Existing
-filesystem inputs are normalized to selected processing paths before pipeline execution. Multiple
-path spellings that resolve to the same target, such as a symlink and its target, may therefore be
-reported as a single result for the resolved processing target.
+Public API execution also uses the same filesystem-identity semantics as the CLI. Existing
+filesystem inputs undergo filesystem-identity evaluation before pipeline execution. Multiple path
+spellings that resolve to the same target, such as a symlink and its target, may therefore be
+normalized to a single selected processing path and reported as a single result for the resolved
+processing target.
+
+Hard-link policy is evaluated separately from path-spelling normalization. If multiple selected
+processing paths refer to the same filesystem object through hard links, the public API preserves
+one result per selected path and reports each affected path as an unsupported, policy-blocked
+processing target. TopMark does not select a source, target, winner, or loser path from the
+hard-link group.
 
 For the public API, the returned view is controlled via
 `report="all" | "actionable" | "noncompliant"`. This replaces the older `skip_compliant` /
@@ -182,7 +189,9 @@ Candidates are returned in resolver order (best match first).
 
 For inputs that reach normal probing, `ProbeFileResult.path` reports the selected processing path,
 not necessarily the original invocation spelling. Missing and filtered explicit inputs still report
-explicit diagnostic input paths because they did not become normal processing paths.
+explicit diagnostic input paths because they did not become normal processing paths. Hard-linked
+processing targets remain separate probe results and are reported as unsupported with the stable
+reason string `hard_link_duplicate`.
 
 Unlike \[`check()`\][topmark.api.commands.pipeline.check] and
 \[`strip()`\][topmark.api.commands.pipeline.strip],
@@ -196,6 +205,8 @@ Design guarantees:
 - `score` is explanatory only and not part of the compatibility contract; use `selected`, `rank`,
   and `matched_by`
 - Explicit input paths are always returned, even if they are filtered or missing
+- Hard-linked selected processing paths remain separate results and do not collapse to a preferred
+  source, target, winner, or loser path
 
 #### Missing and filtered inputs
 
@@ -213,6 +224,10 @@ explainability without exposing resolver internals.
 When an input does become a normal processing path, symlink spelling is not preserved in the result
 path. This keeps public API results aligned with header metadata generation and machine-readable CLI
 output.
+
+Hard-link policy is a processing-target eligibility check rather than path normalization. If
+multiple selected processing paths are hard links to the same filesystem object, each affected path
+remains visible in public API results and is reported as unsupported.
 
 #### Low-level probe helper
 
@@ -250,6 +265,11 @@ This process follows:
 File-backed TOML sources use configuration-source identity based on the resolved configuration-file
 target. If a configuration file is reached through a symlink, provenance and applicability are based
 on the resolved target rather than the symlink spelling.
+
+Configuration-source identity is distinct from processing-target identity. Hard-link processing
+policy applies to runtime filesystem-processing commands and public API helpers, but it does not
+affect configuration loading, layered provenance, applicability evaluation, or configuration-source
+selection.
 
 The public API operates only on the flattened immutable
 \[`FrozenConfig`\][topmark.config.model.FrozenConfig]. Staged validation logs are not exposed

--- a/docs/ci/ci-workflow.md
+++ b/docs/ci/ci-workflow.md
@@ -104,6 +104,11 @@ the canonical Python QA session across Ubuntu, macOS, and Windows so platform-de
 filesystem semantics are checked on real GitHub-hosted filesystems without multiplying the full
 supported Python-version matrix across every operating system.
 
+This job also protects TopMark's filesystem-identity evaluation contract. That includes
+filesystem-identity normalization for platform-sensitive path spellings and processing-target
+eligibility checks such as hard-link policy where the host filesystem supports the required
+semantics.
+
 Coverage reporting runs in a dedicated canonical job on Ubuntu using the resolved canonical Python
 version and the existing `nox -s coverage` session. Coverage intentionally runs outside the full
 test matrix to avoid duplicating expensive QA work that is already covered by the compatibility

--- a/docs/ci/test-validation.md
+++ b/docs/ci/test-validation.md
@@ -81,17 +81,18 @@ ______________________________________________________________________
 
 Pytest markers are declared in `pyproject.toml` under `[tool.pytest.ini_options]`.
 
-| Marker            | Purpose                                                                                            | CI expectation                                       |
-| ----------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `api`             | Tests that exercise the public API.                                                                | Included in normal test runs.                        |
-| `cli`             | Tests that exercise the command-line interface.                                                    | Included in normal test runs.                        |
-| `config`          | Tests for configuration deserialization, path normalization, strictness, and layer merge behavior. | Included in normal test runs.                        |
-| `dev_validation`  | Developer validation tests for internal invariants such as registry consistency.                   | Included in normal test runs.                        |
-| `exit_code`       | Tests that validate the CLI exit-code contract.                                                    | Included in normal test runs.                        |
-| `hypothesis_slow` | Long-running property tests.                                                                       | Skipped in CI unless explicitly selected.            |
-| `integration`     | Environment-dependent integration checks, such as shell completion.                                | Run selectively where the environment supports them. |
-| `pipeline`        | Tests that exercise the processing pipeline.                                                       | Included in normal test runs.                        |
-| `toml`            | Tests for TopMark TOML loading, extraction, schema validation, and source resolution.              | Included in normal test runs.                        |
+| Marker                                                   | Purpose                                                                                            | CI expectation                                       |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `api`                                                    | Tests that exercise the public API.                                                                | Included in normal test runs.                        |
+| `cli`                                                    | Tests that exercise the command-line interface.                                                    | Included in normal test runs.                        |
+| `config`                                                 | Tests for configuration deserialization, path normalization, strictness, and layer merge behavior. | Included in normal test runs.                        |
+| `dev_validation`                                         | Developer validation tests for internal invariants such as registry consistency.                   | Included in normal test runs.                        |
+| `exit_code`                                              | Tests that validate the CLI exit-code contract.                                                    | Included in normal test runs.                        |
+| `hypothesis_slow`                                        | Long-running property tests.                                                                       | Skipped in CI unless explicitly selected.            |
+| `integration`                                            | Environment-dependent integration checks, such as shell completion.                                | Run selectively where the environment supports them. |
+| `pipeline`                                               | Tests that exercise the processing pipeline, including filesystem-identity evaluation and          |                                                      |
+| processing-target eligibility behavior where applicable. | Included in normal test runs.                                                                      |                                                      |
+| `toml`                                                   | Tests for TopMark TOML loading, extraction, schema validation, and source resolution.              | Included in normal test runs.                        |
 
 ______________________________________________________________________
 

--- a/docs/configuration/discovery.md
+++ b/docs/configuration/discovery.md
@@ -93,6 +93,12 @@ Symlink spellings are therefore not preserved as configuration identity. They ma
 shell prompt, but once TopMark has loaded the configuration source, provenance and applicability are
 based on the resolved configuration-file target.
 
+Configuration-source identity is distinct from processing-target identity. Runtime
+filesystem-processing commands evaluate processing-target identity separately, including
+filesystem-identity normalization for selected processing paths and eligibility checks such as
+hard-link policy. Those runtime processing-target checks do not affect configuration discovery,
+precedence, scope-root selection, applicability evaluation, or layered provenance.
+
 ### Layered provenance (inspection)
 
 When using [`topmark config dump --show-layers`](../usage/commands/config/dump.md), this discovery
@@ -139,8 +145,9 @@ not necessarily the spelling used to reach the configuration file.
 Note: `relative_to` only affects metadata fields like `file_relpath`, not file matching.
 
 When a configuration file is loaded through a symlink, config-declared paths are evaluated relative
-to the resolved configuration-file target. This keeps layered configuration behavior consistent with
-TopMark's processing-path identity model.
+to the resolved configuration-file target. This mirrors the path-spelling normalization part of
+TopMark's processing-target identity model while keeping configuration-source identity independent
+from runtime processing-target eligibility checks such as hard-link policy.
 
 ______________________________________________________________________
 
@@ -481,7 +488,7 @@ Run with `-v` or `--verbose` to increase **TEXT output** detail and observe:
 
 - Discovery anchor and workspace base
 - Configuration chain (root → current)
-- Normalization of pattern-file paths
+- Normalization of pattern-file paths and configuration-source paths
 - Active policy and per-file-type overrides
 - Canonical file type identities used by filters and policy lookup
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -21,6 +21,9 @@ topmark:header:end
   site).
 - **Configuration-source identity** is based on the resolved configuration-file target. Symlink
   spellings are not preserved for precedence, scope, applicability, or layered provenance.
+- **Configuration-source identity is distinct from processing-target identity**. Runtime
+  filesystem-processing commands evaluate selected processing paths separately, including
+  filesystem-identity normalization and eligibility checks such as hard-link policy.
 - **Path-to-file settings** (e.g., `exclude_from`, `files_from`) are resolved relative to the
   **declaring config file** (or CWD for CLI-provided values).
 - **Merge semantics vary by field**: runtime behavioral settings usually use nearest-wins semantics,
@@ -49,6 +52,10 @@ used for configuration-source identity. If a configuration file is loaded throug
 precedence, scope evaluation, and provenance operate on the resolved target rather than the symlink
 spelling.
 
+Hard-link processing policy does not affect configuration discovery, layered provenance,
+configuration precedence, scope evaluation, or applicability evaluation. It is enforced later for
+runtime filesystem-processing targets selected by commands such as `check`, `strip`, and `probe`.
+
 During loading, TopMark first validates each whole-source TOML fragment (unknown sections, unknown
 keys, malformed section shapes, missing known sections, etc.). Only the validated layered
 configuration fragment is then passed into layered configuration merging.
@@ -72,6 +79,10 @@ ______________________________________________________________________
 Configuration discovery, precedence evaluation, configuration-source identity normalization, and
 scope applicability are completed before the effective runtime configuration is frozen.
 
+Configuration-source identity normalization handles configuration path spellings, such as symlinked
+configuration files. It is separate from runtime processing-target eligibility checks, such as
+hard-link policy enforcement for selected processing paths.
+
 ______________________________________________________________________
 
 ## Configuration flow at a glance
@@ -92,6 +103,10 @@ flowchart LR
 For file-backed configuration sources, configuration-source identity is established before layered
 configuration merging. Different path spellings that resolve to the same configuration-file target
 therefore contribute to the same effective configuration source.
+
+This configuration-source identity behavior mirrors only the path-spelling normalization part of
+runtime processing-target identity. Runtime processing-target eligibility checks are not part of
+configuration merging and are not represented in the effective configuration snapshot.
 
 This reflects the main distinction in TopMark's layered runtime configuration model:
 

--- a/docs/dev/api-stability.md
+++ b/docs/dev/api-stability.md
@@ -247,7 +247,7 @@ ______________________________________________________________________
 - The snapshot test is implemented in `tests/api/test_public_api_snapshot.py`.
 - The generator logic lives in `tools/api_snapshot.py`.
 - Normalization ensures consistent diffing across OSes and Python builds.
-- Canonical file type identity normalization ensures stable identity handling across configuration,
+- Canonical file type identity normalization ensures stable file type handling across configuration,
   resolver, registry, and machine-readable output boundaries.
 - The snapshot is derived from `topmark.api.__all__`, ensuring the stable façade remains small and
   explicitly defined.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -25,8 +25,8 @@ The following architectural contracts are part of the stable 1.x design:
 - CLI, API, presentation, runtime, configuration, registry, and pipeline concerns remain separated.
 - Runtime execution intent is kept separate from layered configuration state.
 - File type identity is normalized to canonical qualified keys once resolved.
-- Filesystem identity for existing processing inputs is based on the resolved processing target
-  path.
+- Filesystem-identity evaluation for existing processing inputs happens before runtime processing
+  and includes both processing-path normalization and processing-target eligibility checks.
 - Registry mutation is represented as explicit overlay state.
 - Pipeline execution remains independent from presentation rendering.
 - Machine-readable output remains independent from human-facing TEXT and Markdown output.
@@ -138,10 +138,20 @@ ______________________________________________________________________
 ## File resolution diagnostics and exit-code boundaries
 
 TopMark's file selection layer separates **selected processing inputs** from **discovery
-diagnostics**. Selected processing inputs are canonical processing paths. File-list resolution
-collapses multiple path spellings that resolve to the same filesystem target (for example a symlink
-and its target) before normal pipeline execution begins. This keeps downstream pipeline steps
-idempotent and avoids processing the same target file more than once through different spellings.
+diagnostics**. Selected processing inputs are canonical processing paths that have passed
+filesystem-identity evaluation.
+
+Filesystem-identity normalization collapses multiple path spellings that resolve to the same
+filesystem target (for example a symlink and its target) before normal pipeline execution begins.
+This keeps downstream pipeline steps idempotent and avoids processing the same target file more than
+once through different spellings.
+
+Filesystem-identity eligibility checks are distinct from normalization. The pipeline engine performs
+the invocation-wide hard-link guard after processing-path selection. If multiple selected processing
+paths share `(st_dev, st_ino)` identity, the engine creates terminal per-file contexts for all
+affected paths with `fs=hard-linked processing target` and leaves unrelated paths to continue
+through the selected pipeline. This guard lives at the engine boundary because it needs the complete
+selected file list and must behave consistently for `check`, `strip`, `probe`, and API callers.
 
 The resolver returns a structured file-list resolution result containing:
 
@@ -193,6 +203,8 @@ Practical consequences:
   types or dry-run would-change signals.
 - Missing explicit inputs are visible as per-file errors instead of being collapsed into "no files
   to process".
+- Hard-linked selected processing paths are visible as per-file policy-blocked results instead of
+  being collapsed into a preferred source, target, winner, or loser path.
 - Machine payloads expose structured diagnostics and results, while process status remains external
   as the CLI exit code.
 - Public probe API payloads expose normalized strings and DTOs. Internal resolver enums,
@@ -326,10 +338,13 @@ exit code. Consumers must inspect the process exit status separately from parsin
 Path representation follows the same separation between machine-facing serialization and
 human-facing presentation:
 
-- Internal filesystem identity for existing processing inputs is represented by resolved processing
-  target paths where possible.
+- Internal filesystem identity for existing processing inputs is evaluated before runtime
+  processing. Normalized processing paths represent eligible resolved processing targets where
+  possible.
 - Symlink spelling is not preserved for processing identity, generated filesystem-related header
   metadata, or machine-readable path fields.
+- Hard-linked selected processing paths remain separate results and are reported as unsupported,
+  policy-blocked processing targets rather than being serialized as a single preferred path.
 - Machine-readable filesystem path fields are serialized with POSIX `/` separators on all platforms,
   including processing, probe, configuration, and TOML/config provenance payloads.
 - Header metadata path fields describe the selected processing target and are serialized with POSIX

--- a/docs/dev/configuration-schema.md
+++ b/docs/dev/configuration-schema.md
@@ -109,6 +109,11 @@ Configuration-source identity affects:
 
 Symlink spellings are not preserved once a configuration source has been loaded.
 
+Configuration-source identity is distinct from processing-target identity. The hard-link processing
+policy used by runtime filesystem-processing commands does not affect the external configuration
+schema, configuration-source discovery, precedence, scope-root selection, applicability evaluation,
+or layered provenance exports.
+
 ## Schema validation model
 
 TopMark performs **whole-source TOML schema validation** before any layered configuration is
@@ -276,10 +281,13 @@ topmark:
         optional: true
 
   files:
-    # Filtering order:
+    # Runtime filtering order:
     # 1) Path filters (include/exclude patterns + *_from + files_from)
     # 2) File type filters (include_file_types / exclude_file_types)
-    # 3) Eligibility (supported vs unsupported)
+    # 3) Runtime eligibility (supported vs unsupported processing targets)
+    #
+    # Filesystem-identity eligibility checks such as hard-link policy are runtime
+    # processing concerns and are not represented as configuration schema fields.
 
     include_patterns:
       type: list[str]
@@ -337,9 +345,13 @@ This normalization behavior is shared consistently across:
 - API overlays
 - effective runtime policy resolution
 
-Configuration-source identity normalization follows the same model. File-backed configuration
-sources are normalized to their resolved configuration-file target before precedence, scope, and
-applicability evaluation occur.
+Configuration-source identity normalization follows the same path-spelling model. File-backed
+configuration sources are normalized to their resolved configuration-file target before precedence,
+scope, and applicability evaluation occur.
+
+This normalization is separate from runtime processing-target eligibility. Hard-link policy is
+evaluated for selected processing paths during runtime filesystem processing and is not a
+configuration-schema feature.
 
 ______________________________________________________________________
 
@@ -418,4 +430,7 @@ This means:
 - machine-readable provenance reflects configuration-source identity rather than invocation
   spelling.
 
-This behavior mirrors TopMark's processing-path identity model for runtime file processing.
+This behavior mirrors the path-spelling normalization part of TopMark's processing-target identity
+model for runtime file processing. Runtime processing-target eligibility checks, such as hard-link
+policy enforcement, are separate from configuration-source identity and are not exposed by the
+external configuration schema.

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -13,15 +13,15 @@ topmark:header:end
 # Development documentation
 
 This section contains maintainer-facing documentation for TopMark's architecture,
-filesystem-identity model, configuration-resolution model, compatibility contracts, release process,
-generated documentation pipeline, and post-1.0 governance model.
+filesystem-identity evaluation model, configuration-resolution model, compatibility contracts,
+release process, generated documentation pipeline, and post-1.0 governance model.
 
 Use these pages when changing internals, reviewing compatibility boundaries, preparing releases, or
 understanding how the stable 1.x runtime model is organized.
 
 The 1.x runtime model distinguishes several independent identity domains:
 
-- filesystem identity (processing paths);
+- filesystem identity (normalization, processing-path selection, and eligibility checks);
 - configuration-source identity;
 - file type identity;
 - processor identity; and
@@ -34,15 +34,15 @@ ______________________________________________________________________
 
 ## Architecture and runtime model
 
-The pages in this section define TopMark's canonical runtime behavior, including filesystem
-identity, path resolution, configuration layering, file-type resolution, runtime pipelines, and
+The pages in this section define TopMark's canonical runtime behavior, including filesystem-identity
+evaluation, path resolution, configuration layering, file-type resolution, runtime pipelines, and
 plugin integration.
 
 - [Terminology and canonical vocabulary](../terminology.md)
 - [Architecture](architecture.md)
 - [Registry model](registry-model.md) - file-type, processor, and registry identity
-- [Resolution](resolution.md) - filesystem identity, processing paths, and configuration-source
-  identity
+- [Resolution](resolution.md) - filesystem-identity evaluation, processing paths, hard-link policy,
+  and configuration-source identity
 - [Plugins and extensibility](plugins.md)
 - [Configuration schema](configuration-schema.md)
 - [Pipelines](pipelines.md)

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -130,10 +130,16 @@ POSIX-style matching rules rather than filesystem paths. This includes processin
 configuration, and TOML/config provenance payloads. Synthetic configuration-source identifiers are
 stable labels rather than filesystem paths.
 
-Path serialization is distinct from filesystem identity. TopMark currently identifies existing
-processing inputs by their resolved processing target path before machine output is generated. As a
-result, multiple path spellings that resolve to the same target, such as a symlink and its target,
-may produce the same serialized processing path.
+Path serialization is distinct from filesystem identity. TopMark evaluates filesystem identity
+before machine output is generated. Filesystem-identity normalization may collapse multiple path
+spellings that resolve to the same target, such as a symlink and its target, into the same selected
+processing path.
+
+Filesystem-identity eligibility checks are represented as structured results and diagnostics rather
+than path-serialization changes. If multiple selected processing paths are hard links to the same
+filesystem object, machine-readable output preserves one result per selected path and reports each
+affected path as an unsupported, policy-blocked processing target. TopMark does not serialize the
+hard-link group as a single preferred source, target, winner, or loser path.
 
 Human-facing path labels, including unified diff file labels, follow display policy and are not
 machine-stable path fields.
@@ -428,6 +434,11 @@ Per-file result payloads also report the selected processing path. If a file is 
 symlink, the emitted path describes the resolved processing target rather than the symlink spelling.
 This mirrors the path used by the runtime pipeline and generated filesystem-related header metadata.
 
+Hard-linked selected processing paths remain separate per-file result payloads. Each affected result
+is reported as a policy-blocked unsupported processing target, using the same stable status and hint
+surface as the runtime pipeline. Processing commands do not choose a source, target, winner, or
+loser path for the hard-link group.
+
 In **summary mode**, TopMark aggregates results by the pair `(outcome, reason)` rather than
 collapsing all reasons under a single outcome bucket.
 
@@ -500,9 +511,14 @@ quiet mode.
 Probe output reports canonical file type identities after identifier normalization and file-type
 filtering.
 
-Probe payloads report processing paths after discovery, filesystem-identity normalization, and
-filtering. They are diagnostic records for the paths that reach probing, not a lossless echo of the
-original invocation spelling.
+Probe payloads report processing paths after discovery, filesystem-identity evaluation,
+processing-path selection, and filtering. They are diagnostic records for the paths that reach
+probing, not a lossless echo of the original invocation spelling.
+
+Filesystem-identity normalization may collapse equivalent path spellings, such as symlinks, before
+probing. Hard-link eligibility checks behave differently: if multiple selected processing paths are
+hard links to the same filesystem object, probe emits one payload per affected path and reports each
+one as unsupported with the stable reason string `hard_link_duplicate`.
 
 Filtered probe results use machine-friendly reasons to explain why an explicit file input did not
 reach probing. Missing explicit inputs use `probe_missing` with `no_resolution_probe_result` when no
@@ -523,6 +539,8 @@ Note:
   the CLI invocation with `FILE_NOT_FOUND (66)`.
 - Explicit directories that successfully expand to selected child files are treated as discovery
   sources and are not emitted as separate filtered probe payloads.
+- Hard-linked selected processing paths are emitted independently and are not collapsed into a
+  preferred source, target, winner, or loser path.
 - In mixed-input runs, probe payloads may still include filtered, missing, or unsupported entries,
   but exit-code precedence is resolved outside the payload.
 
@@ -589,6 +607,10 @@ preserves the same logical ordering as the human-facing layered export:
 File-backed configuration provenance uses configuration-source identity based on the resolved
 configuration-file target. Symlink spellings for configuration files are therefore not preserved for
 machine-readable provenance, precedence, scope, or applicability evaluation.
+
+Configuration-source identity is distinct from processing-target identity. Hard-link processing
+policy applies to runtime filesystem-processing payloads and probe diagnostics, but does not affect
+configuration-source provenance or runtime configuration snapshots.
 
 - JSON includes `config_provenance` before `config` in the top-level envelope.
 - NDJSON emits a `config_provenance` record first and a `config` record second.

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -26,10 +26,17 @@ system.
 Pipelines operate on an immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig] plus runtime
 options assembled via the TOML → FrozenConfig → runtime flow.
 
-Pipelines also operate on selected processing paths. Filesystem identity normalization,
-processing-path selection, and deduplication occur before ordinary pipeline execution begins.
-Pipeline steps therefore consume processing paths rather than preserving original CLI,
-configuration, glob, or symlink spellings.
+Pipelines also operate on selected processing paths. Filesystem-identity evaluation occurs before
+ordinary pipeline execution begins and includes both processing-path normalization and
+processing-target eligibility checks.
+
+Filesystem-identity normalization collapses equivalent path spellings, such as symlinks, into
+selected processing paths. Pipeline steps therefore consume processing paths rather than preserving
+original CLI, configuration, glob, or symlink spellings.
+
+Processing-target eligibility checks run at the pipeline-engine boundary. For example, hard-linked
+selected processing paths are blocked before ordinary per-file pipeline execution while unrelated
+selected paths continue through the requested pipeline.
 
 See [`Architecture`](./architecture.md) for the conceptual overview.
 
@@ -44,14 +51,20 @@ processing, and presentation layers:
   and `abspath`) for the selected processing target using POSIX `/` serialization on all platforms.
   If a file was reached through a symlink, generated metadata describes the resolved target that
   TopMark reads and writes.
+- The pipeline engine applies invocation-wide processing-target eligibility checks before ordinary
+  step execution. If multiple selected processing paths are hard links to the same filesystem
+  object, each affected path receives a terminal policy-blocked result; no source, target, winner,
+  or loser path is selected.
 - `PatcherStep` generates unified diffs for human review; diff file labels use human-facing display
   paths rather than machine-readable path serialization.
 - TEXT and Markdown frontends share display-path helpers so STDIN-backed processing consistently
   displays the logical `--stdin-filename` when available.
 
 Machine-readable path fields are generated from the selected processing path. Serialization and
-presentation occur after filesystem identity has been established and do not preserve invocation
-spellings.
+presentation occur after filesystem-identity evaluation and do not preserve invocation spellings.
+Hard-linked selected processing paths remain separate result payloads and are reported as
+unsupported, policy-blocked processing targets rather than being serialized as a single preferred
+path.
 
 {% include-markdown "\_snippets/config-strictness.md" %}
 

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -35,10 +35,18 @@ Pipeline execution consumes an immutable \[`FrozenConfig`\][topmark.config.model
 runtime options assembled from the TOML → FrozenConfig → runtime flow documented in
 [`Architecture`](architecture.md) and [`Configuration discovery`](../configuration/discovery.md).
 
-Pipeline execution also consumes a selected **processing path**. Normal file-list resolution
-normalizes filesystem identity, deduplicates multiple path spellings for the same target, and passes
-the canonical processing path into the pipeline. Pipeline steps therefore operate on processing
-paths rather than preserving original CLI, configuration, glob, or symlink spellings.
+Pipeline execution also consumes a selected **processing path**. File-list resolution performs
+filesystem-identity evaluation before ordinary pipeline execution begins.
+
+Filesystem-identity normalization collapses equivalent path spellings, such as symlinks, into a
+selected processing path. Filesystem-identity eligibility checks determine whether selected
+processing paths are safe to process. Pipeline steps therefore operate on processing paths rather
+than preserving original CLI, configuration, glob, or symlink spellings.
+
+Hard-linked selected processing paths are handled by an invocation-wide engine guard before ordinary
+per-file pipeline execution. If multiple selected paths refer to the same filesystem object through
+hard links, every affected path is blocked as an unsupported processing target; no source, target,
+winner, or loser path is selected.
 
 Source-local TOML options such as `[config].root` and `strict` are resolved before pipeline
 execution. They influence configuration discovery and staged config-loading validation behavior, but
@@ -66,8 +74,8 @@ ______________________________________________________________________
 
 All pipelines are built from the same core phases:
 
-1. **Input selection** - discover files, normalize filesystem identity, deduplicate, and select
-   processing paths
+1. **Input selection** - discover files, evaluate filesystem identity, normalize equivalent path
+   spellings, enforce processing-target eligibility, and select processing paths
 1. **Discovery** - identify file type and viability for each processing path
 1. **Inspection** - read content and detect existing headers
 1. **Evaluation** - generate and compare expected headers
@@ -76,10 +84,13 @@ All pipelines are built from the same core phases:
 The `probe` pipeline is an exception: it only executes the resolution phase and stops immediately
 after producing probe results.
 
-Input selection happens before ordinary pipeline execution. This includes symlink handling: file
-symlink spellings and their targets are collapsed to the resolved processing target before pipeline
-steps run. Synthetic probe contexts for filtered or missing explicit inputs preserve diagnostic
-input information only for those paths that never became normal processing paths.
+Input selection happens before ordinary pipeline execution. Filesystem-identity normalization
+handles symlink behavior: file symlink spellings and their targets are collapsed to the resolved
+processing target before pipeline steps run. Filesystem-identity eligibility checks handle safety
+policy such as hard-link detection: hard-linked selected processing paths are blocked before
+ordinary step execution, while unrelated selected paths continue through the requested pipeline.
+Synthetic probe contexts for filtered or missing explicit inputs preserve diagnostic input
+information only for those paths that never became normal processing paths.
 
 ### Unified Pipeline Flow
 
@@ -152,6 +163,10 @@ For filesystem inputs, the processing context path is the selected processing pa
 from the path spelling supplied on the command line or in configuration when symlinks or equivalent
 relative spellings are involved.
 
+For hard-linked filesystem inputs, selected processing paths remain separate results but are blocked
+before ordinary per-file pipeline execution. The engine does not collapse the hard-link group into a
+preferred source, target, winner, or loser path.
+
 ______________________________________________________________________
 
 ## Available Pipelines
@@ -199,6 +214,9 @@ requested paths that did not reach probing.
 Probe results that do reach runtime probing report processing paths. They should not be interpreted
 as a lossless echo of the original invocation spelling.
 
+Hard-linked selected processing paths also remain visible in probe output. Each affected path is
+reported independently as unsupported with the stable reason string `hard_link_duplicate`.
+
 ### SCAN
 
 **Purpose:** Detect file type and existing TopMark headers
@@ -222,6 +240,7 @@ R --> S --> D --> N
 
 - Header detected / missing / malformed
 - File unsupported, unreadable, binary, or blocked by policy
+- Hard-linked processing target blocked before ordinary scan steps run
 
 This pipeline is used as the foundation for all others.
 
@@ -494,6 +513,7 @@ execution from starting.
 - Mixed line endings
 - BOM before shebang
 - Missing read/write permissions
+- Hard-linked processing targets
 - Unsupported file types
 
 In these cases:
@@ -516,6 +536,8 @@ ______________________________________________________________________
 - **Determinism:** Same input → same outcome
 - **Processing-path identity:** pipeline steps operate on selected processing paths, not raw
   invocation spellings
+- **Filesystem-identity safety:** hard-linked selected processing paths are blocked before ordinary
+  per-file step execution without choosing a preferred path
 - **Dry-run safety:** No writes without `--apply`
 - **Separation of concerns:** Steps mutate context, views classify outcomes
 - **Runtime/configuration separation:** pipeline execution consumes resolved runtime configuration
@@ -528,7 +550,8 @@ ______________________________________________________________________
 - [Architecture](./architecture.md) - TOML → FrozenConfig → runtime overview
 - [Resolution](./resolution.md)
   - [Filesystem identity and processing paths](./resolution.md#filesystem-identity-and-processing-paths)
-    \- filesystem identity, symlink handling, and processing-path selection
+    \- filesystem-identity evaluation, symlink normalization, hard-link policy, and processing-path
+    selection
 - [Pipelines (Reference)](./pipelines-reference.md) - generated API-backed reference entry points
 - [Terminology and Canonical Vocabulary](../terminology.md) - canonical definitions for pipeline,
   status, hint, runtime, and machine-readable terminology
@@ -572,6 +595,7 @@ stateDiagram-v2
   PENDING --> NOT_FOUND
   PENDING --> NO_READ_PERMISSION
   PENDING --> UNREADABLE
+  PENDING --> HARD_LINK_DUPLICATE
   PENDING --> NO_WRITE_PERMISSION
   PENDING --> BINARY
   PENDING --> BOM_BEFORE_SHEBANG

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -55,8 +55,11 @@ stable reference once custom namespaces are involved.
 Filesystem identity is a separate concept from registry identity.
 
 Qualified identifiers such as `my_plugin:my_lang` identify file types in the registry model. Runtime
-file processing operates on selected processing paths after filesystem-identity normalization and
-path-resolution have completed.
+file processing operates on selected processing paths after filesystem-identity evaluation has
+completed.
+
+Filesystem-identity evaluation includes both path-spelling normalization (for example symlink
+handling) and processing-target eligibility checks (for example hard-link policy enforcement).
 
 ______________________________________________________________________
 
@@ -107,9 +110,10 @@ Path-based file type selection is performed by the shared scoring resolver in
 \[`topmark.resolution.filetypes`\][topmark.resolution.filetypes]. The formal selection and ambiguity
 policy is documented in [`resolution.md`](resolution.md).
 
-The resolver operates on selected processing paths after filesystem-identity normalization. File
-type plugins therefore do not participate in filesystem identity, symlink handling, processing-path
-selection, or configuration-source identity evaluation.
+The resolver operates on selected processing paths after filesystem-identity evaluation. File type
+plugins therefore do not participate in filesystem identity, symlink handling, hard-link policy,
+processing-path selection, processing-target eligibility checks, or configuration-source identity
+evaluation.
 
 ______________________________________________________________________
 
@@ -207,9 +211,9 @@ def provide_filetypes() -> list[FileType]:
 ```
 
 TopMark stores filename rules in canonical POSIX form. This normalization applies to registry
-matching rules only. Runtime processing paths, configuration-source identity, machine-readable path
-fields, and header metadata paths follow separate filesystem-identity and processing-path contracts
-documented in the resolution model.
+matching rules only. Runtime processing paths, processing-target eligibility, configuration-source
+identity, machine-readable path fields, and header metadata paths follow separate
+filesystem-identity and processing-path contracts documented in the resolution model.
 
 Registry inspection, machine-readable output, and resolver diagnostics therefore always expose
 normalized filename-rule values regardless of platform.
@@ -323,9 +327,9 @@ A typical advanced integration flow is:
 
 This keeps built-in registry construction deterministic and avoids module-import side effects.
 
-Processor registration influences runtime file-type handling only. Filesystem identity,
-processing-path selection, and configuration-source identity are resolved before processor selection
-occurs.
+Processor registration influences runtime file-type handling only. Filesystem-identity evaluation,
+processing-path selection, processing-target eligibility, and configuration-source identity are
+resolved before processor selection occurs.
 
 ______________________________________________________________________
 
@@ -411,4 +415,4 @@ ______________________________________________________________________
 - [`registry.md`](../usage/commands/registry.md) - CLI-facing registry inspection commands
 - [`Resolution model`](./resolution.md) - file-type scoring and ambiguity policy
   - [`Filesystem identity and processing paths`](./resolution.md#filesystem-identity-and-processing-paths)
-    \- filesystem identity, processing paths, and symlink handling
+    \- filesystem-identity evaluation, processing paths, symlink normalization, and hard-link policy

--- a/docs/dev/registry-model.md
+++ b/docs/dev/registry-model.md
@@ -350,11 +350,16 @@ topmark:markdown
 
 identify file types within the registry model.
 
-Filesystem identity, processing-path selection, symlink handling, and configuration-source identity
-are resolved before runtime probing and are documented in [Resolution](resolution.md).
+Filesystem-identity evaluation, processing-path selection, symlink normalization, hard-link policy,
+and configuration-source identity are resolved before runtime probing and are documented in
+[Resolution](resolution.md).
 
 The registry model operates on the resulting processing path and resolved file type identity; it
 does not define filesystem identity semantics itself.
+
+In particular, registry normalization is limited to registry identifiers and registry matching
+metadata. It does not participate in filesystem-identity normalization, processing-target
+eligibility checks, or hard-link policy enforcement.
 
 This affects:
 
@@ -390,6 +395,11 @@ Plugin authors should:
 - define filename rules as relative registry matching rules rather than filesystem paths;
 - use POSIX-style `/` separators for tail-subpath matching rules so registry metadata remains stable
   across platforms.
+
+These filename rules are registry matching metadata, not filesystem paths. Plugin-defined file types
+participate in resolution only after filesystem-identity evaluation has selected eligible processing
+paths. Plugins do not define symlink normalization, hard-link policy, or configuration-source
+identity behavior.
 
 Header processor plugins currently use advanced runtime-overlay integration semantics. They should
 bind processor definitions to canonical qualified file type identifiers.

--- a/docs/dev/resolution.md
+++ b/docs/dev/resolution.md
@@ -67,6 +67,12 @@ Multiple path spellings that resolve to the same processing target (for example 
 target) are collapsed before pipeline execution. Runtime resolution therefore operates on processing
 paths rather than original CLI, configuration, glob, or symlink spellings.
 
+Hard-linked selected paths are not collapsed by discovery because they are distinct directory
+entries and selected processing paths. Instead, the runtime engine detects selected paths that share
+the same `(st_dev, st_ino)` filesystem identity and blocks all affected paths before per-file
+pipeline steps run. This preserves one result per selected path while avoiding ambiguous writes or
+generated filesystem metadata for shared storage.
+
 File-type filters accept both local identifiers such as `python` and canonical qualified identifiers
 such as `topmark:python`.
 
@@ -116,9 +122,14 @@ TopMark intentionally separates:
 1. discovery filtering
 1. runtime configuration resolution
 1. registry composition
+1. filesystem-identity evaluation
 1. runtime file-type probing
 1. deterministic winner selection
 1. pipeline execution
+
+Filesystem-identity evaluation includes filesystem-identity normalization for equivalent path
+spellings (such as symlinks), processing-path selection, and processing-target eligibility checks
+(such as hard-link detection).
 
 Each stage operates on the finalized outputs of the previous stage.
 
@@ -136,8 +147,8 @@ Before a path reaches file-type probing, TopMark performs:
 1. discovery
 1. filtering
 1. filesystem-identity normalization
-1. deduplication
 1. processing-path selection
+1. filesystem-identity eligibility checks
 
 The resulting processing path is then supplied to runtime probing and pipeline execution.
 
@@ -146,17 +157,17 @@ flowchart TD
     input["CLI/config input"]
     discovery["Discovery + filtering"]
     identity["Filesystem identity<br/>normalization"]
-    dedupe["Deduplication"]
-    processing["Processing path"]
+    processing["Processing path<br/>selection"]
+    eligibility["Filesystem identity<br/>eligibility checks"]
     runtime["Runtime resolution"]
     pipeline["Pipeline execution"]
     serialization["Machine-readable<br/>serialization"]
 
     input --> discovery
     discovery --> identity
-    identity --> dedupe
-    dedupe --> processing
-    processing --> runtime
+    identity --> processing
+    processing --> eligibility
+    eligibility --> runtime
     runtime --> pipeline
     pipeline --> serialization
 ```
@@ -164,7 +175,14 @@ flowchart TD
 Machine-readable output serializes the selected processing path; it does not attempt to preserve the
 original invocation spelling.
 
-Filesystem identity is currently defined by the resolved processing target path.
+Filesystem-identity evaluation uses multiple identity concepts.
+
+Processing-path normalization is based on the resolved processing target path and is responsible for
+collapsing equivalent path spellings such as symlinks.
+
+Filesystem-identity eligibility checks may use additional filesystem identity information. For
+example, hard-link policy uses `(st_dev, st_ino)` identity to detect selected processing paths that
+refer to the same filesystem object.
 
 Examples such as:
 
@@ -176,7 +194,9 @@ link-to-file.py
 
 may therefore collapse to a single processing path before runtime resolution begins.
 
-Hard-link detection and device/inode-based identity are outside the current compatibility contract.
+Hard-link policy is part of the stable filesystem-identity contract. Selected processing paths that
+share `(st_dev, st_ino)` identity are reported independently and blocked before ordinary per-file
+pipeline execution begins.
 
 ______________________________________________________________________
 
@@ -185,7 +205,7 @@ ______________________________________________________________________
 TopMark 1.0 exposes a probe-first resolution model via
 \[`probe_resolution_for_path()`\][topmark.resolution.filetypes.probe_resolution_for_path].
 
-Probe-based resolution operates only after discovery filtering, filesystem- identity normalization,
+Probe-based resolution operates only after discovery filtering, filesystem-identity evaluation,
 processing-path selection, and configuration normalization have completed.
 
 This function returns a \[`ResolutionProbeResult`\][topmark.resolution.probe.ResolutionProbeResult]
@@ -438,9 +458,9 @@ This separation keeps responsibilities clear:
 
 The resolver deliberately does not define filesystem identity semantics.
 
-Filesystem identity, symlink handling, deduplication, and processing-path selection occur earlier
-during discovery and file-list resolution. The resolver consumes the resulting processing path and
-focuses exclusively on file-type selection.
+Filesystem-identity evaluation, symlink normalization, processing-target eligibility checks, and
+processing-path selection occur earlier during discovery and file-list resolution. The resolver
+consumes the resulting processing path and focuses exclusively on file-type selection.
 
 This design has several advantages:
 
@@ -452,21 +472,49 @@ This design has several advantages:
 
 ______________________________________________________________________
 
-## Symlink policy
+## Filesystem identity policy
 
-The runtime resolver operates on processing paths and therefore does not preserve original symlink
-spellings.
+The runtime resolver operates on processing paths selected before file-type probing begins. It does
+not preserve original CLI, configuration, glob, or symlink spellings.
+
+Filesystem-identity policy has two related parts:
+
+- filesystem-identity normalization, which collapses equivalent path spellings to selected
+  processing paths; and
+- filesystem-identity eligibility checks, which block selected processing paths that are unsafe or
+  unsupported for runtime processing.
+
+### Symlink normalization
+
+Symlink handling belongs to filesystem-identity normalization.
 
 Current behavior:
 
 - file-symlink inputs are resolved to their processing target;
-- symlink and target spellings are deduplicated before runtime processing;
+- symlink spellings are resolved to the target path before runtime processing;
 - configuration-source identity is based on the resolved configuration-file target;
 - machine-readable output serializes the resulting processing path; and
 - generated filesystem-related header metadata describes the target TopMark reads and writes.
 
 This policy contributes to idempotence and prevents duplicate processing of the same target file
 through multiple spellings.
+
+### Hard-link policy
+
+Hard-link handling belongs to filesystem-identity eligibility checks, not path-spelling
+normalization.
+
+Current behavior:
+
+- hard-linked files remain distinct selected processing paths;
+- selected processing paths that share `(st_dev, st_ino)` identity are all blocked;
+- machine-readable output preserves one result per selected hard-linked path;
+- probe reports affected paths as unsupported with reason `hard_link_duplicate`;
+- processing commands report affected paths as unsupported, policy-blocked processing targets; and
+- TopMark does not select a source, target, winner, or loser path from the hard-link group.
+
+This policy avoids ambiguous writes and generated filesystem metadata for shared storage while
+preserving per-path diagnostics for every selected input.
 
 ______________________________________________________________________
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ TopMark provides stable and consistent behavior across:
 
 - CLI execution and dry-run workflows
 - layered TOML configuration discovery and precedence
-- filesystem identity normalization and processing-path selection
+- filesystem-identity evaluation, processing-path selection, and hard-link safety
 - configuration-source identity and layered provenance reporting
 - repository filtering and file-type resolution
 - probe and diagnostics workflows
@@ -59,8 +59,8 @@ ______________________________________________________________________
 - Supports pre-commit and CI integration
 - Explains repository filtering, file-type resolution, and processor selection via
   [`topmark probe`](usage/commands/probe.md)
-- Uses deterministic filesystem-identity normalization and processing-path selection across CLI,
-  API, CI, and machine-readable workflows
+- Uses deterministic filesystem-identity evaluation, processing-path selection, and hard-link safety
+  across CLI, API, CI, and machine-readable workflows
 - Exposes layered configuration provenance via `topmark config dump --show-layers`
 - Uses deterministic configuration-source identity for layered configuration evaluation
 - Provides stable machine-readable JSON and NDJSON output together with canonical registry metadata
@@ -74,9 +74,12 @@ ______________________________________________________________________
 
 TopMark exposes a small set of dry-run-first CLI commands.
 
-Filesystem-processing commands normalize filesystem identity before runtime processing. Multiple
-path spellings that resolve to the same filesystem target (for example a symlink and its target) are
-treated as a single processing target.
+Filesystem-processing commands evaluate filesystem identity before runtime processing.
+Filesystem-identity normalization resolves equivalent path spellings, such as symlink spellings, to
+the selected processing path used by runtime processing and machine-readable output. Hard-link
+policy is evaluated as a processing-target eligibility check: if multiple selected paths refer to
+the same filesystem object through hard links, TopMark reports each affected path independently and
+blocks processing for the hard-link group.
 
 For command structure, shared options, applicability rules, and common workflows, see:
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -131,6 +131,15 @@ Examples include qualified file-type identities and canonicalized registry match
 The canonical filesystem object identity used by TopMark when processing existing files,
 configuration sources, and runtime inputs.
 
+Filesystem identity is evaluated before runtime processing begins.
+
+Filesystem-identity evaluation consists of two related concepts:
+
+- **Filesystem-identity normalization**: collapsing equivalent path spellings that refer to the same
+  filesystem target (for example a symlink and its target) into a selected processing path.
+- **Filesystem-identity eligibility checks**: determining whether a selected processing path is
+  eligible for processing according to filesystem-identity policy.
+
 For ordinary filesystem processing, identity is based on the resolved processing target rather than
 the original invocation spelling.
 
@@ -144,9 +153,14 @@ link-to-file.py
 
 may all refer to the same filesystem identity.
 
+Hard links are handled differently from symlink spelling aliases. When two or more selected
+processing paths have the same `(st_dev, st_ino)` filesystem identity, TopMark preserves one result
+per selected path but blocks every affected path as a hard-linked processing target. It does not
+select a source, target, winner, or loser path automatically.
+
 > [!NOTE]
 >
-> Filesystem identity is distinct from machine-readable path serialization. TopMark first determines
+> Filesystem identity is distinct from machine-readable path serialization. TopMark first evaluates
 > filesystem identity and then serializes the selected processing path according to the
 > machine-output contract.
 
@@ -166,8 +180,9 @@ ______________________________________________________________________
 
 The process of selecting the most appropriate file type for a path or input.
 
-Resolution may normalize multiple path spellings to a single filesystem identity before runtime
-processing begins.
+Resolution operates after filesystem-identity evaluation has selected eligible processing paths.
+Filesystem-identity normalization may collapse multiple path spellings, such as symlinks, to a
+single selected processing path before runtime processing begins.
 
 ### Filename rule
 
@@ -298,7 +313,9 @@ A mutating execution mode that performs filesystem writes.
 The guarantee that repeated runs without source changes converge to the same result.
 
 Filesystem-identity normalization contributes to idempotence by preventing the same target file from
-being processed multiple times through different path or symlink spellings.
+being processed multiple times through different path or symlink spellings. Filesystem-identity
+eligibility checks, such as hard-link policy, contribute to safety by blocking ambiguous write
+targets before mutation planning.
 
 ### Mutation planning
 

--- a/docs/usage/ci.md
+++ b/docs/usage/ci.md
@@ -41,9 +41,14 @@ topmark check .
 This validates the selected files and exits with `WOULD_CHANGE (3)` when headers would need to be
 inserted, updated, or removed.
 
-TopMark normalizes filesystem identity before runtime processing. If multiple path spellings resolve
-to the same filesystem target (for example a symlink and its target), CI validation operates on the
-selected processing path and processes the target once.
+TopMark evaluates filesystem identity before runtime processing. Filesystem-identity normalization
+resolves equivalent path spellings, such as symlink spellings, to the selected processing path used
+by CI validation.
+
+Hard-link policy is evaluated as a processing-target eligibility check. If multiple selected paths
+refer to the same filesystem object through hard links, TopMark reports each affected path
+independently and blocks processing for the entire hard-link group without selecting a preferred
+source, target, winner, or loser path.
 
 If you also want to validate the TopMark configuration, either provide `--strict` to `topmark check`
 or add a dedicated configuration validation step:
@@ -109,8 +114,11 @@ Notes:
 - Explicit missing literal paths are hard input errors and produce `FILE_NOT_FOUND (66)`.
 - Unmatched glob patterns are soft discovery diagnostics and do not fail `check`.
 - In mixed-result runs, hard input and filesystem errors take precedence over `WOULD_CHANGE (3)`.
-- Filesystem-identity normalization and processing-path selection do not affect exit-code semantics.
-  Equivalent path spellings contribute to the same runtime processing outcome.
+- Filesystem-identity evaluation occurs before runtime processing and may affect processing-target
+  eligibility. Equivalent path spellings contribute to the same runtime processing outcome after
+  filesystem-identity normalization.
+- Hard-link policy participates through normal processing outcomes and diagnostics and does not
+  introduce a dedicated CI exit code.
 
 ### `topmark config check`
 
@@ -248,6 +256,10 @@ Pre-commit and CI serve complementary roles:
 - pre-commit gives contributors fast local feedback before a commit is created;
 - CI enforces the same expectation for pull requests, branches, and external contributions.
 
+Both pre-commit and CI use the same filesystem-identity evaluation rules, including
+filesystem-identity normalization for symlink spellings and hard-link policy enforcement for runtime
+file-processing commands.
+
 A practical adoption sequence is:
 
 1. run TopMark locally and apply the initial header updates;
@@ -276,7 +288,13 @@ Machine-readable output can expose structured CI diagnostics such as:
 
 For filesystem-processing commands, machine-readable path fields report selected processing paths
 rather than preserving the original CLI argument spelling. If a file is reached through a symlink,
-JSON and NDJSON output describe the resolved processing target used by TopMark.
+filesystem-identity normalization resolves the symlink spelling to the processing target used by
+TopMark, and JSON/NDJSON output reports that selected processing path.
+
+If multiple selected paths are hard links to the same filesystem object, machine-readable output
+still contains one result per selected path. Each affected path is reported independently as a
+policy-blocked processing target; TopMark does not select a preferred source, target, winner, or
+loser path.
 
 This makes JSON and NDJSON output useful for CI annotations, dashboards, repository audits, policy
 validation, and custom reporting pipelines.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -26,7 +26,7 @@ The CLI is intentionally conservative:
 
 - commands default to dry-run behavior
 - mutations require `--apply`
-- filesystem identity is normalized before runtime processing
+- filesystem identity policies are evaluated before runtime processing
 - unsupported files are skipped diagnostically
 - repeated runs converge to stable results
 - command help and shell completion are available across supported platforms
@@ -45,9 +45,15 @@ ______________________________________________________________________
 | Inspect file type resolution         | `topmark probe README.md`           | [`topmark probe`](commands/probe.md), [Filtering](filtering.md)                                        |
 | Inspect effective configuration      | `topmark config dump --show-layers` | [`topmark config dump`](commands/config/dump.md), [Configuration](configuration.md)                    |
 
-Filesystem inputs are normalized to selected processing paths before runtime processing. If multiple
-path spellings resolve to the same filesystem target (for example a symlink and its target), TopMark
-processes the target once and reports the selected processing path in machine-readable output.
+Filesystem inputs undergo filesystem-identity evaluation before runtime processing. If multiple path
+spellings resolve to the same filesystem target (for example a symlink and its target),
+filesystem-identity normalization resolves symlink spellings to the target path, and TopMark reports
+the selected processing path in machine-readable output.
+
+Hard-link policy is evaluated as a processing-target eligibility check. If multiple selected paths
+refer to the same filesystem object through hard links, TopMark reports each affected path
+independently and blocks processing for the entire hard-link group without selecting a preferred
+source, target, winner, or loser path.
 
 ______________________________________________________________________
 
@@ -98,8 +104,12 @@ topmark strip --apply src/
 ```
 
 For commands that operate on filesystem inputs (`check`, `strip`, and `probe`), positional paths
-participate in TopMark's discovery, filtering, filesystem-identity normalization, and
-processing-path selection pipeline before runtime processing begins.
+participate in TopMark's discovery, filtering, filesystem-identity evaluation, and processing-path
+selection pipeline before runtime processing begins.
+
+Filesystem-identity evaluation includes filesystem-identity normalization for equivalent path
+spellings, processing-path selection, and processing-target eligibility checks such as hard-link
+policy.
 
 ______________________________________________________________________
 
@@ -274,7 +284,7 @@ File type filters behave consistently across:
 - API overlays
 - resolution and probe filtering
 
-File type filtering operates after filesystem-identity normalization and processing-path selection.
+File type filtering operates after filesystem-identity evaluation and processing-path selection.
 
 For canonical file-type identifier semantics and layered configuration behavior, see
 [Configuration](configuration.md).
@@ -373,5 +383,6 @@ The CLI reports:
 - ambiguous or malformed file type identifiers
 
 Diagnostics are designed to remain deterministic and compatible with the stable machine-readable
-output contracts. This includes stable processing-path reporting for runtime filesystem inputs and
-stable configuration-source identity reporting for file-backed configuration provenance.
+output contracts. This includes stable processing-path reporting after filesystem-identity
+normalization, stable hard-link policy diagnostics for unsupported processing targets, and stable
+configuration-source identity reporting for file-backed configuration provenance.

--- a/docs/usage/commands/check.md
+++ b/docs/usage/commands/check.md
@@ -106,10 +106,13 @@ working directory; path-based filters run before file-type filters, and exclude 
 precedence. See [Filtering](../filtering.md#path-based-filtering) for the full path discovery
 contract.
 
-During discovery, TopMark normalizes filesystem identity and selects processing paths. If multiple
-path spellings resolve to the same filesystem target (for example a symlink and its target), `check`
-processes the resolved target once. Downstream filtering, probing, header generation, and
-machine-readable output operate on the selected processing path rather than the original spelling.
+During discovery, TopMark performs filesystem-identity evaluation and selects processing paths. If
+multiple path spellings resolve to the same filesystem target (for example a symlink and its
+target), `check` processes the resolved target once. Downstream filtering, probing, header
+generation, and machine-readable output operate on the selected processing path rather than the
+original spelling. Hard-link policy is evaluated as a processing-target eligibility check: if
+multiple selected processing paths are hard links to the same filesystem object, each affected path
+is reported as an unsupported, policy-blocked processing target.
 
 ### File type filters
 
@@ -150,6 +153,9 @@ Notes:
 - Existing filesystem inputs are normalized to selected processing paths before runtime processing.
 - Symlink spellings are not preserved for runtime identity, generated filesystem-related header
   metadata, or machine-readable `result.path` fields.
+- Hard-linked selected paths are handled as processing-target eligibility failures. Each affected
+  path is reported independently and blocked from processing; TopMark does not select a preferred
+  source, target, winner, or loser path.
 - Exclude rules win over include rules when both match a path.
 - File-type filters are applied after path-based include/exclude filtering.
 - File-type filters are normalized to canonical qualified file type identities before filtering,
@@ -252,6 +258,9 @@ ______________________________________________________________________
 - Header metadata path fields: generated from the selected processing target. If a file is reached
   through a symlink, `file_relpath`, `file_abspath`, `relpath`, and `abspath` describe the resolved
   target TopMark reads and writes rather than the symlink spelling.
+- Hard-link safety: if multiple selected paths refer to the same filesystem object through hard
+  links, `check` blocks every affected path. No header is inserted or updated for those paths, and
+  no source, target, winner, or loser path is selected.
 - Idempotency: running `topmark check` again on a file that already has a correct header produces no
   diff and exit code 0 (unless other files would change).
 
@@ -303,7 +312,9 @@ For the canonical schema, stable `kind` values, and shared conventions, see:
 Machine-readable output emits selected processing paths with POSIX `/` separators and resolved file
 type identities using canonical qualified identity strings when available. If a checked file is
 reached through a symlink, per-file `result.path` describes the resolved processing target rather
-than the symlink spelling. Configuration payloads also emit normalized file type filters and
+than the symlink spelling. If selected paths are hard links to the same filesystem object, `check`
+emits one result per selected path and reports each affected path as a policy-blocked unsupported
+processing target. Configuration payloads also emit normalized file type filters and
 `policy_by_type` keys.
 
 Notes:
@@ -513,6 +524,9 @@ ______________________________________________________________________
 - **Symlink path not shown in output**: `check` processes selected processing paths. If a symlink
   and its target resolve to the same file, machine-readable output and generated header metadata
   describe the resolved target rather than the symlink spelling.
+- **Hard-linked files are reported as unsupported**: `check` blocks processing when multiple
+  selected paths refer to the same filesystem object through hard links. Each affected path is
+  reported independently; no preferred path is selected from the hard-link group.
 - **File type filter does not match**: use [`topmark probe`](probe.md) to inspect resolution
   decisions, and prefer qualified identifiers such as `topmark:python` when local identifiers may be
   ambiguous.

--- a/docs/usage/commands/config.md
+++ b/docs/usage/commands/config.md
@@ -42,7 +42,8 @@ internally by CLI/API orchestration. When using the Python API, provide plain ma
 via `config=...`, `policy=...`, and `policy_by_type=...`.
 
 API overlays follow the same identifier normalization and runtime policy-resolution semantics as
-TOML configuration and CLI filtering.
+TOML configuration and CLI filtering. These semantics are configuration concerns and are distinct
+from runtime filesystem-identity evaluation for selected processing paths.
 
 TopMark performs whole-source TOML validation during loading before layered configuration merging
 and runtime applicability evaluation. Unknown sections or keys, malformed section shapes, and
@@ -60,6 +61,10 @@ ______________________________________________________________________
 
 The `config` command family is **file-agnostic**. These commands operate on configuration state and
 do not process source files.
+
+Configuration-source identity is resolved during configuration loading. Runtime processing-target
+identity, including filesystem-identity normalization and hard-link eligibility checks, is evaluated
+later by filesystem-processing commands such as `check`, `strip`, and `probe`.
 
 Across all `config` subcommands:
 
@@ -135,7 +140,9 @@ discovered config, CLI overrides) and includes source-local TOML fragments. This
 original TOML fragments (after schema validation) that contributed to each layer.
 
 Machine-readable configuration snapshots emit normalized canonical qualified file type identities
-after configuration normalization.
+after configuration normalization. They do not apply runtime processing-target eligibility checks
+such as hard-link policy because the `config` command family operates on configuration state rather
+than source-file processing targets.
 
 ### Strictness and provenance
 
@@ -177,6 +184,7 @@ ______________________________________________________________________
 - **Unexpected file type filter behavior**: prefer qualified identifiers such as `topmark:python`
   when local identifiers may be ambiguous.
 - **Unexpected policy application**: inspect normalized identifiers using
-  [`topmark config dump`](config/dump.md).
+  [`topmark config dump`](config/dump.md), or inspect file type resolution using
+  [`topmark probe`](probe.md).
 - **Unexpected validation failures**: use [`topmark config check`](config/check.md) together with
   `-vv` or machine-readable output to inspect staged validation diagnostics.

--- a/docs/usage/commands/config/check.md
+++ b/docs/usage/commands/config/check.md
@@ -92,7 +92,11 @@ files, and CLI overrides before staged validation produces the effective runtime
 For file-backed configuration sources, TopMark determines configuration-source identity using the
 resolved configuration-file target. If a configuration file is reached through a symlink,
 precedence, scope evaluation, applicability checks, and provenance operate on the resolved target
-rather than the symlink spelling. See
+rather than the symlink spelling. Configuration-source identity is distinct from processing-target
+identity. Runtime filesystem-processing commands such as `check`, `strip`, and `probe` evaluate
+selected processing paths separately, including filesystem-identity normalization and eligibility
+checks such as hard-link policy. Those runtime checks do not affect configuration loading,
+configuration provenance, or configuration validation. See
 [Configuration discovery, precedence, and policy](../../../configuration/discovery.md) for the full
 configuration-loading and validation contract.
 
@@ -215,6 +219,10 @@ after configuration normalization.
 Machine-readable configuration provenance uses configuration-source identity based on the resolved
 configuration-file target. Configuration-source paths reported by machine-readable output therefore
 describe the resolved configuration target rather than a symlink spelling used to reach it.
+
+Unlike file-processing machine output, configuration machine output does not apply runtime
+processing-target eligibility checks such as hard-link policy because configuration validation
+operates on configuration sources rather than processing targets.
 
 {% include-markdown "\_snippets/path-serialization-contract.md" %}
 

--- a/docs/usage/commands/config/dump.md
+++ b/docs/usage/commands/config/dump.md
@@ -122,6 +122,12 @@ For file-backed layers, `origin` and `scope_root` describe the resolved configur
 used for configuration-source identity. If a configuration file is loaded through a symlink, layered
 provenance reports the resolved target rather than the symlink spelling.
 
+Configuration-source identity is distinct from processing-target identity. Runtime
+filesystem-processing commands such as `check`, `strip`, and `probe` evaluate selected processing
+paths separately, including filesystem-identity normalization and eligibility checks such as
+hard-link policy. Those runtime checks do not affect configuration loading, layered provenance,
+applicability evaluation, or runtime configuration serialization.
+
 The second TOML document is identical to the standard flattened runtime configuration output.
 
 TopMark resolves configuration from defaults, user config, the project chain, explicit `--config`
@@ -133,6 +139,11 @@ precedence, scope evaluation, applicability checks, and layered provenance opera
 target rather than the symlink spelling. See
 [Configuration discovery, precedence, and policy](../../../configuration/discovery.md) for the full
 configuration-loading and validation contract.
+
+This configuration-source identity behavior mirrors only the path-spelling normalization part of
+TopMark's runtime processing-target identity model. Processing-target eligibility checks such as
+hard-link policy are evaluated later by runtime filesystem-processing commands and are not part of
+configuration dumping.
 
 Configuration and policy override values shown by this command are part of the stable public
 configuration surface. Internal implementation details are not part of the user-facing CLI or Python
@@ -198,6 +209,10 @@ after configuration normalization.
 Machine-readable configuration provenance uses configuration-source identity based on the resolved
 configuration-file target. Configuration-source paths reported by machine-readable output therefore
 describe the resolved configuration target rather than a symlink spelling used to reach it.
+
+Unlike file-processing machine output, configuration machine output does not apply runtime
+processing-target eligibility checks such as hard-link policy because `config dump` operates on
+configuration sources rather than processing targets.
 
 {% include-markdown "\_snippets/path-serialization-contract.md" %}
 
@@ -352,3 +367,6 @@ ______________________________________________________________________
 - **Configuration path differs from invocation spelling**: layered provenance and machine-readable
   provenance report resolved configuration targets. If a configuration file is loaded through a
   symlink, `origin` and `scope_root` may differ from the path spelling supplied on the command line.
+- **Hard-link policy is not reflected in the output**: `config dump` reports configuration state,
+  not processing-target eligibility. Hard-link policy is enforced by runtime filesystem-processing
+  commands such as `check`, `strip`, and `probe`.

--- a/docs/usage/commands/probe.md
+++ b/docs/usage/commands/probe.md
@@ -105,10 +105,11 @@ working directory; path-based filters run before file-type filters, and exclude 
 precedence. See [Filtering](../filtering.md#path-based-filtering) for the full path discovery
 contract.
 
-During discovery, TopMark normalizes filesystem identity and selects processing paths before runtime
-probing begins. If multiple path spellings resolve to the same filesystem target (for example a
-symlink and its target), `probe` operates on the selected processing path rather than preserving the
-original spelling.
+During discovery, TopMark performs filesystem-identity evaluation and selects processing paths
+before runtime probing begins. If multiple path spellings resolve to the same filesystem target (for
+example a symlink and its target), `probe` operates on the selected processing path rather than
+preserving the original spelling. Hard-link policy is evaluated as a processing-target eligibility
+check.
 
 Filtered and missing explicit inputs remain diagnostic records because they never became normal
 processing paths.
@@ -178,8 +179,11 @@ ______________________________________________________________________
   [`strip`](strip.md), while preserving filtered explicit inputs as diagnostic probe results.
 - Shared runtime resolution: uses the same normalization, scoring, and runtime resolution logic as
   [`check`](check.md) and [`strip`](strip.md).
-- Processing-path identity: runtime probing operates on selected processing paths. Multiple path
-  spellings that resolve to the same target are collapsed before ordinary probe execution.
+- Processing-path identity: runtime probing operates on selected processing paths. Symlink spellings
+  are resolved to the target path before ordinary probe execution.
+- Hard-link policy: if multiple selected processing paths are hard links to the same filesystem
+  object, probe reports each affected path as unsupported rather than selecting a source, target,
+  winner, or loser path.
 - Candidate visibility: exposes selected file type, processor, candidate scores, match signals,
   runtime-resolution status, and runtime-resolution reason.
 - Idempotency: repeated runs produce identical output for unchanged inputs.
@@ -224,6 +228,10 @@ Probe machine-readable output emits processing paths with POSIX `/` separators a
 type identities using canonical qualified identity strings when available. For probe results that
 reach runtime probing, the emitted path describes the selected processing target rather than the
 original symlink or invocation spelling.
+
+Hard-linked processing targets remain separate probe results. Each affected selected path produces
+its own machine-readable probe payload and is reported as an unsupported processing target with
+reason `hard_link_duplicate`.
 
 ### Shared output controls
 
@@ -278,6 +286,10 @@ selected.
 Directories that successfully expand to selected files are not emitted as additional filtered probe
 results. Explicit missing paths are represented as missing-input probe results rather than filtered
 probe results.
+
+If multiple selected processing paths are hard links to the same filesystem object, probe emits one
+result per selected path. Each affected result reports an unsupported outcome with reason
+`hard_link_duplicate`. TopMark does not select a preferred path from the hard-link group.
 
 ```jsonc
 {
@@ -427,6 +439,10 @@ ______________________________________________________________________
 - **Symlink path not shown in output**: `probe` reports selected processing paths for inputs that
   reach runtime probing. If a symlink and its target resolve to the same file, the emitted probe
   path describes the resolved processing target rather than the symlink spelling.
+- **Hard-linked files are reported as unsupported**: TopMark blocks processing when multiple
+  selected paths refer to the same filesystem object through hard links. Each affected path is
+  reported independently with reason `hard_link_duplicate`; no preferred path is selected from the
+  hard-link group.
 - **File type filter does not match**: prefer qualified identifiers such as `topmark:python` when
   local identifiers may be ambiguous.
 - **No processor**: check that a processor binding exists for the selected file type.

--- a/docs/usage/commands/registry.md
+++ b/docs/usage/commands/registry.md
@@ -35,6 +35,10 @@ The `registry` command family is informational and file-agnostic. These commands
 effective composed registry state and do not process project files or perform configuration
 discovery.
 
+Because registry commands do not select source-file processing targets, they do not apply
+filesystem-identity normalization, processing-path selection, or processing-target eligibility
+checks such as hard-link policy.
+
 Across all `registry` subcommands:
 
 - positional PATH arguments are rejected as invalid CLI usage
@@ -71,14 +75,15 @@ markdown
 in public CLI filters and configuration when unambiguous.
 
 Registry-oriented machine-readable output and effective runtime views use canonical qualified file
-type identities for deterministic identity handling.
+type identities for deterministic registry identity handling.
 
 {% include-markdown "\_snippets/file-type-identifiers.md" %}
 
 See [file-type filtering](../filtering.md#file-type-filtering) for the full identifier contract.
 
 Registry commands expose the effective runtime registry view after registry composition and
-configuration normalization.
+configuration normalization. This registry normalization is independent of runtime
+filesystem-identity evaluation for selected processing paths.
 
 ______________________________________________________________________
 

--- a/docs/usage/commands/strip.md
+++ b/docs/usage/commands/strip.md
@@ -105,10 +105,13 @@ working directory; path-based filters run before file-type filters, and exclude 
 precedence. See [Filtering](../filtering.md#path-based-filtering) for the full path discovery
 contract.
 
-During discovery, TopMark normalizes filesystem identity and selects processing paths. If multiple
-path spellings resolve to the same filesystem target (for example a symlink and its target), `strip`
-processes the resolved target once. Downstream filtering, probing, stripping, and machine-readable
-output operate on the selected processing path rather than the original spelling.
+During discovery, TopMark performs filesystem-identity evaluation and selects processing paths. If
+multiple path spellings resolve to the same filesystem target (for example a symlink and its
+target), `strip` processes the resolved target once. Downstream filtering, probing, stripping, and
+machine-readable output operate on the selected processing path rather than the original spelling.
+Hard-link policy is evaluated separately from processing-path selection: if multiple selected
+processing paths are hard links to the same filesystem object, each affected path is reported as an
+unsupported, policy-blocked processing target.
 
 ### File type filters
 
@@ -144,6 +147,9 @@ Notes:
 
 - Existing filesystem inputs are normalized to selected processing paths before runtime processing.
 - Symlink spellings are not preserved for runtime identity or machine-readable `result.path` fields.
+- Hard-linked selected paths are handled as processing-target eligibility failures. Each affected
+  path is reported independently and blocked from processing; TopMark does not select a preferred
+  source, target, winner, or loser path.
 
 {% include-markdown "\_snippets/report-scope.md" %}
 
@@ -191,6 +197,9 @@ ______________________________________________________________________
   removed.
 - Processing-path identity: if a file is reached through a symlink, stripping operates on the
   resolved target TopMark reads and writes rather than the symlink spelling used to reach it.
+- Hard-link safety: if multiple selected paths refer to the same filesystem object through hard
+  links, `strip` blocks every affected path. No header removal is performed for those paths, and no
+  source, target, winner, or loser path is selected.
 
 ______________________________________________________________________
 
@@ -240,7 +249,9 @@ For the canonical schema, stable `kind` values, and shared conventions, see:
 Machine-readable output emits selected processing paths with POSIX `/` separators and resolved file
 type identities using canonical qualified identity strings when available. If a stripped file is
 reached through a symlink, per-file `result.path` describes the resolved processing target rather
-than the symlink spelling. Configuration payloads also emit normalized file type filters and
+than the symlink spelling. If selected paths are hard links to the same filesystem object, `strip`
+emits one result per selected path and reports each affected path as a policy-blocked unsupported
+processing target. Configuration payloads also emit normalized file type filters and
 `policy_by_type` keys.
 
 Notes:
@@ -449,6 +460,9 @@ ______________________________________________________________________
 - **Symlink path not shown in output**: `strip` operates on selected processing paths. If a symlink
   and its target resolve to the same file, machine-readable output reports the resolved processing
   target rather than the symlink spelling.
+- **Hard-linked files are reported as unsupported**: `strip` blocks processing when multiple
+  selected paths refer to the same filesystem object through hard links. Each affected path is
+  reported independently; no preferred path is selected from the hard-link group.
 - **File type filter does not match**: use [`topmark probe`](probe.md) to inspect resolution
   decisions, and prefer qualified identifiers such as `topmark:python` when local identifiers may be
   ambiguous.

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -26,6 +26,11 @@ For file-backed configuration sources, TopMark determines configuration-source i
 resolved configuration-file target. Symlink spellings are not preserved for precedence, scope, or
 applicability evaluation.
 
+Configuration-source identity is distinct from processing-target identity. The hard-link processing
+policy used by runtime file-processing commands such as `check`, `strip`, and `probe` does not
+affect configuration discovery, configuration precedence, scope evaluation, or applicability
+evaluation.
+
 {% include-markdown "\_snippets/terminology.md" %}
 
 ______________________________________________________________________
@@ -49,8 +54,10 @@ configuration provenance operate on the resolved configuration-file target.
 
 > [!NOTE]
 >
-> This behavior mirrors the processing-path contract used for runtime file processing. TopMark
-> normalizes filesystem identity before configuration applicability and runtime evaluation.
+> This behavior mirrors the processing-path contract used for runtime file processing, but the two
+> identity systems are evaluated independently. Configuration-source identity governs configuration
+> loading and precedence, while processing-target identity governs runtime file-processing behavior
+> such as path selection and hard-link policy enforcement.
 
 ______________________________________________________________________
 
@@ -243,6 +250,10 @@ normalization, and configuration-source identity resolution have completed.
 
 For configuration files loaded through symlinks, the effective configuration is associated with the
 resolved configuration target rather than the symlink spelling used to reach it.
+
+Hard-link processing policy is not represented in the runtime configuration model because it is a
+processing-target eligibility rule evaluated by runtime file-processing commands rather than a
+configuration-layering concern.
 
 ______________________________________________________________________
 

--- a/docs/usage/exit-codes.md
+++ b/docs/usage/exit-codes.md
@@ -69,9 +69,11 @@ Notes:
   configuration-loading or runtime-resolution outcomes depending on command behavior.
 - Explicit missing literal paths are treated as hard input errors (66). Unmatched glob patterns are
   soft diagnostics and do not produce 66.
-- Filesystem identity normalization and processing-path selection do not affect exit-code semantics.
-  Different path spellings that resolve to the same filesystem target contribute to the same runtime
-  processing outcome.
+- Filesystem-identity evaluation occurs before runtime processing and may affect processing-target
+  eligibility. Different path spellings that resolve to the same filesystem target contribute to the
+  same runtime processing outcome after filesystem-identity normalization. Filesystem-identity
+  eligibility checks, such as hard-link detection, may contribute diagnostic outcomes without
+  introducing command-specific exit codes.
 
 ______________________________________________________________________
 
@@ -91,7 +93,9 @@ runtime-resolution details, and processing metadata.
 
 For filesystem inputs, machine-readable path fields report selected processing paths. Exit codes are
 derived from runtime outcomes and do not depend on whether a file was reached through a symlink or
-another equivalent path spelling.
+another equivalent path spelling after filesystem-identity normalization. Filesystem-identity
+eligibility checks, such as hard-link detection, affect diagnostic and processing outcomes but do
+not introduce separate exit-code values.
 
 This separation keeps automation deterministic while preserving stable machine-readable output
 contracts independently from process exit semantics.
@@ -122,6 +126,8 @@ Notes:
 - Unmatched glob patterns are treated as discovery diagnostics and do not cause failure.
 - Files reached through symlinks contribute to the same runtime outcome as their selected processing
   target and do not introduce additional exit-code states.
+- Hard-linked processing targets are reported through normal processing outcomes and diagnostics;
+  they do not introduce a dedicated exit code.
 
 ______________________________________________________________________
 
@@ -146,6 +152,8 @@ Notes:
   stripped.
 - Files reached through symlinks contribute to the same runtime outcome as their selected processing
   target and do not introduce additional exit-code states.
+- Hard-linked processing targets are reported through normal processing outcomes and diagnostics;
+  they do not introduce a dedicated exit code.
 
 ______________________________________________________________________
 
@@ -168,8 +176,10 @@ Notes:
   probe outcomes.
 - Unmatched glob patterns are reported as filtered semantic outcomes and result in exit code 69.
 - Ambiguous or unresolved file-type filtering may also contribute to semantic resolution outcomes.
-- Filesystem-identity normalization occurs before runtime probing. Exit-code semantics are based on
+- Filesystem-identity evaluation occurs before runtime probing. Exit-code semantics are based on
   probe outcomes for selected processing paths rather than the original input spelling.
+- Hard-linked processing targets contribute to normal probe unsupported outcomes (`69`) and do not
+  introduce a dedicated exit code.
 
 ______________________________________________________________________
 
@@ -279,8 +289,9 @@ semantic outcomes occur during a single invocation.
 This ensures that hard runtime or environment failures take precedence over informational, semantic,
 or availability-oriented outcomes.
 
-Filesystem-identity normalization and processing-path selection occur before exit-code evaluation
-and do not introduce additional priority levels.
+Filesystem-identity evaluation and processing-path selection occur before exit-code evaluation and
+do not introduce additional priority levels. Hard-link policy therefore participates through normal
+processing outcomes rather than through a dedicated exit-code class.
 
 Example:
 

--- a/docs/usage/filtering.md
+++ b/docs/usage/filtering.md
@@ -44,8 +44,12 @@ TopMark applies filtering in a deterministic order:
 
 Exclude rules take precedence over include rules.
 
-Filesystem-identity normalization and processing-path selection occur during path discovery before
+Filesystem-identity evaluation and processing-path selection occur during path discovery before
 runtime applicability evaluation and processor resolution.
+
+Filesystem-identity evaluation includes filesystem-identity normalization for equivalent path
+spellings (such as symlinks), processing-path selection, and processing-target eligibility checks
+(such as hard-link detection).
 
 For canonical file-type identifier semantics, see [File-type filtering](#file-type-filtering). For
 layered configuration behavior, see [Configuration](configuration.md).
@@ -63,8 +67,8 @@ TopMark intentionally separates:
 
 1. path discovery
 1. path filtering
-1. filesystem-identity normalization
-1. deduplication and processing-path selection
+1. filesystem-identity evaluation
+1. processing-path selection
 1. file-type filtering
 1. runtime applicability evaluation
 1. runtime probing and processor resolution
@@ -75,9 +79,15 @@ This layered filtering model keeps runtime behavior deterministic while preservi
 diagnostics and machine-readable filtering semantics.
 
 When multiple path spellings resolve to the same filesystem target (for example a symlink and its
-target), TopMark selects a canonical processing path before runtime filtering continues. Downstream
-filtering, probing, header generation, and machine-readable output operate on that processing path
-rather than the original spelling used to reach the file.
+target), filesystem-identity normalization resolves symlink spellings to the target path and selects
+a canonical processing path before runtime filtering continues. Downstream filtering, probing,
+header generation, and machine-readable output operate on that processing path rather than the
+original spelling used to reach the file.
+
+Hard-link policy is evaluated as a processing-target eligibility check. If multiple selected paths
+refer to the same filesystem object through hard links, TopMark reports each affected path
+independently and blocks processing for the entire hard-link group without selecting a preferred
+source, target, winner, or loser path.
 
 ______________________________________________________________________
 
@@ -115,7 +125,10 @@ Stable path-filtering semantics:
 - Absolute patterns are not supported.
 - Exclude rules take precedence over include rules.
 - Path-based filtering occurs before file-type filtering.
-- Existing filesystem inputs are normalized to canonical processing paths before runtime processing.
+- Existing filesystem inputs undergo filesystem-identity evaluation before runtime processing.
+- Hard-linked selected paths are handled as processing-target eligibility failures. Each affected
+  path is reported independently and blocked from processing; TopMark does not select a preferred
+  source, target, winner, or loser path.
 - Symlink spellings are not preserved for runtime identity, generated filesystem-related header
   metadata, or machine-readable path fields.
 
@@ -148,7 +161,7 @@ This includes:
 - file-type filtering
 - canonical file-type identifier normalization and resolution
 - ambiguity handling
-- filesystem-identity normalization and processing-path selection
+- filesystem-identity evaluation and processing-path selection
 
 However, unlike processing commands ([`check`](commands/check.md), [`strip`](commands/strip.md)),
 [`probe`](commands/probe.md) also reports \*\*explicit inputs that were filtered out before runtime
@@ -201,6 +214,10 @@ excluded implicitly during recursive discovery are not enumerated.
 For probe records that reach runtime probing, reported filesystem paths describe the selected
 processing path. They do not guarantee preservation of the original CLI argument, glob match, or
 symlink spelling.
+
+If multiple selected paths are hard links to the same filesystem object, probe reports each affected
+path independently as an unsupported processing target with reason `hard_link_duplicate`. TopMark
+does not select a preferred source, target, winner, or loser path from the hard-link group.
 
 ______________________________________________________________________
 
@@ -358,6 +375,9 @@ Filtering decisions can influence exit codes indirectly:
   `SUCCESS (0)`), or `UNSUPPORTED_FILE_TYPE (69)` in [`probe`](commands/probe.md)
 
 Missing explicit inputs take precedence over semantic runtime probe outcomes.
+
+Hard-link processing policy participates through normal processing outcomes and diagnostics and does
+not introduce dedicated filtering exit codes.
 
 When multiple conditions occur, TopMark applies a deterministic exit-code priority model (see
 [Exit Codes documentation](exit-codes.md)), where hard input and filesystem errors take precedence.

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -133,9 +133,14 @@ topmark check .
 
 > [!NOTE]
 >
-> TopMark normalizes filesystem identity before processing files. If a file is reachable through
-> multiple path spellings (for example a symlink and its target), TopMark selects a canonical
-> processing path and processes the target once.
+> TopMark evaluates filesystem identity before processing files. Filesystem-identity normalization
+> resolves equivalent path spellings, such as symlink spellings, to the selected processing path
+> used for runtime processing and machine-readable output.
+>
+> Hard-link policy is evaluated as a processing-target eligibility check. If multiple selected paths
+> refer to the same filesystem object through hard links, TopMark reports each affected path
+> independently and blocks processing for the entire hard-link group without selecting a preferred
+> source, target, winner, or loser path.
 
 ______________________________________________________________________
 
@@ -163,6 +168,9 @@ topmark check --apply .
 > Generated filesystem-related header fields such as `file_relpath` and `file_abspath` describe the
 > selected processing target. If a file is reached through a symlink, header metadata reflects the
 > resolved target TopMark reads and writes.
+>
+> Files blocked by processing-target eligibility checks, such as hard-linked processing targets, are
+> not modified and therefore do not receive updated header metadata.
 
 ______________________________________________________________________
 

--- a/docs/usage/header-placement.md
+++ b/docs/usage/header-placement.md
@@ -22,10 +22,11 @@ Configuration-loading strictness (for example through `--strict` or `strict`) do
 header-placement semantics. It controls only whether a run proceeds when staged
 configuration-loading validation warnings are present.
 
-Header placement rules apply only after a file has passed runtime applicability evaluation and
-runtime processor resolution. File-type-specific runtime policy overrides configured through
-`policy_by_type` may influence runtime mutation eligibility and insertion behavior, but the selected
-header processor controls the concrete comment syntax and placement behavior.
+Header placement rules apply only after a file has passed filesystem-identity evaluation, runtime
+applicability evaluation, and runtime processor resolution. File-type-specific runtime policy
+overrides configured through `policy_by_type` may influence runtime mutation eligibility and
+insertion behavior, but the selected header processor controls the concrete comment syntax and
+placement behavior.
 
 {% include-markdown "\_snippets/terminology.md" %}
 
@@ -48,6 +49,7 @@ ______________________________________________________________________
 TopMark intentionally separates:
 
 1. runtime file discovery
+1. filesystem-identity evaluation and processing-path selection
 1. runtime applicability evaluation
 1. runtime file-type probing
 1. runtime processor resolution
@@ -60,6 +62,11 @@ policy evaluation, and processor resolution have completed.
 
 The generated header metadata describes the selected processing target rather than the original
 invocation spelling used to reach that target.
+
+Filesystem-identity normalization resolves equivalent path spellings, such as symlink spellings, to
+that selected processing target before header metadata is generated. Processing-target eligibility
+checks, such as hard-link policy, run before placement as well; hard-linked selected processing
+paths are blocked and do not receive inserted, updated, or stripped headers.
 
 This layered runtime model keeps placement behavior deterministic while preserving stable
 processor-specific comment syntax and insertion semantics.
@@ -236,6 +243,8 @@ ______________________________________________________________________
 
 - Path serialization: generated header path fields (`file_relpath`, `file_abspath`, `relpath`, and
   `abspath`) describe the selected processing target and use POSIX `/` separators on all platforms.
+- Filesystem-identity safety: files blocked by processing-target eligibility checks, such as
+  hard-linked processing targets, do not reach header rendering or placement.
 - Newline preservation: the inserted header uses the same newline style as the file (LF/CRLF/CR).
 - BOM preservation: if a UTF-8 BOM is present, it is preserved.
 - Idempotency: re-running TopMark on a file with a compliant header produces no runtime changes.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -24,7 +24,8 @@ Start here if you want to:
 - run TopMark from the CLI;
 - upgrade an existing repository to TopMark 1.0;
 - configure header fields, policies, filtering, and file discovery;
-- understand filesystem identity, processing paths, and symlink behavior;
+- understand filesystem-identity evaluation, processing paths, symlink normalization, and hard-link
+  policy;
 - integrate TopMark with pre-commit or CI;
 - understand exit codes, reports, and machine-readable output.
 

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -228,8 +228,8 @@ contract.
 Machine-readable filesystem path fields expose TopMark's selected processing paths.
 
 A processing path is selected after discovery, filtering, filesystem-identity normalization, and
-deduplication. It is not necessarily the original CLI argument, configuration entry, glob match, or
-symlink spelling supplied by the user.
+processing-path selection. It is not necessarily the original CLI argument, configuration entry,
+glob match, or symlink spelling supplied by the user.
 
 TopMark currently identifies existing processing inputs by resolved processing target path. For
 example, if both of these paths refer to the same target:
@@ -248,6 +248,11 @@ real/source.py
 The emitted path is still serialized with POSIX `/` separators on all platforms, as documented in
 the path-representation contract above.
 
+Hard-link policy is intentionally separate from this path serialization contract. If two or more
+selected processing paths are hard links to the same filesystem object, TopMark keeps one
+machine-output result per selected path, but reports each affected path as an unsupported,
+policy-blocked processing target instead of selecting a source, target, winner, or loser path.
+
 ______________________________________________________________________
 
 ## Resolution diagnostics ([`probe`](../usage/commands/probe.md))
@@ -259,9 +264,9 @@ not compute header changes, diffs, strip plans, or write plans.
 Probe output reports canonical file type identities after identifier normalization and file-type
 filtering.
 
-Probe output also reports processing paths after discovery and filesystem-identity normalization.
-When a symlinked input reaches probing, the emitted path describes the resolved processing target
-rather than preserving the symlink spelling.
+Probe output also reports processing paths after discovery, filesystem-identity evaluation, and
+processing-path selection. When a symlinked input reaches probing, the emitted path describes the
+resolved processing target rather than preserving the symlink spelling.
 
 Probe machine-readable output is unaffected by TEXT verbosity or quiet mode. The JSON and NDJSON
 formats expose the same resolution evidence used by the human-facing probe renderers:
@@ -425,9 +430,9 @@ Filtered probe payloads may use one of these reasons:
 Fields:
 
 - `path`: probed filesystem processing path, serialized with POSIX `/` separators. For normal probe
-  payloads, this is the selected processing path after filesystem-identity normalization. For
-  filtered and missing explicit inputs, this remains the explicit path supplied to the command
-  because no normal processing path was selected.
+  payloads, this is the selected processing path after filesystem-identity evaluation. For filtered
+  and missing explicit inputs, this remains the explicit path supplied to the command because no
+  normal processing path was selected.
 - `status`: probe status, currently one of:
   - `resolved` - a file type and processor were selected.
   - `unsupported` - no file type candidate matched.
@@ -444,6 +449,7 @@ Fields:
   - `excluded_by_file_type_filter`
   - `excluded_by_discovery_filter`
   - `no_resolution_probe_result`
+  - `hard_link_duplicate`
 - `selected_file_type`: selected canonical file type identity and score, or `null` when unresolved,
   unbound, filtered, or missing.
 - `selected_processor`: selected processor identity, or `null` when unresolved, unbound, filtered,
@@ -632,6 +638,13 @@ Per-file result payloads report the selected processing path. If a file is reach
 symlink, the emitted `path` describes the resolved processing target rather than the symlink
 spelling. This is the same path identity used by runtime pipeline processing and generated
 filesystem-related header metadata.
+
+If two or more selected processing paths are hard links to the same filesystem object, processing
+machine output still contains one result per selected path. Each affected result reports
+`status.fs.label = "hard-linked processing target"` and is classified as a policy-blocked skip.
+TopMark does not choose a source, target, winner, or loser path for the hard-link group. Unrelated
+selected files continue to produce normal results. Probe machine output reports affected paths as
+`status = "unsupported"` with `reason = "hard_link_duplicate"`.
 
 At a high level, per-file results include:
 

--- a/docs/usage/policies.md
+++ b/docs/usage/policies.md
@@ -45,8 +45,10 @@ Policy semantics behave consistently across:
 - API overlays
 - effective runtime policy evaluation and runtime resolution
 
-Runtime policy evaluation operates on selected processing paths after filesystem-identity
-normalization and processing-path selection have completed.
+Runtime policy evaluation operates on selected processing paths after filesystem-identity evaluation
+and processing-path selection have completed. Filesystem-identity normalization resolves equivalent
+path spellings, while processing-target eligibility checks such as hard-link policy are evaluated
+separately from policy resolution.
 
 Policy values shown here are part of the public configuration surface.
 
@@ -86,6 +88,10 @@ For file-backed configuration sources, policy layering uses configuration-source
 the resolved configuration-file target. If a policy-bearing configuration file is loaded through a
 symlink, precedence, applicability, and layered provenance are evaluated using the resolved
 configuration target rather than the symlink spelling.
+
+Configuration-source identity is distinct from processing-target identity. The hard-link processing
+policy used by filesystem-processing commands such as `check`, `strip`, and `probe` does not affect
+policy layering, configuration precedence, applicability evaluation, or layered policy provenance.
 
 These runtime policy layers are constructed after staged TOML-layer validation. Source-local TOML
 sections (e.g. `[config]`) do not participate in runtime policy layering.
@@ -263,7 +269,10 @@ identities.
 > [!NOTE] **File-type identity and filesystem identity**
 >
 > File-type identity and filesystem identity are separate concepts. File-type policy resolution
-> operates on the selected processing target after filesystem identity normalization has completed.
+> operates on the selected processing target after filesystem-identity evaluation has completed.
+> Filesystem-identity normalization resolves equivalent path spellings before policy resolution,
+> while processing-target eligibility checks such as hard-link policy are evaluated separately from
+> policy resolution.
 
 Example:
 

--- a/docs/usage/pre-commit.md
+++ b/docs/usage/pre-commit.md
@@ -28,9 +28,13 @@ setup, recommended patterns, and troubleshooting.
 Hook execution uses the same runtime-resolution, filtering, policy-evaluation, and runtime
 configuration semantics as normal CLI execution.
 
-Hook execution also uses the same filesystem-identity normalization and processing-path selection
+Hook execution also uses the same filesystem-identity evaluation and processing-path selection
 semantics as normal CLI execution. If multiple path spellings resolve to the same filesystem target
 (for example a symlink and its target), TopMark processes the selected processing target once.
+
+Hard-link policy is evaluated separately. If multiple selected paths refer to the same filesystem
+object through hard links, TopMark reports each affected path independently and blocks processing
+for the entire hard-link group.
 
 ______________________________________________________________________
 
@@ -119,9 +123,12 @@ pass policy options such as `--header-mutation-mode`, `--allow-header-in-empty-f
 These options follow the same runtime policy-resolution and file type identity semantics as normal
 CLI execution.
 
-Filesystem-processing hooks also follow the same processing-path identity semantics as normal CLI
+Filesystem-processing hooks also follow the same filesystem-identity semantics as normal CLI
 execution. Runtime processing operates on selected processing paths rather than preserving the
 original filename spelling supplied by pre-commit.
+
+Hard-link processing policy is applied before runtime processing. Affected paths are reported
+independently and are not reduced to a preferred source, target, winner, or loser path.
 
 Invoke the manual hook locally:
 
@@ -145,11 +152,14 @@ multiple times per invocation (for different batches). This is expected.
 
 TopMark applies the same layered runtime filtering pipeline during hook execution:
 
-1. filesystem-identity normalization and processing-path selection
+1. filesystem-identity evaluation and processing-path selection
 1. path filtering
 1. file-type filtering
 1. runtime-resolution and probe evaluation
 1. runtime policy evaluation
+
+Filesystem-identity evaluation includes processing-path selection for equivalent path spellings
+(such as symlinks) and processing-target eligibility checks (such as hard-link detection).
 
 {% include-markdown "\_snippets/output-contract.md" %}
 
@@ -157,6 +167,10 @@ For filesystem-backed hook execution, machine-readable path fields and generated
 header metadata describe the selected processing target. If a file is reached through a symlink,
 output and generated metadata reflect the resolved target TopMark reads and writes rather than the
 symlink spelling.
+
+If selected paths are hard links to the same filesystem object, hook execution still produces one
+result per selected path. Each affected path is reported independently as a policy-blocked
+processing target.
 
 **Run once per repository** by setting `pass_filenames: false` in the hook manifest and letting
 TopMark perform its own file discovery from config:
@@ -301,8 +315,10 @@ Notes:
 - Use `--quiet` in CI to suppress human-readable TEXT output and rely solely on exit status.
 - Use `topmark-probe` when a hook appears to skip, include, or classify files with unexpected
   semantic runtime outcomes.
-- Filesystem-identity normalization and processing-path selection do not affect exit-code semantics.
-  Equivalent path spellings contribute to the same runtime processing outcome.
+- Filesystem-identity evaluation occurs before runtime processing and may affect processing-target
+  eligibility. Equivalent path spellings contribute to the same runtime processing outcome.
+  Hard-link policy participates through normal processing outcomes and diagnostics rather than
+  through dedicated pre-commit hook exit codes.
 - For full details and edge cases (mixed-result runs, precedence), see:
   - [`Exit codes`](./exit-codes.md)
   - [`check` command](./commands/check.md)
@@ -346,6 +362,19 @@ TopMark reports selected processing paths during runtime processing.
 If a hook receives a symlink path from pre-commit, machine-readable output, runtime probing, and
 generated filesystem-related header metadata may report the resolved processing target rather than
 the original symlink spelling.
+
+See:
+
+- [Machine-readable output](machine-output.md)
+- [Filesystem identity and processing paths](../dev/resolution.md#filesystem-identity-and-processing-paths)
+
+### Hard-linked files are reported as unsupported
+
+TopMark blocks processing when multiple selected paths refer to the same filesystem object through
+hard links.
+
+Each affected path is reported independently. TopMark does not select a preferred source, target,
+winner, or loser path from the hard-link group.
 
 See:
 

--- a/docs/usage/shared-options.md
+++ b/docs/usage/shared-options.md
@@ -60,7 +60,10 @@ TopMark intentionally separates:
 - process exit-code semantics.
 
 For filesystem-processing commands, machine-readable path fields report selected processing paths
-rather than preserving the original CLI path spelling.
+rather than preserving the original CLI path spelling. Filesystem-identity normalization resolves
+equivalent path spellings, such as symlink spellings, before path serialization. Processing-target
+eligibility checks such as hard-link policy are evaluated separately from path serialization and do
+not alter the emitted path representation.
 
 > [!NOTE] Verbosity, quiet mode and color rendering affect only human-facing TEXT rendering.
 
@@ -174,9 +177,14 @@ Runtime file-processing commands ([`check`](commands/check.md), [`strip`](comman
 These modes are mutually exclusive: do not mix `-` (content mode) with `--files-from -`,
 `--include-from -`, or `--exclude-from -` (list mode).
 
-For filesystem-backed inputs, TopMark normalizes filesystem identity and selects processing paths
-before runtime processing begins. Multiple path spellings that resolve to the same filesystem target
-(for example a symlink and its target) are treated as a single processing target.
+For filesystem-backed inputs, TopMark evaluates filesystem identity and selects processing paths
+before runtime processing begins. Filesystem-identity normalization resolves equivalent path
+spellings, such as symlink spellings, to the selected processing path used for runtime processing.
+
+Hard-link policy is evaluated as a processing-target eligibility check. If multiple selected paths
+refer to the same filesystem object through hard links, each affected path is reported independently
+and processing is blocked for the entire hard-link group without selecting a preferred source,
+target, winner, or loser path.
 
 > [!NOTE] **STDIN input**
 >
@@ -189,8 +197,8 @@ In content STDIN mode, `--stdin-filename` is required so TopMark can resolve fil
 binding, and path-sensitive policy exactly as it would for a real file path.
 
 Because content mode does not reference an existing filesystem object, filesystem-identity
-normalization and processing-path selection do not apply. The supplied `--stdin-filename` acts only
-as a virtual path for runtime resolution and policy evaluation.
+evaluation and processing-path selection do not apply. The supplied `--stdin-filename` acts only as
+a virtual path for runtime resolution and policy evaluation.
 
 For mutation commands (`check` and `strip`), `--apply` in content mode writes transformed content to
 STDOUT and routes diagnostics to STDERR. This ensures consistent file-type resolution and runtime
@@ -214,6 +222,11 @@ For file-backed configuration sources, configuration discovery uses configuratio
 based on the resolved configuration-file target. Layered provenance, applicability evaluation, and
 configuration precedence are therefore based on resolved configuration targets rather than symlink
 spellings.
+
+Configuration-source identity is distinct from processing-target identity. Runtime
+filesystem-processing commands evaluate selected processing paths separately, including
+filesystem-identity normalization and eligibility checks such as hard-link policy. Those runtime
+checks do not affect configuration discovery, layered provenance, or configuration precedence.
 
 ______________________________________________________________________
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,19 +18,21 @@ dynamic = ["version"]
 description = "Inspect, insert, update, remove, and validate project file headers across codebases."
 readme = { file = "README.md", content-type = "text/markdown" }
 keywords = [
-  "headers",
-  "file-headers",
-  "license-header",
-  "copyright-header",
-  "source-code",
+  "automation",
+  "ci",
   "cli",
   "code-quality",
-  "project-maintenance",
   "compliance",
-  "automation",
-  "pre-commit",
-  "ci",
+  "copyright-header",
   "developer-tools",
+  "file-headers",
+  "headers",
+  "license-compliance",
+  "license-header",
+  "pre-commit",
+  "project-maintenance",
+  "repository-maintenance",
+  "source-code",
 ]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/topmark/pipeline/engine.py
+++ b/src/topmark/pipeline/engine.py
@@ -50,14 +50,22 @@ from topmark.config.policy import make_policy_registry
 from topmark.core.exit_codes import ExitCode
 from topmark.core.logging import get_logger
 from topmark.pipeline import runner
+from topmark.pipeline.context.model import HaltState
 from topmark.pipeline.context.model import ProcessingContext
+from topmark.pipeline.hints import Axis
+from topmark.pipeline.hints import Cluster
+from topmark.pipeline.hints import KnownCode
 from topmark.pipeline.status import ContentStatus
 from topmark.pipeline.status import FsStatus
 from topmark.pipeline.status import WriteStatus
+from topmark.resolution.probe import ResolutionProbeReason
+from topmark.resolution.probe import ResolutionProbeResult
+from topmark.resolution.probe import ResolutionProbeStatus
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
+    from os import stat_result
     from pathlib import Path
 
     from topmark.config.model import FrozenConfig
@@ -66,6 +74,87 @@ if TYPE_CHECKING:
     from topmark.runtime.model import RunOptions
 
 logger: TopmarkLogger = get_logger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class _FilesystemIdentity:
+    """Stable filesystem-object identity used for hard-link detection."""
+
+    device: int
+    inode: int
+
+
+def _filesystem_identity(path: Path) -> _FilesystemIdentity | None:
+    """Return `(st_dev, st_ino)` identity for an existing path when available."""
+    try:
+        stat_info: stat_result = path.stat()
+    except OSError:
+        return None
+
+    if stat_info.st_nlink < 2:
+        return None
+
+    return _FilesystemIdentity(device=stat_info.st_dev, inode=stat_info.st_ino)
+
+
+def _hard_link_duplicate_paths(file_list: Sequence[Path]) -> set[Path]:
+    """Return selected paths that share filesystem storage with another selected path."""
+    paths_by_identity: dict[_FilesystemIdentity, list[Path]] = {}
+
+    for path in file_list:
+        identity: _FilesystemIdentity | None = _filesystem_identity(path)
+        if identity is None:
+            continue
+        paths_by_identity.setdefault(identity, []).append(path)
+
+    duplicates: set[Path] = set()
+    for paths in paths_by_identity.values():
+        unique_paths: set[Path] = set(paths)
+        if len(unique_paths) > 1:
+            duplicates.update(unique_paths)
+
+    return duplicates
+
+
+def _build_hard_link_duplicate_context(
+    *,
+    path: Path,
+    run_options: RunOptions,
+    config: FrozenConfig,
+    policy_registry: PolicyRegistry | None,
+) -> ProcessingContext:
+    """Build a terminal context for a hard-linked processing target."""
+    ctx: ProcessingContext = ProcessingContext.bootstrap(
+        path=path,
+        config=config,
+        run_options=run_options,
+        policy_registry_override=policy_registry,
+    )
+    ctx.status.fs = FsStatus.HARD_LINK_DUPLICATE
+    ctx.halt_state = HaltState(
+        reason_code=KnownCode.FS_HARD_LINK_DUPLICATE.value,
+        step_name="HardLinkIdentityGuard",
+    )
+    ctx.resolution_probe = ResolutionProbeResult(
+        path=path,
+        status=ResolutionProbeStatus.UNSUPPORTED,
+        reason=ResolutionProbeReason.HARD_LINK_DUPLICATE,
+        candidates=(),
+        selected_file_type=None,
+        selected_processor=None,
+    )
+    ctx.hint(
+        axis=Axis.FS,
+        code=KnownCode.FS_HARD_LINK_DUPLICATE,
+        message=(
+            "Path shares storage with another selected processing path; "
+            "hard-linked targets are blocked"
+        ),
+        cluster=Cluster.BLOCKED_POLICY,
+        terminal=True,
+        reason=FsStatus.HARD_LINK_DUPLICATE.value,
+    )
+    return ctx
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -190,6 +279,7 @@ def run_steps_for_files(
     default_policy_registry: PolicyRegistry | None = (
         None if path_configs is not None else make_policy_registry(config)
     )
+    hard_link_duplicate_paths: set[Path] = _hard_link_duplicate_paths(file_list)
 
     # Process each path independently; collect contexts and degrade gracefully
     # on non-fatal errors (recording the first encountered exit code).
@@ -203,6 +293,17 @@ def run_steps_for_files(
                 if path_configs is not None
                 else default_policy_registry
             )
+            if path in hard_link_duplicate_paths:
+                results.append(
+                    _build_hard_link_duplicate_context(
+                        path=path,
+                        config=effective_config,
+                        run_options=run_options,
+                        policy_registry=policy_registry,
+                    )
+                )
+                continue
+
             # When no precomputed registry is supplied, bootstrap() derives one from config.
             ctx_obj: ProcessingContext = ProcessingContext.bootstrap(
                 path=path,

--- a/src/topmark/pipeline/hints.py
+++ b/src/topmark/pipeline/hints.py
@@ -184,6 +184,7 @@ class KnownCode(EnumIntrospectionMixin, str, Enum):
     # FS
     FS_BOM_BEFORE_SHEBANG = "fs:bom_before_shebang"
     FS_EMPTY = "fs:empty_file"
+    FS_HARD_LINK_DUPLICATE = "fs:hard_link_duplicate"
     FS_MIXED_NEWLINES = "fs:mixed_newlines"
     FS_NOT_FOUND = "fs:not_found"
     FS_UNREADABLE = "fs:unreadable"

--- a/src/topmark/pipeline/outcomes.py
+++ b/src/topmark/pipeline/outcomes.py
@@ -227,6 +227,12 @@ def map_bucket(ctx: ProcessingContext, *, apply: bool) -> ResultBucket:
             outcome=Outcome.ERROR,
             reason=ctx.status.fs.value,
         )
+    if ctx.status.fs == FsStatus.HARD_LINK_DUPLICATE:
+        return ret(
+            debug_tag="skip:fs-hard-link-duplicate",
+            outcome=Outcome.SKIPPED,
+            reason=ctx.status.fs.value,
+        )
     if ctx.status.resolve != ResolveStatus.RESOLVED:
         return ret(
             debug_tag="skip:resolve",

--- a/src/topmark/pipeline/status.py
+++ b/src/topmark/pipeline/status.py
@@ -76,6 +76,10 @@ class FsStatus(BaseStatus):
         "no write permission",
         StyleRole.ERROR,
     )
+    HARD_LINK_DUPLICATE = (
+        "hard-linked processing target",
+        StyleRole.BLOCKED_POLICY,
+    )
     BINARY = (
         "binary file",
         StyleRole.ERROR,

--- a/src/topmark/resolution/probe.py
+++ b/src/topmark/resolution/probe.py
@@ -55,6 +55,7 @@ class ResolutionProbeReason(str, Enum):
         SELECTED_BY_TIE_BREAK: Multiple candidates shared the top score and were
             ordered deterministically by tie-break rules.
         NO_CANDIDATES: No file type candidates matched the path.
+        HARD_LINK_DUPLICATE: The path shares storage with another selected processing path.
         SELECTED_FILE_TYPE_HAS_NO_BOUND_PROCESSOR: The selected file type has no
             associated processor binding.
     """
@@ -65,6 +66,7 @@ class ResolutionProbeReason(str, Enum):
     SELECTED_HIGHEST_SCORE = "selected_highest_score"
     SELECTED_BY_TIE_BREAK = "selected_by_tie_break"
     NO_CANDIDATES = "no_candidates"
+    HARD_LINK_DUPLICATE = "hard_link_duplicate"
     SELECTED_FILE_TYPE_HAS_NO_BOUND_PROCESSOR = "selected_file_type_has_no_bound_processor"
 
 

--- a/tests/cli/machine/test_hard_link_identity_machine.py
+++ b/tests/cli/machine/test_hard_link_identity_machine.py
@@ -1,0 +1,185 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_hard_link_identity_machine.py
+#   file_relpath : tests/cli/machine/test_hard_link_identity_machine.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Machine-output regressions for hard-linked processing targets."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.cli.conftest import assert_SUCCESS
+from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
+from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
+from tests.cli.conftest import run_cli_in
+from tests.helpers.json import parse_json_object
+from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
+from topmark.core.formats import OutputFormat
+from topmark.core.typing_guards import as_object_dict
+from topmark.core.typing_guards import is_any_list
+from topmark.core.typing_guards import is_mapping
+from topmark.pipeline.hints import KnownCode
+from topmark.pipeline.status import FsStatus
+from topmark.resolution.probe import ResolutionProbeReason
+from topmark.resolution.probe import ResolutionProbeStatus
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+
+def _link_or_skip(source: Path, target: Path) -> None:
+    """Create a hard link or skip when the current filesystem forbids it."""
+    try:
+        os.link(source, target)
+    except OSError as exc:
+        pytest.skip(f"hard links are not supported in this test environment: {exc}")
+
+
+def _results(payload: dict[str, object]) -> list[dict[str, object]]:
+    """Return typed processing result payloads."""
+    results_obj: object = payload["results"]
+    assert is_any_list(results_obj)
+    return [as_object_dict(item) for item in results_obj if is_mapping(item)]
+
+
+def _status_fs(result: dict[str, object]) -> str:
+    """Return the filesystem status value from a processing result payload."""
+    status_obj: object = result["status"]
+    assert is_mapping(status_obj)
+    status: dict[str, object] = as_object_dict(status_obj)
+    fs_obj: object = status["fs"]
+    assert is_mapping(fs_obj)
+    fs: dict[str, object] = as_object_dict(fs_obj)
+    label: object = fs["label"]
+    assert isinstance(label, str)
+    return label
+
+
+@pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP])
+def test_processing_json_blocks_hard_link_pair(tmp_path: Path, command: str) -> None:
+    """`check` and `strip` emit one blocked result per hard-linked selected path."""
+    first: Path = tmp_path / "a.py"
+    second: Path = tmp_path / "b.py"
+    first.write_text("print('hello')\n", encoding="utf-8")
+    _link_or_skip(first, second)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            command,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+            "a.py",
+            "b.py",
+        ],
+    )
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    results: list[dict[str, object]] = _results(payload)
+
+    assert len(results) == 2
+    assert [_status_fs(item) for item in results] == [
+        FsStatus.HARD_LINK_DUPLICATE.value,
+        FsStatus.HARD_LINK_DUPLICATE.value,
+    ]
+
+
+def test_processing_json_continues_after_hard_link_block(tmp_path: Path) -> None:
+    """A normal selected file still appears as a normal result beside blocked hard links."""
+    first: Path = tmp_path / "a.py"
+    second: Path = tmp_path / "b.py"
+    normal: Path = tmp_path / "normal.py"
+    first.write_text("print('hello')\n", encoding="utf-8")
+    normal.write_text("print('normal')\n", encoding="utf-8")
+    _link_or_skip(first, second)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+            "a.py",
+            "normal.py",
+            "b.py",
+        ],
+    )
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    results: list[dict[str, object]] = _results(payload)
+    statuses_by_path: dict[str, str] = {str(item["path"]): _status_fs(item) for item in results}
+
+    assert statuses_by_path["a.py"] == FsStatus.HARD_LINK_DUPLICATE.value
+    assert statuses_by_path["b.py"] == FsStatus.HARD_LINK_DUPLICATE.value
+    assert statuses_by_path["normal.py"] == FsStatus.OK.value
+
+
+def test_probe_json_reports_hard_links_as_unsupported(tmp_path: Path) -> None:
+    """`probe` reports hard-linked processing targets as unsupported probe results."""
+    first: Path = tmp_path / "a.py"
+    second: Path = tmp_path / "b.py"
+    first.write_text("print('hello')\n", encoding="utf-8")
+    _link_or_skip(first, second)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.PROBE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+            "a.py",
+            "b.py",
+        ],
+    )
+    assert_UNSUPPORTED_FILE_TYPE(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    probes_obj: object = payload["probes"]
+    assert is_any_list(probes_obj)
+    probes: list[dict[str, object]] = [
+        as_object_dict(item) for item in probes_obj if is_mapping(item)
+    ]
+
+    assert len(probes) == 2
+    assert {probe["status"] for probe in probes} == {ResolutionProbeStatus.UNSUPPORTED.value}
+    assert {probe["reason"] for probe in probes} == {
+        ResolutionProbeReason.HARD_LINK_DUPLICATE.value
+    }
+
+
+def test_processing_ndjson_contains_hard_link_hint_code(tmp_path: Path) -> None:
+    """NDJSON detail mode preserves one result per blocked selected path."""
+    first: Path = tmp_path / "a.py"
+    second: Path = tmp_path / "b.py"
+    first.write_text("print('hello')\n", encoding="utf-8")
+    _link_or_skip(first, second)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
+            "a.py",
+            "b.py",
+        ],
+    )
+    assert_SUCCESS(result)
+
+    assert KnownCode.FS_HARD_LINK_DUPLICATE.value not in result.output
+    assert result.output.count(FsStatus.HARD_LINK_DUPLICATE.value) == 2

--- a/tests/pipeline/test_hard_link_identity.py
+++ b/tests/pipeline/test_hard_link_identity.py
@@ -1,0 +1,136 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_hard_link_identity.py
+#   file_relpath : tests/pipeline/test_hard_link_identity.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Regression tests for hard-link filesystem identity handling."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers.config import make_frozen_config
+from topmark.pipeline.engine import run_steps_for_files
+from topmark.pipeline.hints import Cluster
+from topmark.pipeline.hints import KnownCode
+from topmark.pipeline.pipelines import Pipeline
+from topmark.pipeline.status import FsStatus
+from topmark.runtime.model import RunOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.config.model import FrozenConfig
+    from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.engine import PipelineExecution
+    from topmark.pipeline.hints import Hint
+
+
+def _link_or_skip(source: Path, target: Path) -> None:
+    """Create a hard link or skip when the current filesystem forbids it."""
+    try:
+        os.link(source, target)
+    except OSError as exc:
+        pytest.skip(f"hard links are not supported in this test environment: {exc}")
+
+
+def _run_check(paths: list[Path], config: FrozenConfig) -> list[ProcessingContext]:
+    """Run the check pipeline for `paths` and return per-file contexts."""
+    run_options = RunOptions()
+    pipeline_run: PipelineExecution = run_steps_for_files(
+        run_options=run_options,
+        config=config,
+        path_configs=None,
+        pipeline=Pipeline.CHECK.steps,
+        file_list=paths,
+    )
+    assert pipeline_run.exit_code is None
+    return pipeline_run.results
+
+
+def test_hard_link_pair_blocks_all_selected_paths(tmp_path: Path) -> None:
+    """A hard-link pair is blocked symmetrically with no winner path."""
+    first: Path = tmp_path / "a.py"
+    second: Path = tmp_path / "b.py"
+    first.write_text("print('hello')\n", encoding="utf-8")
+    _link_or_skip(first, second)
+
+    results: list[ProcessingContext] = _run_check(
+        [first, second],
+        make_frozen_config(field_values={"project": "HardLinkTest"}),
+    )
+
+    assert [result.path for result in results] == [first, second]
+    assert [result.status.fs for result in results] == [
+        FsStatus.HARD_LINK_DUPLICATE,
+        FsStatus.HARD_LINK_DUPLICATE,
+    ]
+    for result in results:
+        assert result.is_halted
+        hint: Hint = result.diagnostic_hints.items[0]
+        assert hint is not None
+        assert hint.code == KnownCode.FS_HARD_LINK_DUPLICATE.value
+        assert hint.cluster == Cluster.BLOCKED_POLICY.value
+        assert hint.terminal is True
+
+
+def test_hard_link_triplet_blocks_all_selected_paths(tmp_path: Path) -> None:
+    """A hard-link triplet blocks every selected path in the identity group."""
+    first: Path = tmp_path / "a.py"
+    second: Path = tmp_path / "b.py"
+    third: Path = tmp_path / "c.py"
+    first.write_text("print('hello')\n", encoding="utf-8")
+    _link_or_skip(first, second)
+    _link_or_skip(first, third)
+
+    results: list[ProcessingContext] = _run_check(
+        [first, second, third],
+        make_frozen_config(field_values={"project": "HardLinkTest"}),
+    )
+
+    assert len(results) == 3
+    assert {result.status.fs for result in results} == {FsStatus.HARD_LINK_DUPLICATE}
+
+
+def test_hard_link_blocks_do_not_stop_unrelated_files(tmp_path: Path) -> None:
+    """Unrelated selected files continue through the normal pipeline."""
+    first: Path = tmp_path / "a.py"
+    second: Path = tmp_path / "b.py"
+    normal: Path = tmp_path / "normal.py"
+    first.write_text("print('hello')\n", encoding="utf-8")
+    normal.write_text("print('normal')\n", encoding="utf-8")
+    _link_or_skip(first, second)
+
+    results: list[ProcessingContext] = _run_check(
+        [first, normal, second],
+        make_frozen_config(field_values={"project": "HardLinkTest"}),
+    )
+
+    by_path: dict[Path, ProcessingContext] = {result.path: result for result in results}
+    assert by_path[first].status.fs == FsStatus.HARD_LINK_DUPLICATE
+    assert by_path[second].status.fs == FsStatus.HARD_LINK_DUPLICATE
+    assert by_path[normal].status.fs == FsStatus.OK
+    assert by_path[normal].steps
+
+
+def test_missing_path_during_hard_link_scan_is_ignored(tmp_path: Path) -> None:
+    """Hard-link preflight ignores paths that cannot be statted."""
+    missing: Path = tmp_path / "missing.py"
+    normal: Path = tmp_path / "normal.py"
+    normal.write_text("print('normal')\n", encoding="utf-8")
+
+    results: list[ProcessingContext] = _run_check(
+        [missing, normal],
+        make_frozen_config(field_values={"project": "HardLinkTest"}),
+    )
+
+    by_path: dict[Path, ProcessingContext] = {result.path: result for result in results}
+    assert by_path[normal].status.fs == FsStatus.OK


### PR DESCRIPTION
## Summary

- Adds an engine-level hard-link identity guard for selected processing paths sharing `(st_dev, st_ino)`.
- Blocks all affected hard-linked paths symmetrically as unsupported, policy-blocked processing targets.
- Preserves one result per selected path and avoids choosing a source/target/winner/loser path.
- Keeps unrelated selected files processing normally.
- Extends probe output with `hard_link_duplicate`.
- Adds regression coverage for pipeline behavior and machine output across `check`, `strip`, and `probe`.
- Updates documentation and changelog wording for the 1.1.0 filesystem-identity contract.

## Validation

- Full test suite reported green locally.
- Documentation updated across usage, API, developer, CI, configuration, and machine-output pages.

Fixes #103.