### PR TITLE
test(ci): require symlink-dependent filesystem tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,8 @@ jobs:
           python-version: ${{ needs.python-metadata.outputs.canonical }}
 
       - name: Run canonical Python QA on ${{ matrix.os }}
+        env:
+          TOPMARK_REQUIRE_SYMLINKS: "1"
         run: |
           nox -s qa -p ${{ needs.python-metadata.outputs.canonical }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ ______________________________________________________________________
   blocked as hard-linked processing targets while unrelated files continue processing normally.
 - Extended the GitHub Actions pin audit with an optional `--fix` mode that can repair stale repeated
   action refs using an already-present preferred pinned ref selected from version-comment metadata.
+- Required symlink-dependent regression tests to execute in the cross-platform filesystem CI job
+  instead of silently skipping when symlink creation is unavailable.
 
 ### Breaking Changes - Unreleased
 
@@ -179,6 +181,8 @@ ______________________________________________________________________
   classification.
 - Documented local repair workflows, trust boundaries, and maintenance guidance for the GitHub
   Actions pin audit, including the new `--fix` mode.
+- Documented that the filesystem CI job requires symlink capability through
+  `TOPMARK_REQUIRE_SYMLINKS=1` on Ubuntu, macOS, and Windows.
 
 ### Internal - Unreleased
 
@@ -217,6 +221,8 @@ ______________________________________________________________________
 - Added deterministic repair support for GitHub Actions pin drift in local composite actions and
   workflow files without introducing network access, dynamic version resolution, or Dependabot
   replacement behavior.
+- Added a `TOPMARK_REQUIRE_SYMLINKS` test-helper guard so symlink-dependent tests fail loudly in CI
+  jobs that are expected to exercise symlink behavior.
 
 ### Notes - Unreleased
 

--- a/docs/ci/ci-workflow.md
+++ b/docs/ci/ci-workflow.md
@@ -107,7 +107,9 @@ supported Python-version matrix across every operating system.
 This job also protects TopMark's filesystem-identity evaluation contract. That includes
 filesystem-identity normalization for platform-sensitive path spellings and processing-target
 eligibility checks such as hard-link policy where the host filesystem supports the required
-semantics.
+semantics. Symlink-dependent regressions are required in this job: the workflow sets
+`TOPMARK_REQUIRE_SYMLINKS=1`, so a runner that cannot create symlinks fails the job instead of
+silently skipping those tests.
 
 Coverage reporting runs in a dedicated canonical job on Ubuntu using the resolved canonical Python
 version and the existing `nox -s coverage` session. Coverage intentionally runs outside the full
@@ -206,7 +208,10 @@ nox -s coverage -p 3.13
 
 The `filesystem-tests` job runs the same canonical `qa` session on Ubuntu, macOS, and Windows. Local
 reproduction can validate the current machine's filesystem behavior, but it cannot replace the
-cross-platform GitHub-hosted runs for case-sensitivity and path-canonicalization behavior.
+cross-platform GitHub-hosted runs for case-sensitivity and path-canonicalization behavior. In this
+job, symlink creation is mandatory through `TOPMARK_REQUIRE_SYMLINKS=1`; if a Windows runner loses
+symlink capability because Developer Mode or equivalent privileges are unavailable, the job fails
+rather than reporting a misleading skip.
 
 The concrete `3.13` commands shown here reflect the current canonical Python version. That value is
 resolved from project metadata and is expected to move when the supported Python range moves.

--- a/tests/helpers/paths.py
+++ b/tests/helpers/paths.py
@@ -18,6 +18,7 @@ serialized with POSIX separators and must therefore not contain backslashes.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 from typing import Final
 
@@ -28,6 +29,8 @@ from topmark.core.typing_guards import is_mapping
 if TYPE_CHECKING:
     from pathlib import Path
 
+
+REQUIRE_SYMLINKS_ENV: Final[str] = "TOPMARK_REQUIRE_SYMLINKS"
 
 MACHINE_PATH_FIELD_NAMES: Final[frozenset[str]] = frozenset(
     {
@@ -143,6 +146,10 @@ def symlink_or_skip(
 ) -> Path:
     """Create a symlink or skip when the platform disallows symlinks.
 
+    Set `TOPMARK_REQUIRE_SYMLINKS=1` in CI jobs where symlink-dependent
+    regressions must execute. In that mode, an unavailable symlink capability is
+    reported as a test failure instead of a skip.
+
     Args:
         link: Symlink path to create.
         target: Symlink target.
@@ -157,5 +164,8 @@ def symlink_or_skip(
     except (NotImplementedError, OSError) as exc:
         import pytest
 
-        pytest.skip(f"symlink creation is not available in this test environment: {exc}")
+        message: str = f"symlink creation is not available in this test environment: {exc}"
+        if os.environ.get(REQUIRE_SYMLINKS_ENV) == "1":
+            pytest.fail(message)
+        pytest.skip(message)
     return link


### PR DESCRIPTION
## Summary

Improve Windows CI coverage for symlink-dependent filesystem identity regressions.

This change converts symlink support from a best-effort capability into an explicit requirement for the dedicated cross-platform filesystem test job. If a GitHub Actions runner cannot create symlinks, the affected tests now fail rather than being silently skipped.

## Changes

- Set `TOPMARK_REQUIRE_SYMLINKS=1` in the `filesystem-tests` GitHub Actions job.
- Update `tests.helpers.paths.symlink_or_skip()` to fail when symlink capability is required but unavailable.
- Document the symlink requirement and its rationale in `docs/ci/ci-workflow.md`.
- Update the Unreleased changelog.

## Why

Issue #106 identified a potential coverage gap: filesystem-identity behavior introduced and documented through #90, #102, #103, #104, and #105 could appear protected by CI while symlink-dependent tests were actually skipped on a platform.

By requiring symlink support in the dedicated filesystem matrix job, GitHub-hosted Windows, macOS, and Ubuntu runners now provide a stronger signal that symlink-related regression coverage is genuinely executing.

## Validation

- Existing symlink-dependent tests continue to use the shared helper.
- CI now fails if symlink creation is unavailable where filesystem-identity regressions are expected to run.
- No filesystem-identity semantics were changed.

## Related Issues

- Closes #106
- Related: #90, #91, #102, #103, #113, #122