### PR TITLE
feat(ci): add repair mode to GitHub Actions pin audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ ______________________________________________________________________
   keeping the highest-precedence occurrence for layered configuration and provenance.
 - Added a hard-link filesystem-identity guard: selected paths sharing `(st_dev, st_ino)` are all
   blocked as hard-linked processing targets while unrelated files continue processing normally.
+- Extended the GitHub Actions pin audit with an optional `--fix` mode that can repair stale repeated
+  action refs using an already-present preferred pinned ref selected from version-comment metadata.
 
 ### Breaking Changes - Unreleased
 
@@ -172,6 +174,8 @@ ______________________________________________________________________
 - Clarified TopMark's identity-domain terminology and compatibility boundaries for processing-target
   identity, configuration-source identity, registry identity, path serialization, and
   filesystem-identity evaluation.
+- Documented local repair workflows, trust boundaries, and maintenance guidance for the GitHub
+  Actions pin audit, including the new `--fix` mode.
 
 ### Internal - Unreleased
 
@@ -207,6 +211,9 @@ ______________________________________________________________________
 - Added regression coverage for hard-linked selected processing paths across pipeline execution,
   `check`, `strip`, `probe`, JSON output, NDJSON output, and mixed hard-linked plus unrelated file
   selections.
+- Added deterministic repair support for GitHub Actions pin drift in local composite actions and
+  workflow files without introducing network access, dynamic version resolution, or Dependabot
+  replacement behavior.
 
 ### Notes - Unreleased
 

--- a/docs/ci/action-pin-audit.md
+++ b/docs/ci/action-pin-audit.md
@@ -48,7 +48,9 @@ The audit helps prevent:
 - hidden maintenance drift inside local actions.
 
 The workflow intentionally complements Dependabot rather than attempting to replace it, keeping
-manual review and CI validation as the final dependency-governance gate.
+manual review and CI validation as the final dependency-governance gate. The repository tool also
+provides an explicit `--fix` mode for maintainers who want to repair stale repeated refs after a
+Dependabot update introduced drift.
 
 ______________________________________________________________________
 
@@ -88,7 +90,7 @@ The workflow intentionally operates as:
 - offline;
 - low-privilege.
 
-The audit does not:
+The scheduled, manual, and pull-request workflow runs do not:
 
 - publish packages;
 - upload artifacts;
@@ -96,7 +98,9 @@ The audit does not:
 - query GitHub APIs;
 - update dependencies automatically.
 
-The audit performs static repository analysis only.
+The default audit performs static repository analysis only. The local tool's explicit `--fix` mode
+can rewrite stale repeated refs in the working tree, but it still does not query GitHub APIs,
+resolve tags dynamically, or choose versions that are not already present in the scanned files.
 
 ______________________________________________________________________
 
@@ -140,6 +144,13 @@ Run the default repository consistency audit:
 python tools/ci/audit_action_pins.py
 ```
 
+Repair stale repeated refs when the preferred ref can be selected unambiguously from the scanned
+files:
+
+```bash
+python tools/ci/audit_action_pins.py --fix
+```
+
 Print an aggregated summary report:
 
 ```bash
@@ -160,10 +171,10 @@ python tools/ci/audit_action_pins.py --report all
 
 The default command exits with:
 
-| Exit code | Meaning                                  |
-| --------- | ---------------------------------------- |
-| `0`       | All repeated actions use consistent refs |
-| `1`       | Divergent refs were detected             |
+| Exit code | Meaning                                                                   |
+| --------- | ------------------------------------------------------------------------- |
+| `0`       | All repeated actions use consistent refs                                  |
+| `1`       | Divergent refs remain, or `--fix` could not select a unique preferred ref |
 
 Example successful output:
 
@@ -194,7 +205,8 @@ readability and maintenance review.
 When updating pinned GitHub Actions for the stable release workflow set:
 
 1. update workflow files;
-1. update local composite actions;
+1. update local composite actions, or run `python tools/ci/audit_action_pins.py --fix` after the
+   workflow update;
 1. run the audit locally;
 1. ensure the workflow remains green.
 
