### PR TITLE
Clarify compatibility boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,9 @@ ______________________________________________________________________
   configuration discovery, configuration schema, machine-output, command, and API documentation.
 - Documented the TopMark 1.1.0 hard-link compatibility contract for processing and probe machine
   output.
+- Clarified TopMark's identity-domain terminology and compatibility boundaries for processing-target
+  identity, configuration-source identity, registry identity, path serialization, and
+  filesystem-identity evaluation.
 
 ### Internal - Unreleased
 

--- a/docs/_snippets/path-serialization-contract.md
+++ b/docs/_snippets/path-serialization-contract.md
@@ -17,8 +17,8 @@ topmark:header:end
 >
 > Path serialization is a presentation contract and is distinct from filesystem identity.
 >
-> TopMark first determines a canonical processing path for the filesystem target being processed and
-> then serializes that processing path according to the machine-output contract.
+> TopMark first determines the selected processing path for the filesystem target being processed
+> and then serializes that processing path according to the machine-output contract.
 >
 > This contract applies to:
 >
@@ -39,8 +39,8 @@ topmark:header:end
 > may refer to the same filesystem identity and therefore produce the same serialized processing
 > path.
 >
-> TopMark's machine-readable path fields remain path-based and are derived from the canonical
-> processing path selected for each processing target.
+> TopMark's machine-readable path fields remain path-based and are derived from the selected
+> processing path for each processing target.
 >
 > Filesystem identity policy is a separate concern from path serialization. TopMark may apply
 > additional filesystem-identity rules when determining whether a processing target is eligible for

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -137,11 +137,12 @@ identical file-type identity semantics. Local identifiers such as `"python"` are
 unambiguous. Internally, TopMark normalizes identifiers to canonical qualified keys such as
 `"topmark:python"` before filtering, resolution, policy evaluation, and binding lookup.
 
-Public API execution also uses the same filesystem-identity semantics as the CLI. Existing
-filesystem inputs undergo filesystem-identity evaluation before pipeline execution. Multiple path
-spellings that resolve to the same target, such as a symlink and its target, may therefore be
-normalized to a single selected processing path and reported as a single result for the resolved
-processing target.
+Public API execution also uses the same documented filesystem-identity semantics as the CLI.
+Existing filesystem inputs undergo filesystem-identity evaluation before pipeline execution.
+Multiple path spellings that resolve to the same target, such as a symlink and its target, may
+therefore be normalized to a single selected processing path and reported as a single result for the
+resolved processing target. The selected processing path is the public result identity used by API
+file results; original invocation spellings are not guaranteed to be preserved.
 
 Hard-link policy is evaluated separately from path-spelling normalization. If multiple selected
 processing paths refer to the same filesystem object through hard links, the public API preserves
@@ -269,7 +270,8 @@ on the resolved target rather than the symlink spelling.
 Configuration-source identity is distinct from processing-target identity. Hard-link processing
 policy applies to runtime filesystem-processing commands and public API helpers, but it does not
 affect configuration loading, layered provenance, applicability evaluation, or configuration-source
-selection.
+selection. Conversely, configuration-source identity does not determine which runtime processing
+paths enter pipeline execution.
 
 The public API operates only on the flattened immutable
 \[`FrozenConfig`\][topmark.config.model.FrozenConfig]. Staged validation logs are not exposed

--- a/docs/dev/api-stability.md
+++ b/docs/dev/api-stability.md
@@ -73,7 +73,21 @@ This boundary intentionally separates:
 - stable user-facing execution APIs;
 - stable machine-readable output contracts;
 - stable configuration and file type identity semantics;
+- stable documented processing-target behavior;
 - evolving registry internals and overlay helpers.
+
+### Identity-domain compatibility boundaries
+
+TopMark documents several identity domains that intentionally share vocabulary but have separate
+compatibility boundaries:
+
+| Domain                         | Stable compatibility surface                                                                                                                                                                                                   | Flexible implementation detail                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Processing-target identity     | Public/API/CLI results are based on selected processing paths after filesystem-identity evaluation. Header metadata and processing machine output use that selected processing path.                                           | The internal data structures and helper functions used to choose the selected processing path.        |
+| Configuration-source identity  | File-backed TOML provenance, precedence, and applicability are based on resolved configuration-file targets. Synthetic sources use stable labels.                                                                              | The staged config-loading objects and merge-building machinery.                                       |
+| Registry identity              | Canonical qualified identifiers such as `topmark:python`, `qualified_key`, `file_type_key`, and `processor_key` are stable machine-readable/public behavior.                                                                   | Registry composition internals, overlay mutation helpers, and scoring implementation details.         |
+| Path serialization             | Machine-readable filesystem path fields use POSIX `/` separators and report selected processing paths, not invocation spellings.                                                                                               | Human-facing path formatting and presentation labels.                                                 |
+| Filesystem-identity evaluation | Documented outcomes are stable: equivalent symlink spellings collapse to selected processing paths, and selected hard-linked processing targets are reported as unsupported policy-blocked results without selecting a winner. | Low-level platform probes, cache shape, and implementation helpers used to detect equivalent objects. |
 
 ______________________________________________________________________
 
@@ -103,11 +117,13 @@ the public façade defined by `topmark.api.__all__` is considered part of the st
 Overlay state and internal registries are intentionally excluded from the snapshot; only symbols and
 signatures exported via \[`topmark.api`\][topmark.api] are tracked.
 
-Configuration layering and TOML source resolution are internal implementation details and are not
-part of the public API contract.
+Configuration layering objects and TOML source resolution machinery are internal implementation
+details and are not part of the public API symbol contract. The documented configuration-source
+identity behavior exposed through provenance, applicability, and machine-readable output is part of
+the supported behavior contract.
 
