### PR TITLE
Deduplicate resolved TOML source identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ ______________________________________________________________________
 - Defined configuration-source identity for file-backed TOML sources using the resolved
   configuration-file target for precedence, scope applicability, layered provenance, and
   machine-readable configuration provenance.
+- Deduplicated repeated resolved configuration-source identities during TOML-side resolution,
+  keeping the highest-precedence occurrence for layered configuration and provenance.
 - Added a hard-link filesystem-identity guard: selected paths sharing `(st_dev, st_ino)` are all
   blocked as hard-linked processing targets while unrelated files continue processing normally.
 
@@ -126,6 +128,8 @@ ______________________________________________________________________
 - Fixed ambiguous hard-linked processing-target behavior by blocking every selected path that shares
   `(st_dev, st_ino)` identity with another selected path instead of choosing a source, target,
   winner, or loser path.
+- Fixed duplicate configuration-source provenance when the same resolved TOML source is reached
+  through multiple discovery or explicit `--config` paths.
 
 ### Documentation - Unreleased
 
@@ -158,8 +162,9 @@ ______________________________________________________________________
 - Documented filesystem-identity evaluation, filesystem-identity normalization, processing-path
   selection, symlink handling, hard-link policy, and the boundary between identity evaluation and
   machine-readable path serialization across user, API, and developer documentation.
-- Documented configuration-source identity and symlinked configuration-file behavior across
-  configuration discovery, configuration schema, machine-output, command, and API documentation.
+- Documented configuration-source identity, duplicate resolved-source deduplication, and symlinked
+  configuration-file behavior across configuration discovery, configuration schema, architecture,
+  terminology, machine-output, command, and API documentation.
 - Documented workspace-root discovery and resolved discovery-anchor behavior across configuration,
   command, machine-output, terminology, architecture, and API-stability documentation.
 - Documented the TopMark 1.1.0 hard-link compatibility contract for processing and probe machine
@@ -197,6 +202,8 @@ ______________________________________________________________________
   layered provenance, public machine output, and processing-path serialization.
 - Added regression coverage for workspace-root discovery through symlinked input anchors, symlinked
   current working directories, and repositories reached through symlinked parent paths.
+- Added regression coverage for duplicate resolved configuration-source identities across
+  discovered, explicit, and symlinked configuration paths.
 - Added regression coverage for hard-linked selected processing paths across pipeline execution,
   `check`, `strip`, `probe`, JSON output, NDJSON output, and mixed hard-linked plus unrelated file
   selections.

--- a/docs/_snippets/runtime-configuration-model.md
+++ b/docs/_snippets/runtime-configuration-model.md
@@ -32,6 +32,10 @@ similarly operates on selected processing paths derived from filesystem-identity
 Workspace-root discovery and configuration-discovery anchoring are evaluated independently and may
 traverse resolved filesystem locations when determining configuration search roots.
 