@@ -221,13 +233,18 @@ uses: ./.github/actions/setup-python-nox
 
 are intentionally ignored because the audit is concerned with external dependency pinning.
 
-The tool intentionally does not:
+The default audit intentionally does not:
 
 - query GitHub APIs;
 - auto-upgrade actions;
 - mutate workflow files;
 - resolve tags dynamically;
 - replace Dependabot.
+
+The explicit `--fix` mode may mutate workflow files and local composite-action metadata, but only by
+rewriting stale repeated refs to the preferred ref already present for the same action. The
+preferred ref must be selectable from a unique highest SemVer-like trailing version comment such as
+`# v8.2.0`.
 
 This keeps the audit deterministic, offline, reproducible, and lightweight enough for routine CI
 usage.

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -61,7 +61,7 @@ and maintenance expectations than repository-source validation or release public
 
 - [Dependabot workflow](./dependabot.md) - documents dependency-update and security-audit behavior.
 - [GitHub Action pin audit](./action-pin-audit.md) - audits GitHub Action pin consistency across
-  workflows and local composite actions.
+  workflows and local composite actions, with an explicit local repair mode for stale repeated refs.
 
 ______________________________________________________________________
 
@@ -77,7 +77,7 @@ Use this family of pages as follows:
 | How are release artifacts produced and published?                | [Release workflow](./release-workflow.md)                           |
 | How do we validate packages after publication?                   | [Published artifact validation](./published-artifact-validation.md) |
 | How are dependency updates handled?                              | [Dependabot](./dependabot.md)                                       |
-| How do we audit GitHub Action pin consistency?                   | [GitHub Action pin audit](./action-pin-audit.md)                    |
+| How do we audit or locally repair GitHub Action pin consistency? | [GitHub Action pin audit](./action-pin-audit.md)                    |
 
 ______________________________________________________________________
 

--- a/tools/ci/audit_action_pins.py
+++ b/tools/ci/audit_action_pins.py
@@ -15,9 +15,10 @@ This repository tool scans workflow files and local composite action metadata fo
 referenced with multiple refs, which can happen when Dependabot updates workflow files
 but does not update nested local composite actions under `.github/actions/`.
 
-The audit is intentionally offline and read-only. It does not query GitHub, resolve
-tags, update files, or replace Dependabot. Its only contract is to detect inconsistent
-refs already present in the repository.
+The audit is intentionally offline. By default it is read-only and reports
+inconsistent refs already present in the repository. With `--fix`, it rewrites stale
+repeated refs to the preferred ref already present in the scanned files. It never
+queries GitHub, resolves tags, upgrades actions, or replaces Dependabot.
 
 Examples:
     Run the audit from the repository root:
@@ -30,6 +31,12 @@ Examples:
 
     ```bash
     python tools/ci/audit_action_pins.py --root /path/to/repo
+    ```
+
+    Repair stale repeated refs when the preferred ref can be selected unambiguously:
+
+    ```bash
+    python tools/ci/audit_action_pins.py --fix
     ```
 
     Print an alphabetical summary of all action refs and counts:
@@ -45,7 +52,8 @@ Examples:
     ```
 
 Raises:
-    SystemExit: Exits with status code 1 when divergent refs are detected.
+    SystemExit: Exits with status code 1 when divergent refs remain or automatic repair
+        cannot select one preferred ref unambiguously.
 """
 
 from __future__ import annotations
@@ -74,11 +82,10 @@ ACTION_METADATA_GLOBS: Final[tuple[str, ...]] = (
 )
 USES_PATTERN: Final[re.Pattern[str]] = re.compile(
     r"""
-    ^\s*
-    uses:
-    \s*
+    ^
+    (?P<prefix>\s*uses:\s*)
     (?P<target>[^\s#]+)
-    (?:\s*\#\s*(?P<comment>.*))?
+    (?P<suffix>\s*(?:\#\s*(?P<comment>.*))?)
     \s*$
     """,
     re.VERBOSE,
@@ -88,6 +95,11 @@ EXTERNAL_ACTION_PATTERN: Final[re.Pattern[str]] = re.compile(
 )
 
 REPORT_MODES: Final[tuple[str, ...]] = ("none", "summary", "files", "all")
+
+VERSION_COMMENT_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^v(?P<parts>\d+(?:\.\d+)*)(?:[-+][A-Za-z0-9_.-]+)?$"
+)
+SHA_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -100,6 +112,9 @@ class ActionUse:
         path: Repository-relative file path containing the reference.
         line_number: One-based source line number.
         comment: Optional trailing comment, commonly used for the human-readable tag.
+        line: Original source line containing the reference.
+        prefix: Text before the action ref, including indentation and `uses:`.
+        suffix: Text after the action ref, including any trailing comment.
     """
 
     action: str
@@ -107,6 +122,9 @@ class ActionUse:
     path: Path
     line_number: int
     comment: str | None
+    line: str
+    prefix: str
+    suffix: str
 
     @property
     def ref_display(self) -> str:
@@ -118,6 +136,46 @@ class ActionUse:
         if self.comment is None:
             return self.ref
         return f"{self.ref} # {self.comment}"
+
+    @property
+    def target(self) -> str:
+        """Return the complete external action target.
+
+        Returns:
+            The `owner/repo@ref` action target.
+        """
+        return f"{self.action}@{self.ref}"
+
+    @property
+    def replacement_line(self) -> str:
+        """Return the original line rewritten with this action target.
+
+        Returns:
+            Source line containing the current action target and original suffix.
+        """
+        return f"{self.prefix}{self.target}{self.suffix}"
+
+    def with_ref_display(self, ref_display: str) -> ActionUse:
+        """Return this action use with a different ref display.
+
+        Args:
+            ref_display: Replacement ref, optionally followed by a trailing `#` comment.
+
+        Returns:
+            Updated action use preserving the original source location and line prefix.
+        """
+        ref, comment = split_ref_display(ref_display)
+        suffix = "" if comment is None else f" # {comment}"
+        return ActionUse(
+            action=self.action,
+            ref=ref,
+            path=self.path,
+            line_number=self.line_number,
+            comment=comment,
+            line=self.line,
+            prefix=self.prefix,
+            suffix=suffix,
+        )
 
     def format_location(self) -> str:
         """Return a compact source location for reports.
@@ -135,10 +193,12 @@ class AuditResult:
     Attributes:
         uses: All discovered external action references.
         divergent_actions: Action references grouped by action name when multiple refs exist.
+        unfixable_actions: Divergent action names that cannot be repaired automatically.
     """
 
     uses: tuple[ActionUse, ...]
     divergent_actions: dict[str, tuple[ActionUse, ...]]
+    unfixable_actions: dict[str, tuple[str, ...]]
 
     @property
     def has_failures(self) -> bool:
@@ -148,6 +208,78 @@ class AuditResult:
             `True` when at least one action is pinned to multiple refs.
         """
         return bool(self.divergent_actions)
