### PR TITLE
Clarify filesystem-identity compatibility boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,9 @@ ______________________________________________________________________
 - Clarified TopMark's identity-domain terminology and compatibility boundaries for processing-target
   identity, configuration-source identity, registry identity, path serialization, and
   filesystem-identity evaluation.
+- Added cross-references between public API, terminology, and API-stability documentation so
+  filesystem-identity concepts link directly to the authoritative identity-domain compatibility
+  classification.
 - Documented local repair workflows, trust boundaries, and maintenance guidance for the GitHub
   Actions pin audit, including the new `--fix` mode.
 

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -371,4 +371,7 @@ For resolution diagnostics, prefer:
 ______________________________________________________________________
 
 **Stability note:** See [API stability and snapshot policy](../dev/api-stability.md) for how TopMark
-protects the stable public API surface across supported Python versions.
+protects the stable public API surface across supported Python versions, including the
+[identity-domain compatibility boundaries](../dev/api-stability.md#identity-domain-compatibility-boundaries)
+shared by public API results, machine-readable output, configuration provenance, and documented
+processing-target behavior.

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -130,6 +130,12 @@ configuration-source identities, and canonicalized registry matching rules. Thes
 interchangeable across domains. Workspace-root discovery and discovery anchors are related discovery
 concepts rather than canonical identity domains.
 
+> [!NOTE]
+>
+> For the compatibility status of each identity domain, see
+> [Identity-domain compatibility boundaries](dev/api-stability.md#identity-domain-compatibility-boundaries).
+> Not every canonical identity is part of the same public compatibility surface.
+
 ### Filesystem identity
 
 The canonical filesystem object identity used by TopMark when evaluating runtime processing targets.


### PR DESCRIPTION
## Summary

Complete the compatibility-governance review for filesystem identity
semantics tracked by #104.

This PR does not change behavior. Instead, it improves documentation
discoverability by linking the existing identity-domain terminology and
public API documentation to the authoritative compatibility-boundary
definitions.

### Changes

- Add a cross-reference from `docs/api/public.md` to the identity-domain
  compatibility boundaries in `docs/dev/api-stability.md`.
- Add a cross-reference from `docs/terminology.md` to the same
  compatibility-boundary section.
- Update the unreleased changelog accordingly.

### Rationale

The filesystem-identity review concluded that the relevant compatibility
boundaries are already defined and documented following the work from:

- #88 Path serialization contract
- #90 Filesystem identity policy
- #102 Workspace-root discovery through symlinks
- #103 Hard-link filesystem identity policy
- #105 Identity domains and compatibility boundaries
- #118 Configuration-source identity deduplication

The remaining opportunity was documentation discoverability rather than
behavioral change.

### Compatibility

No runtime behavior changes.

No machine-readable output changes.

No public API changes.

No new compatibility guarantees introduced.

Closes #104.