+If multiple discovered or explicit configuration entries resolve to the same configuration-source
+identity, TopMark retains only the highest-precedence occurrence for configuration layering and
+provenance evaluation.
+
 Filesystem-identity evaluation includes:
 
 - filesystem-identity normalization (for example symlink-path normalization and processing-path

--- a/docs/configuration/discovery.md
+++ b/docs/configuration/discovery.md
@@ -100,6 +100,12 @@ Symlink spellings are therefore not preserved as configuration identity. They ma
 shell prompt, but once TopMark has loaded the configuration source, provenance and applicability are
 based on the resolved configuration-file target.
 
+If the same resolved configuration source is reached more than once (for example through automatic
+project-chain discovery and again through `--config`, or through two spellings of the same symlinked
+configuration file), TopMark keeps the highest-precedence occurrence for TOML-side resolution and
+layered provenance. This avoids duplicate layers for one configuration-source identity while
+preserving the normal precedence model.
+
 Configuration-source identity is distinct from processing-target identity. Runtime
 filesystem-processing commands evaluate processing-target identity separately, including
 filesystem-identity normalization for selected processing paths and eligibility checks such as

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -76,6 +76,11 @@ Project-chain discovery starts from the resolved discovery anchor before configu
 identity is evaluated. This keeps workspace-root discovery separate from configuration-source
 identity normalization and from runtime processing-target identity.
 
+If multiple discovered or explicit configuration entries resolve to the same configuration-source
+identity, TopMark keeps only the highest-precedence occurrence in the layered configuration model.
+This prevents one physical configuration file from contributing multiple effective layers through
+different discovery paths, explicit `--config` spelling, or symlink spelling.
+
 {% include-markdown "\_snippets/config-strictness.md" %}
 
 Whole-source TOML schema validation happens before layered config deserialization. The staged

--- a/docs/dev/configuration-schema.md
+++ b/docs/dev/configuration-schema.md
@@ -371,6 +371,11 @@ Configuration-source identity normalization follows the same path-spelling model
 configuration sources are normalized to their resolved configuration-file target before precedence,
 scope, and applicability evaluation occur.
 
+If multiple discovered or explicit configuration entries resolve to the same configuration-source
+identity, TopMark retains only the highest-precedence occurrence for configuration layering and
+provenance evaluation. A physical configuration file therefore contributes at most one effective
+layer, even when reached through multiple discovery paths or symlink spellings.
+
 Workspace-root discovery is evaluated earlier and determines which project configuration files are
 found. Discovery uses the resolved discovery anchor when walking the project chain.
 

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -623,9 +623,11 @@ configuration-file target. Symlink spellings for configuration files are therefo
 machine-readable provenance, precedence, scope, or applicability evaluation.
 
 Project-chain discovery begins from the resolved discovery anchor before configuration-source
-identity is established. Machine-readable provenance payloads describe the discovered configuration
-sources and, when available, their resolved scope roots. They do not currently include a separate
-field for the original discovery-anchor spelling used to start project-chain discovery.
+identity is established. Machine-readable provenance payloads describe the resolved configuration
+sources and, when available, their resolved scope roots. If multiple entries resolve to the same
+configuration-source identity, provenance keeps the highest-precedence occurrence and emits one
+layer for that source identity. Provenance payloads do not currently include a separate field for
+the original discovery-anchor spelling used to start project-chain discovery.
 
 Configuration-source identity is distinct from processing-target identity. Hard-link processing
 policy applies to runtime filesystem-processing payloads and probe diagnostics, but does not affect

--- a/docs/dev/resolution.md
+++ b/docs/dev/resolution.md
@@ -492,7 +492,8 @@ Current behavior:
 
 - file-symlink inputs are resolved to their processing target;
 - symlink spellings are resolved to the target path before runtime processing;
-- configuration-source identity is based on the resolved configuration-file target;
+- configuration-source identity is based on the resolved configuration-file target, with duplicate
+  resolved source identities collapsed to the highest-precedence occurrence;
 - project-chain configuration discovery resolves the selected discovery anchor before walking
   upward, so symlinked CWD and input-anchor spellings use the resolved target chain for
   workspace/root discovery;

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -333,6 +333,10 @@ For file-backed TOML sources, configuration-source identity is based on the reso
 configuration-file target. Symlink spellings are not preserved for precedence, scope, provenance, or
 applicability evaluation.
 
+If multiple discovered or explicit configuration entries resolve to the same configuration-source
+identity, TopMark retains only the highest-precedence occurrence for layered configuration
+construction and provenance reporting.
+
 Configuration-source identity is independent from workspace-root discovery, runtime
 processing-target identity, and filesystem identity.
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -55,7 +55,11 @@ link-to-topmark.toml
 may refer to the same configuration source.
 
 Configuration precedence, scope evaluation, layered configuration export, and machine-readable
-configuration provenance operate on the resolved configuration-file target.
+configuration provenance operate on the resolved configuration-file target. If multiple discovered
+or explicit entries resolve to the same configuration-source identity, TopMark keeps the
+highest-precedence occurrence and reports that source once in layered provenance. This prevents one
+physical configuration file from contributing multiple layers through different path spellings or
+discovery paths.
 
 > [!NOTE]
 >

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -708,7 +708,9 @@ precedence evaluation, and runtime overlays have completed.
 
 `ConfigPayload` may include resolved configuration file paths in fields such as
 `files.config_files`. Those paths describe configuration sources participating in the effective
-configuration; they are not a separate serialized discovery-anchor field.
+configuration; they are not a separate serialized discovery-anchor field. If multiple inputs resolve
+to the same configuration-source identity, TopMark keeps the highest-precedence occurrence and emits
+that source identity once.
 
 Normalization rules:
 

--- a/src/topmark/toml/resolution.py
+++ b/src/topmark/toml/resolution.py
@@ -286,6 +286,37 @@ def _discover_local_config_files(start: Path) -> list[Path]:
 # ---- Resolve TOML-side settings ----
 
 
+def _deduplicate_sources_by_identity(
+    sources: list[ResolvedTopmarkTomlSource],
+) -> list[ResolvedTopmarkTomlSource]:
+    """Return TOML sources deduplicated by resolved configuration-source identity.
+
+    Source lists are ordered from lowest to highest precedence. If the same
+    resolved configuration source is reached more than once, keep the highest
+    precedence occurrence so provenance and layered merging describe each
+    configuration-source identity once.
+
+    Args:
+        sources: Resolved TOML source records in precedence order.
+
+    Returns:
+        Source records in precedence order, with duplicate source identities
+        removed.
+    """
+    seen: set[object] = set()
+    retained_reversed: list[ResolvedTopmarkTomlSource] = []
+
+    for source in reversed(sources):
+        identity: object = source.path
+        if identity in seen:
+            logger.debug("Skipping duplicate TOML source identity: %s", source.path)
+            continue
+        seen.add(identity)
+        retained_reversed.append(source)
+
+    return list(reversed(retained_reversed))
+
+
 def _resolve_writer_options(
     sources: list[ResolvedTopmarkTomlSource],
 ) -> WriterOptions | None:
@@ -381,6 +412,8 @@ def resolve_topmark_toml_sources(
 
     for extra in extra_config_files or ():
         _append_loaded_source(source_entries, Path(extra), kind="explicit")
+
+    source_entries = _deduplicate_sources_by_identity(source_entries)
 
     resolved_writer: WriterOptions | None = _resolve_writer_options(source_entries)
     resolved_strict: bool | None = _resolve_strict(

--- a/tests/config/resolution/test_bridge.py
+++ b/tests/config/resolution/test_bridge.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
     from topmark.config.resolution.bridge import ResolvedConfigDraft
     from topmark.diagnostic.model import MutableDiagnosticLog
+    from topmark.toml.resolution import ResolvedTopmarkTomlSources
 
 
 def test_default_template_resolves_without_errors() -> None:
@@ -72,9 +73,49 @@ def test_explicit_config_symlink_resolves_to_target_path(tmp_path: Path) -> None
     target_config.write_text("[config]\nstrict = true\n", encoding="utf-8")
     link_config: Path = symlink_or_skip(tmp_path / "links" / "topmark.toml", target_config)
 
-    resolved = resolve_topmark_toml_sources(
+    resolved: ResolvedTopmarkTomlSources = resolve_topmark_toml_sources(
         input_paths=[tmp_path],
         extra_config_files=[link_config],
+        no_config=True,
+    )
+
+    assert len(resolved.sources) == 1
+    assert resolved.sources[0].kind == "explicit"
+    assert resolved.sources[0].path == target_config.resolve()
+    assert resolved.sources[0].path != link_config
+    assert resolved.strict is True
+
+
+def test_duplicate_config_source_identity_keeps_highest_precedence_entry(
+    tmp_path: Path,
+) -> None:
+    """Duplicate resolved config-source identities should be merged once."""
+    config_file: Path = tmp_path / "topmark.toml"
+    config_file.write_text("[config]\nstrict = true\n", encoding="utf-8")
+
+    resolved: ResolvedTopmarkTomlSources = resolve_topmark_toml_sources(
+        input_paths=[tmp_path],
+        extra_config_files=[config_file],
+    )
+
+    assert len(resolved.sources) == 1
+    assert resolved.sources[0].kind == "explicit"
+    assert resolved.sources[0].path == config_file.resolve()
+    assert resolved.strict is True
+
+
+def test_duplicate_symlinked_config_source_identity_is_deduplicated(
+    tmp_path: Path,
+) -> None:
+    """A symlinked config and its target should resolve to one source identity."""
+    target_config: Path = tmp_path / "real" / "topmark.toml"
+    target_config.parent.mkdir(parents=True)
+    target_config.write_text("[config]\nstrict = true\n", encoding="utf-8")
+    link_config: Path = symlink_or_skip(tmp_path / "links" / "topmark.toml", target_config)
+
+    resolved: ResolvedTopmarkTomlSources = resolve_topmark_toml_sources(
+        input_paths=[tmp_path],
+        extra_config_files=[target_config, link_config],
         no_config=True,
     )
 


### PR DESCRIPTION
## Summary

- Deduplicates repeated resolved TOML configuration-source identities during TOML-side resolution.
- Keeps the highest-precedence occurrence when discovery, explicit `--config`, or symlink spellings resolve to the same configuration-file target.
- Updates configuration, machine-output, architecture, schema, terminology, and runtime-model documentation to clarify the deduplication behavior.
- Adds regression coverage for duplicate discovered, explicit, and symlinked configuration paths.

## Scope

This closes #89 by resolving the remaining configuration-discovery/path-canonicalization ambiguity after the later identity-policy work in #88, #90, #94, #102, #103, and #105.

This intentionally does not implement #112; discovery-anchor exposure in machine-readable output remains a separate follow-up.