+
+    @property
+    def can_fix(self) -> bool:
+        """Return whether all divergent refs can be repaired automatically.
+
+        Returns:
+            `True` when divergent actions exist and none are ambiguous.
+        """
+        return self.has_failures and not self.unfixable_actions
+
+
+def split_ref_display(ref_display: str) -> tuple[str, str | None]:
+    """Split a ref display string into ref and optional comment.
+
+    Args:
+        ref_display: Ref text, optionally containing a trailing `#` comment.
+
+    Returns:
+        Pair of ref and optional comment text.
+    """
+    ref, separator, comment = ref_display.partition("#")
+    stripped_ref = ref.strip()
+    if not separator:
+        return stripped_ref, None
+    stripped_comment = comment.strip()
+    return stripped_ref, stripped_comment or None
+
+
+def parse_version_comment(comment: str | None) -> tuple[int, ...] | None:
+    """Parse a SemVer-like version comment.
+
+    Args:
+        comment: Optional trailing action-pin comment.
+
+    Returns:
+        Numeric version tuple when the comment looks like `v1.2.3`, otherwise `None`.
+    """
+    if comment is None:
+        return None
+    match: re.Match[str] | None = VERSION_COMMENT_PATTERN.match(comment.strip())
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.group("parts").split("."))
+
+
+def choose_preferred_ref_display(action_uses: Sequence[ActionUse]) -> str | None:
+    """Choose the ref display to use when repairing one divergent action group.
+
+    The repair strategy intentionally avoids network lookups. It can only select a
+    preferred ref when exactly one ref display has the highest SemVer-like trailing
+    version comment.
+
+    Args:
+        action_uses: Divergent references for one action.
+
+    Returns:
+        Preferred ref display, or `None` when no unique preferred ref can be selected.
+    """
+    candidates: dict[str, tuple[int, ...]] = {}
+    for action_use in action_uses:
+        version = parse_version_comment(action_use.comment)
+        if version is not None and SHA_PATTERN.match(action_use.ref):
+            candidates[action_use.ref_display] = version
+
+    if not candidates:
+        return None
+
+    highest_version = max(candidates.values())
+    preferred = [ref for ref, version in candidates.items() if version == highest_version]
+    if len(preferred) != 1:
+        return None
+    return preferred[0]
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -175,6 +307,15 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         help=(
             "Optional report mode. Use 'summary' for aggregated action/ref counts, "
             "'files' for counts grouped by source file, or 'all' for both."
+        ),
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help=(
+            "Rewrite stale repeated action refs to the preferred ref already present "
+            "in scanned files. The preferred ref is selected from the highest "
+            "SemVer-like trailing version comment, such as '# v8.2.0'."
         ),
     )
     return parser.parse_args(argv)
@@ -229,6 +370,9 @@ def parse_action_uses(root: Path, path: Path) -> tuple[ActionUse, ...]:
                 path=relative_path,
                 line_number=line_number,
                 comment=match.group("comment"),
+                line=line,
+                prefix=match.group("prefix"),
+                suffix=match.group("suffix"),
             )
         )
     return tuple(uses)
@@ -266,7 +410,63 @@ def audit_repository(root: Path) -> AuditResult:
         for action, action_uses in sorted(grouped.items())
         if len({action_use.ref for action_use in action_uses}) > 1
     }
-    return AuditResult(uses=tuple(all_uses), divergent_actions=divergent_actions)
+    unfixable_actions: dict[str, tuple[str, ...]] = {
+        action: tuple(sorted({action_use.ref_display for action_use in action_uses}))
+        for action, action_uses in divergent_actions.items()
+        if choose_preferred_ref_display(action_uses) is None
+    }
+    return AuditResult(
+        uses=tuple(all_uses),
+        divergent_actions=divergent_actions,
+        unfixable_actions=unfixable_actions,
+    )
+
+
+def fix_repository(root: Path, result: AuditResult) -> tuple[ActionUse, ...]:
+    """Rewrite stale repeated action refs to their preferred pinned refs.
+
+    Args:
+        root: Repository root to update.
+        result: Audit result containing divergent action groups.
+
+    Returns:
+        Updated action references that were rewritten.
+
+    Raises:
+        ValueError: If at least one divergent action cannot be repaired automatically.
+    """
+    if result.unfixable_actions:
+        action_names = ", ".join(sorted(result.unfixable_actions))
+        raise ValueError(f"Cannot select preferred refs for: {action_names}")
+
+    replacements_by_path: dict[Path, dict[int, ActionUse]] = defaultdict(dict)
+    for action_uses in result.divergent_actions.values():
+        preferred_ref_display = choose_preferred_ref_display(action_uses)
+        if preferred_ref_display is None:
+            continue
+        for action_use in action_uses:
+            if action_use.ref_display == preferred_ref_display:
+                continue
+            replacements_by_path[action_use.path][action_use.line_number] = (
+                action_use.with_ref_display(preferred_ref_display)
+            )
+
+    rewritten: list[ActionUse] = []
+    for relative_path, replacements in sorted(
+        replacements_by_path.items(), key=lambda item: item[0].as_posix()
+    ):
+        path = root / relative_path
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        for line_number, replacement in sorted(replacements.items()):
+            original = lines[line_number - 1]
+            newline = "\n" if original.endswith("\n") else ""
+            if original.endswith("\r\n"):
+                newline = "\r\n"
+            lines[line_number - 1] = f"{replacement.replacement_line}{newline}"
+            rewritten.append(replacement)
+        path.write_text("".join(lines), encoding="utf-8")
+
+    return tuple(rewritten)
 
 
 # ---- Reporting helpers ----