-However, canonical file type identity semantics are part of the stable public behavior contract
-shared across:
+Canonical file type identity semantics are part of the stable public behavior contract shared
+across:
 
 - CLI filtering;
 - TOML configuration;

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -98,12 +98,16 @@ Stability guarantees:
 - Machine-readable payloads contain no ANSI color codes.
 - Payload shapes are JSON-safe (no Python-specific objects).
 - Machine-readable filesystem path fields serialize selected processing paths with POSIX `/`
-  separators on all platforms.
+  separators on all platforms. This is a path-serialization contract over already-selected
+  processing paths, not a guarantee that original invocation spellings are preserved.
 - Header metadata path fields describe the selected processing target and are serialized with POSIX
   `/` separators when TopMark renders headers.
 - New fields may be added over time as additive 1.x evolution.
 - Existing fields are not removed or renamed without a breaking-change signal.
 - Resolved file type identities are emitted using canonical qualified keys when available.
+- Configuration provenance payloads use configuration-source identities; runtime processing payloads
+  use selected processing paths. Consumers should not compare those fields as if they belonged to
+  the same identity domain.
 
 Consumers should:
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -121,15 +121,19 @@ python
 
 ### Canonical identity
 
-The normalized representation used internally for comparison, storage, machine-readable output,
-filtering, runtime policy lookup, registry composition, and resolution.
+The normalized representation used for deterministic comparison, storage, machine-readable output,
+filtering, runtime policy lookup, registry composition, and resolution within a specific identity
+domain.
 
-Examples include qualified file-type identities and canonicalized registry matching rules.
+Examples include qualified file-type identities, selected processing paths, normalized
+configuration-source identities, and canonicalized registry matching rules. These identities are not
+interchangeable across domains.
 
 ### Filesystem identity
 
-The canonical filesystem object identity used by TopMark when processing existing files,
-configuration sources, and runtime inputs.
+The canonical filesystem object identity used by TopMark when evaluating runtime processing targets.
+It is distinct from configuration-source identity, registry identity, and machine-readable path
+serialization.
 
 Filesystem identity is evaluated before runtime processing begins.
 
@@ -163,6 +167,24 @@ select a source, target, winner, or loser path automatically.
 > Filesystem identity is distinct from machine-readable path serialization. TopMark first evaluates
 > filesystem identity and then serializes the selected processing path according to the
 > machine-output contract.
+
+### Processing-target identity
+
+The selected runtime path identity used for per-file processing after file discovery, filtering, and
+filesystem-identity evaluation.
+
+Processing-target identity is represented by the selected processing path, not by the original CLI,
+configuration, glob, or symlink spelling. It is the path identity used for runtime pipeline
+contexts, generated header metadata, public API file results, and processing machine output.
+
+### Filesystem-identity evaluation
+
+The runtime pre-processing phase that decides which selected processing paths may enter ordinary
+per-file pipeline execution. It includes filesystem-identity normalization and filesystem-identity
+eligibility checks.
+
+Filesystem-identity evaluation is a runtime processing concern. It does not define configuration
+precedence, TOML provenance, registry lookup, or JSON path serialization.
 
 ### Namespace
 
@@ -280,12 +302,17 @@ Example:
 The fully resolved runtime configuration applicable to a specific path, command invocation, or
 execution context.
 
-### Configuration source identity
+### Configuration-source identity
 
 The normalized identity assigned to a loaded TOML configuration source.
 
-Configuration-source identity is based on the resolved processing target of the loaded configuration
-file. Symlink spellings are not preserved for precedence, scope, or applicability evaluation.
+For file-backed TOML sources, configuration-source identity is based on the resolved
+configuration-file target. Symlink spellings are not preserved for precedence, scope, provenance, or
+applicability evaluation.
+
+Configuration-source identity is independent from runtime processing-target identity. Runtime
+filesystem-identity eligibility checks, including hard-link policy, do not affect configuration
+loading, layered provenance, source precedence, or applicability evaluation.
 
 ______________________________________________________________________
 
@@ -349,8 +376,9 @@ Formats:
 The compatibility guarantees governing machine-readable schemas, record kinds, field naming, payload
 structure, and semantic stability.
 
-The machine-readable contract governs path serialization but does not define filesystem identity
-semantics.
+The machine-readable contract governs schema shape, stable field names, canonical identity fields,
+and path serialization. It reports selected processing paths after filesystem-identity evaluation,
+but it does not freeze the internal algorithms used to evaluate filesystem identity.
 
 ### Payload
 

--- a/src/topmark/utils/path.py
+++ b/src/topmark/utils/path.py
@@ -65,7 +65,7 @@ def canonicalize_existing_path(path: Path) -> Path:
 
 
 def canonical_processing_path(path: Path) -> Path:
-    """Return the canonical path used as TopMark's filesystem identity.
+    """Return the canonical processing path for an existing filesystem target.
 
     Existing filesystem inputs are identified by their resolved processing
     target. Symlink spelling is therefore not preserved for processing identity
@@ -75,7 +75,7 @@ def canonical_processing_path(path: Path) -> Path:
         path: Existing filesystem path selected for processing.
 
     Returns:
-        The canonical processing path for the filesystem target.
+        The canonical processing path for the selected filesystem target.
     """
     return canonicalize_existing_path(path)
 


### PR DESCRIPTION
## Summary

- Clarifies TopMark's identity-domain terminology across the glossary and developer documentation.
- Documents the compatibility boundary between processing-target identity, configuration-source identity, registry identity, path serialization, and filesystem-identity evaluation.
- Tightens public API and machine-format wording so selected processing paths are documented without freezing internal implementation details.
- Updates the Unreleased changelog entry.

## Scope

Fixes #105.

Related prior work: #88, #90, #92, #93, #94, #103.