@@ -432,6 +632,33 @@ def format_audit_report(result: AuditResult) -> str:
     return "\n".join(lines)
 
 
+def format_fix_report(rewritten: Sequence[ActionUse]) -> str:
+    """Format a human-readable repair report.
+
+    Args:
+        rewritten: Action references rewritten by `--fix`.
+
+    Returns:
+        Text report suitable for local terminals and GitHub Actions logs.
+    """
+    lines: list[str] = []
+    lines.append("GitHub Actions pin repair")
+    lines.append("=========================")
+    lines.append("")
+
+    if not rewritten:
+        lines.append("No stale repeated action refs needed rewriting.")
+        return "\n".join(lines)
+
+    lines.append(f"Rewritten action references: {len(rewritten)}")
+    lines.append("")
+    for action_use in rewritten:
+        lines.append(f"- {action_use.format_location()}")
+        lines.append(f"  {action_use.ref_display}")
+
+    return "\n".join(lines)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the action-pin audit CLI.
 
@@ -442,11 +669,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         Process exit code. Returns 0 when refs are consistent and 1 when divergence is detected.
     """
     args: argparse.Namespace = parse_args(sys.argv[1:] if argv is None else argv)
-    result: AuditResult = audit_repository(args.root)
+    root: Path = args.root.resolve()
+    result: AuditResult = audit_repository(root)
     optional_report: str = format_optional_reports(result, args.report)
     if optional_report:
         print(optional_report)
         print()
+
+    if args.fix and result.has_failures:
+        if not result.can_fix:
+            print(format_audit_report(result))
+            print()
+            print("Automatic repair skipped: no unique preferred ref could be selected.")
+            return 1
+        try:
+            rewritten = fix_repository(root, result)
+        except ValueError as error:
+            print(format_audit_report(result))
+            print()
+            print(f"Automatic repair failed: {error}")
+            return 1
+        print(format_fix_report(rewritten))
+        print()
+        result = audit_repository(root)
+
     print(format_audit_report(result))
     return 1 if result.has_failures else 0
 


### PR DESCRIPTION
## Summary

Implements issue #119 by extending the GitHub Actions pin audit with
an optional local repair mode.

The new `--fix` option can automatically resolve repository-local
action pin drift caused by partial Dependabot updates while preserving
TopMark's existing offline and deterministic dependency-governance
model.

## Changes

- Add `--fix` to `tools/ci/audit_action_pins.py`
- Detect repairable vs ambiguous divergent action refs
- Select preferred refs using existing SemVer-like version comments
- Rewrite stale repeated refs in workflows and local composite actions
- Re-run the audit after repair and report final status
- Expand audit reporting and diagnostics
- Document repair workflows, trust boundaries, and maintenance guidance
- Update CI index documentation to reference local repair capability

## Design Constraints

The repair mode intentionally does not:

- query GitHub APIs
- resolve tags dynamically
- discover newer versions
- replace Dependabot
- perform automatic upgrades

Repairs are limited to refs already present in the scanned repository.

## Motivation

PR #114 exposed a maintenance scenario where Dependabot updated
workflow references but left a matching pin inside a local composite
action unchanged. The existing audit correctly detected the drift,
but maintainers had to repair it manually.

This change preserves the audit's governance role while reducing the
manual effort required to restore consistency.

Closes #119
Related: #109
Motivated by: #114