### PR TITLE
Expose discovery anchor in configuration provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,11 @@ ______________________________________________________________________
   configuration-file target for precedence, scope applicability, layered provenance, and
   machine-readable configuration provenance.
 - Deduplicated repeated resolved configuration-source identities during TOML-side resolution,
+- Deduplicated repeated resolved configuration-source identities during TOML-side resolution,
   keeping the highest-precedence occurrence for layered configuration and provenance.
+- Extended machine-readable configuration provenance to expose the resolved configuration-discovery
+  anchor separately from configuration-source identity, scope roots, processing targets, and
+  filesystem identity.
 - Added a hard-link filesystem-identity guard: selected paths sharing `(st_dev, st_ino)` are all
   blocked as hard-linked processing targets while unrelated files continue processing normally.
 - Extended the GitHub Actions pin audit with an optional `--fix` mode that can repair stale repeated
@@ -134,6 +138,9 @@ ______________________________________________________________________
   winner, or loser path.
 - Fixed duplicate configuration-source provenance when the same resolved TOML source is reached
   through multiple discovery or explicit `--config` paths.
+- Fixed missing machine-readable visibility into configuration-discovery starting points by
+  exporting the resolved discovery anchor in configuration provenance payloads while preserving
+  existing provenance and identity semantics.
 
 ### Documentation - Unreleased
 
@@ -171,6 +178,9 @@ ______________________________________________________________________
   terminology, machine-output, command, and API documentation.
 - Documented workspace-root discovery and resolved discovery-anchor behavior across configuration,
   command, machine-output, terminology, architecture, and API-stability documentation.
+- Documented `config_provenance.discovery_anchor` and clarified its distinction from
+  configuration-source identity, scope roots, processing targets, and filesystem identity across
+  machine-output and configuration-command documentation.
 - Documented the TopMark 1.1.0 hard-link compatibility contract for processing and probe machine
   output.
 - Clarified TopMark's identity-domain terminology and compatibility boundaries for processing-target
@@ -215,6 +225,8 @@ ______________________________________________________________________
   current working directories, and repositories reached through symlinked parent paths.
 - Added regression coverage for duplicate resolved configuration-source identities across
   discovered, explicit, and symlinked configuration paths.
+- Added machine-output and TOML-provenance regression coverage for discovery-anchor serialization,
+  POSIX path formatting, provenance-only schema handling, and symlinked discovery scenarios.
 - Added regression coverage for hard-linked selected processing paths across pipeline execution,
   `check`, `strip`, `probe`, JSON output, NDJSON output, and mixed hard-linked plus unrelated file
   selections.

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -110,9 +110,9 @@ Stability guarantees:
   the same identity domain.
 
 Workspace-root discovery and discovery-anchor evaluation occur before either identity domain is
-established. Machine-readable output does not currently expose a dedicated `discovery_anchor` field,
-but configuration provenance may serialize discovery results such as resolved configuration-source
-origins and scope roots.
+established. `config_provenance.discovery_anchor` exposes the resolved project/local discovery
+anchor when provenance is requested. Configuration provenance layers separately serialize resolved
+configuration-source origins and scope roots.
 
 Consumers should:
 
@@ -315,7 +315,8 @@ Examples:
 {
   "meta": { ... },
   "config_provenance": {
-    "layers": [
+    "discovery_anchor": "/repo",
+    "config_layers": [
       {
         "origin": "<defaults>",
         "kind": "default",
@@ -623,11 +624,12 @@ configuration-file target. Symlink spellings for configuration files are therefo
 machine-readable provenance, precedence, scope, or applicability evaluation.
 
 Project-chain discovery begins from the resolved discovery anchor before configuration-source
-identity is established. Machine-readable provenance payloads describe the resolved configuration
-sources and, when available, their resolved scope roots. If multiple entries resolve to the same
-configuration-source identity, provenance keeps the highest-precedence occurrence and emits one
-layer for that source identity. Provenance payloads do not currently include a separate field for
-the original discovery-anchor spelling used to start project-chain discovery.
+identity is established. Machine-readable provenance payloads expose that resolved starting point as
+`discovery_anchor`, then describe the resolved configuration sources and, when available, their
+resolved scope roots. If multiple entries resolve to the same configuration-source identity,
+provenance keeps the highest-precedence occurrence and emits one layer for that source identity. The
+field does not preserve the original discovery-anchor spelling used to start project-chain
+discovery.
 
 Configuration-source identity is distinct from processing-target identity. Hard-link processing
 policy applies to runtime filesystem-processing payloads and probe diagnostics, but does not affect
@@ -636,9 +638,9 @@ configuration-source provenance or runtime configuration snapshots.
 - JSON includes `config_provenance` before `config` in the top-level envelope.
 - NDJSON emits a `config_provenance` record first and a `config` record second.
 
-The `config_provenance` payload is inspection-oriented. Each provenance layer preserves metadata
-such as `origin`, `kind`, `precedence`, and optional `scope_root`, and exposes the corresponding
-source-local TopMark TOML fragment under `toml`.
+The `config_provenance` payload is inspection-oriented. The payload may include `discovery_anchor`,
+and each provenance layer preserves metadata such as `origin`, `kind`, `precedence`, and optional
+`scope_root`, and exposes the corresponding source-local TopMark TOML fragment under `toml`.
 
 Config-specific payload keys and NDJSON kinds are defined in
 \[`topmark.config.machine.schemas.ConfigKey`\][topmark.config.machine.schemas.ConfigKey] and

--- a/docs/usage/commands/config/dump.md
+++ b/docs/usage/commands/config/dump.md
@@ -118,6 +118,11 @@ Each layer includes:
 - `scope_root` - optional applicability root associated with the configuration source
 - `toml` - the source-local TopMark TOML fragment after TOML-layer validation
 
+The provenance export also records a top-level `discovery_anchor`, which identifies the resolved
+filesystem location from which project-chain configuration discovery started. The discovery anchor
+is distinct from configuration-source `origin`, layer `scope_root`, processing targets, and
+filesystem identity.
+
 For file-backed layers, `origin` and `scope_root` describe the resolved configuration-file target
 used for configuration-source identity. If a configuration file is loaded through a symlink, layered
 provenance reports the resolved target rather than the symlink spelling.
@@ -224,10 +229,11 @@ configuration sources rather than processing targets.
 Notes:
 
 - `config dump` is file-agnostic and emits the effective runtime configuration after applying
-  defaults -> discovered configuratin -> `--config` files -> CLI overrides, with whole-source TOML
+  defaults -> discovered configuration -> `--config` files -> CLI overrides, with whole-source TOML
   validation performed per source before layered configuration merging.
 - With `--show-layers`, machine-readable output also includes a `config_provenance` payload before
-  the flattened runtime configuration snapshot.
+  the flattened runtime configuration snapshot. The provenance payload includes `discovery_anchor`,
+  the resolved filesystem location from which project-chain configuration discovery started.
 - File-backed provenance entries use configuration-source identity based on resolved configuration
   targets. `origin` and `scope_root` therefore describe resolved configuration targets rather than
   symlink spellings.
@@ -255,8 +261,10 @@ With `--show-layers`, the JSON envelope becomes:
 }
 ```
 
-The `config_provenance` payload reports configuration layers using configuration-source identity.
-For file-backed layers, provenance paths describe resolved configuration targets.
+The `config_provenance` payload reports configuration layers using configuration-source identity and
+also includes `discovery_anchor`, the resolved filesystem location from which project-chain
+configuration discovery started. For file-backed layers, provenance paths describe resolved
+configuration targets.
 
 ### NDJSON schema
 
@@ -283,6 +291,10 @@ Example:
 {"kind":"config_provenance","meta":{...},"config_provenance":{...}}
 {"kind":"config","meta":{...},"config":{...}}
 ```
+
+Within `config_provenance`, `discovery_anchor` identifies the resolved filesystem location from
+which project-chain configuration discovery started. It is distinct from configuration-source
+`origin` values and layer `scope_root` values.
 
 ______________________________________________________________________
 

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -708,9 +708,9 @@ precedence evaluation, and runtime overlays have completed.
 
 `ConfigPayload` may include resolved configuration file paths in fields such as
 `files.config_files`. Those paths describe configuration sources participating in the effective
-configuration; they are not a separate serialized discovery-anchor field. If multiple inputs resolve
-to the same configuration-source identity, TopMark keeps the highest-precedence occurrence and emits
-that source identity once.
+configuration; they are separate from `config_provenance.discovery_anchor`, which is emitted only
+when layered provenance is requested. If multiple inputs resolve to the same configuration-source
+identity, TopMark keeps the highest-precedence occurrence and emits that source identity once.
 
 Normalization rules:
 
@@ -829,7 +829,8 @@ envelope becomes:
 {
   "meta": { /* MetaPayload */ },
   "config_provenance": {
-    "layers": [
+    "discovery_anchor": "/repo",
+    "config_layers": [
       {
         "origin": "<defaults>",
         "kind": "default",
@@ -845,7 +846,13 @@ envelope becomes:
 }
 ```
 
-`config_provenance` is an inspection-oriented payload. Each layer contains:
+`config_provenance` is an inspection-oriented payload. It contains:
+
+- `discovery_anchor` - resolved project/local discovery anchor used to find discovered config
+  sources, when available
+- `config_layers` - ordered provenance layers
+
+Each layer contains:
 
 - `origin` - provenance origin label
 - `kind` - resolved config layer kind
@@ -880,7 +887,8 @@ JSON shape:
 
 ```jsonc
 {
-  "layers": [
+  "discovery_anchor": "/repo",
+  "config_layers": [
     {
       "origin": "<defaults>",
       "kind": "default",
@@ -909,8 +917,9 @@ The payload is inspection-oriented rather than a loadable `topmark.toml` documen
 human-facing layered TOML export by preserving ordered layers and the corresponding source-local
 TopMark TOML fragments.
 
-Real filesystem `origin` and `scope_root` values use POSIX `/` separators on all platforms.
-Synthetic layer origins such as built-in defaults are stable labels rather than filesystem paths.
+Real filesystem `discovery_anchor`, `origin`, and `scope_root` values use POSIX `/` separators on
+all platforms. Synthetic layer origins such as built-in defaults are stable labels rather than
+filesystem paths.
 
 File-backed configuration provenance uses configuration-source identity based on the resolved
 configuration-file target. If a configuration file is loaded through a symlink, `origin` and
@@ -919,8 +928,10 @@ spelling.
 
 Workspace-root discovery is evaluated earlier. Project-chain discovery determines which
 configuration files participate in layered configuration construction before provenance identities
-are assigned. Provenance payloads then serialize discovered configuration-source origins and, when
-available, resolved scope roots for those layers.
+are assigned. `discovery_anchor` records the resolved project/local starting directory for that
+discovery. It is not a configuration source, scope root, processing target, or filesystem identity.
+Provenance payloads then serialize discovered configuration-source origins and, when available,
+resolved scope roots for those layers.
 
 The outer `config_layers` container key belongs to the config machine-readable output domain, while
 the inner provenance-layer fragment keys (`origin`, `kind`, `precedence`, `toml`, `scope_root`) are
@@ -1251,12 +1262,13 @@ Consumers should:
 - Assume additive fields may appear over time within the 1.x compatibility model.
 - Prefer canonical identity fields such as `qualified_key`, `file_type_key`, and `processor_key`
   over display-oriented names.
-- Treat filesystem `path`, `origin`, and `scope_root` fields as serialized processing/provenance
-  paths, not as lossless echoes of the original invocation spelling.
+- Treat filesystem `path`, `discovery_anchor`, `origin`, and `scope_root` fields as serialized
+  processing/provenance paths, not as lossless echoes of the original invocation spelling.
 
 Consumers should not infer the original workspace-root discovery-anchor spelling from
-machine-readable payloads. The stable 1.x contract serializes discovered configuration sources and
-scope roots where applicable, but does not currently expose a dedicated `discovery_anchor` field.
+machine-readable payloads. The stable 1.x contract serializes the resolved discovery anchor in
+`config_provenance.discovery_anchor` when provenance is requested, plus discovered configuration
+sources and scope roots where applicable.
 
 Breaking machine-readable output changes should be signaled through Conventional Commits using the
 `!` marker and documented in the changelog.

--- a/src/topmark/config/resolution/bridge.py
+++ b/src/topmark/config/resolution/bridge.py
@@ -195,6 +195,7 @@ def _resolve_single_builtin_toml_table_and_build_mutable_config(
         sources=[source],
         writer_options=parsed.writer_options if parsed is not None else None,
         strict=parsed.config_loading_options.strict if parsed is not None else None,
+        discovery_anchor=None,
     )
     return ResolvedConfigDraft(
         resolved=resolved,

--- a/src/topmark/toml/machine/payloads.py
+++ b/src/topmark/toml/machine/payloads.py
@@ -129,4 +129,13 @@ def build_toml_provenance_payload(
             )
         )
 
-    return TomlProvenancePayload(layers=out_layers)
+    discovery_anchor: str | None = (
+        format_machine_path(resolved_toml.discovery_anchor)
+        if resolved_toml.discovery_anchor is not None
+        else None
+    )
+
+    return TomlProvenancePayload(
+        layers=out_layers,
+        discovery_anchor=discovery_anchor,
+    )

--- a/src/topmark/toml/machine/schemas.py
+++ b/src/topmark/toml/machine/schemas.py
@@ -41,6 +41,7 @@ class TomlKey(str, Enum):
         PRECEDENCE: Numeric layer precedence.
         TOML: Nested TopMark TOML fragment for the layer.
         SCOPE_ROOT: Optional scope root attached to the layer.
+        DISCOVERY_ANCHOR: Resolved project/local discovery anchor.
     """
 
     CONFIG_LAYERS = "config_layers"
@@ -49,6 +50,7 @@ class TomlKey(str, Enum):
     PRECEDENCE = "precedence"
     TOML = "toml"
     SCOPE_ROOT = "scope_root"
+    DISCOVERY_ANCHOR = "discovery_anchor"
 
 
 @dataclass(kw_only=True, slots=True)
@@ -93,16 +95,23 @@ class TomlProvenancePayload:
     Attributes:
         layers: Ordered provenance layers, starting with the built-in defaults
             layer when present.
+        discovery_anchor: Optional resolved project/local discovery anchor used
+            to find discovered TOML sources.
     """
 
     layers: list[TomlProvenanceLayerPayload]
+    discovery_anchor: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         """Return the provenance payload as a JSON-friendly mapping.
 
         Returns:
-            A dict containing the ordered `config_layers` export.
+            A dict containing the optional discovery anchor and ordered
+            `config_layers` export.
         """
-        return {
+        out: dict[str, object] = {
             TomlKey.CONFIG_LAYERS.value: [layer.to_dict() for layer in self.layers],
         }
+        if self.discovery_anchor is not None:
+            out[TomlKey.DISCOVERY_ANCHOR.value] = self.discovery_anchor
+        return out

--- a/src/topmark/toml/resolution.py
+++ b/src/topmark/toml/resolution.py
@@ -118,11 +118,15 @@ class ResolvedTopmarkTomlSources:
         strict: Resolved config-loading strictness using
             highest-precedence non-`None` wins, optionally overridden by the
             explicit function argument to `resolve_topmark_toml_sources()`.
+        discovery_anchor: Resolved anchor directory used to start project/local
+            TOML discovery, or `None` for synthetic/bundled config payloads that
+            do not perform project/local discovery.
     """
 
     sources: list[ResolvedTopmarkTomlSource]
     writer_options: WriterOptions | None
     strict: bool | None
+    discovery_anchor: Path | None = None
 
 
 # ---- Shared helpers ----
@@ -425,4 +429,5 @@ def resolve_topmark_toml_sources(
         sources=source_entries,
         writer_options=resolved_writer,
         strict=resolved_strict,
+        discovery_anchor=anchor,
     )

--- a/tests/cli/machine/test_config_dump_machine.py
+++ b/tests/cli/machine/test_config_dump_machine.py
@@ -40,8 +40,11 @@ from __future__ import annotations
 import textwrap
 from typing import TYPE_CHECKING
 
+import pytest
+
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
+from tests.cli.conftest import run_cli_in
 from tests.helpers.json import parse_json_object
 from tests.helpers.ndjson import assert_ndjson_meta
 from tests.helpers.ndjson import parse_ndjson_records
@@ -103,16 +106,16 @@ def test_config_dump_json_includes_meta() -> None:
     assert "meta" in payload
     assert "config" in payload
 
-    meta_obj = payload.get("meta")
+    meta_obj: object | None = payload.get("meta")
     assert is_mapping(meta_obj)
     meta: dict[str, object] = as_object_dict(meta_obj)
 
-    tool_obj = meta.get("tool")
+    tool_obj: object | None = meta.get("tool")
     assert isinstance(tool_obj, str)
     assert tool_obj == "topmark"
 
     # Version should be a non-empty string
-    version_obj = meta.get("version")
+    version_obj: object | None = meta.get("version")
     assert isinstance(version_obj, str)
     assert version_obj != ""
 
@@ -136,11 +139,11 @@ def test_config_dump_json_show_layers_includes_config_provenance() -> None:
     assert "config_provenance" in payload
     assert "config" in payload
 
-    provenance_obj = payload.get("config_provenance")
+    provenance_obj: object | None = payload.get("config_provenance")
     assert is_mapping(provenance_obj)
     provenance: dict[str, object] = as_object_dict(provenance_obj)
 
-    layers_obj = provenance.get("config_layers")
+    layers_obj: object | None = provenance.get("config_layers")
     assert is_any_list(layers_obj)
     layers: list[object] = layers_obj
     assert layers
@@ -153,8 +156,100 @@ def test_config_dump_json_show_layers_includes_config_provenance() -> None:
     assert isinstance(first.get("kind"), str)
     assert isinstance(first.get("precedence"), int)
 
-    toml_obj = first.get("toml")
+    toml_obj: object | None = first.get("toml")
     assert is_mapping(toml_obj)
+
+
+def test_config_dump_json_show_layers_includes_discovery_anchor(tmp_path: Path) -> None:
+    """JSON config provenance should expose the resolved discovery anchor."""
+    workspace: Path = tmp_path / "workspace"
+    config_file: Path = workspace / "topmark.toml"
+    _write_minimal_config(config_file)
+
+    result: Result = run_cli_in(
+        workspace,
+        [
+            CliCmd.CONFIG,
+            CliCmd.CONFIG_DUMP,
+            CliOpt.SHOW_CONFIG_LAYERS,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+        ],
+    )
+    assert_SUCCESS(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+
+    provenance_obj: object | None = payload.get("config_provenance")
+    assert is_mapping(provenance_obj)
+    provenance: dict[str, object] = as_object_dict(provenance_obj)
+
+    discovery_anchor_obj: object | None = provenance.get("discovery_anchor")
+    assert isinstance(discovery_anchor_obj, str)
+    assert discovery_anchor_obj == workspace.resolve().as_posix()
+
+
+def test_config_dump_json_show_layers_resolves_symlinked_discovery_anchor(
+    tmp_path: Path,
+) -> None:
+    """Discovery-anchor provenance should use the resolved target for symlinked CWD."""
+    real_workspace: Path = tmp_path / "real-workspace"
+    config_file: Path = real_workspace / "topmark.toml"
+    _write_minimal_config(config_file)
+
+    linked_workspace: Path = tmp_path / "linked-workspace"
+    try:
+        linked_workspace.symlink_to(real_workspace, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks are unavailable in this environment: {exc}")
+
+    result: Result = run_cli_in(
+        linked_workspace,
+        [
+            CliCmd.CONFIG,
+            CliCmd.CONFIG_DUMP,
+            CliOpt.SHOW_CONFIG_LAYERS,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+        ],
+    )
+    assert_SUCCESS(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+
+    provenance_obj: object | None = payload.get("config_provenance")
+    assert is_mapping(provenance_obj)
+    provenance: dict[str, object] = as_object_dict(provenance_obj)
+
+    discovery_anchor_obj: object | None = provenance.get("discovery_anchor")
+    assert isinstance(discovery_anchor_obj, str)
+    assert discovery_anchor_obj == real_workspace.resolve().as_posix()
+
+
+def test_config_dump_json_without_show_layers_omits_discovery_anchor(tmp_path: Path) -> None:
+    """Default config snapshots should not mix provenance into `config`."""
+    workspace: Path = tmp_path / "workspace"
+    config_file: Path = workspace / "topmark.toml"
+    _write_minimal_config(config_file)
+
+    result: Result = run_cli_in(
+        workspace,
+        [
+            CliCmd.CONFIG,
+            CliCmd.CONFIG_DUMP,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+        ],
+    )
+    assert_SUCCESS(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    assert "config_provenance" not in payload
+
+    config_obj: object | None = payload.get("config")
+    assert is_mapping(config_obj)
+    config: dict[str, object] = as_object_dict(config_obj)
+    assert "discovery_anchor" not in config
 
 
 def test_config_dump_json_show_layers_defaults_layer_shape() -> None:
@@ -172,11 +267,11 @@ def test_config_dump_json_show_layers_defaults_layer_shape() -> None:
 
     payload: dict[str, object] = parse_json_object(result.output)
 
-    provenance_obj = payload.get("config_provenance")
+    provenance_obj: object | None = payload.get("config_provenance")
     assert is_mapping(provenance_obj)
     provenance: dict[str, object] = as_object_dict(provenance_obj)
 
-    layers_obj = provenance.get("config_layers")
+    layers_obj: object | None = provenance.get("config_layers")
     assert is_any_list(layers_obj)
     layers: list[object] = layers_obj
     assert layers
@@ -189,7 +284,7 @@ def test_config_dump_json_show_layers_defaults_layer_shape() -> None:
     assert first.get("kind") == "default"
     assert first.get("precedence") == 0
 
-    toml_obj = first.get("toml")
+    toml_obj: object | None = first.get("toml")
     assert is_mapping(toml_obj)
     toml_fragment: dict[str, object] = as_object_dict(toml_obj)
     assert "config" in toml_fragment
@@ -217,15 +312,15 @@ def test_config_dump_json_config_files_use_posix_paths_for_explicit_config(
 
     payload: dict[str, object] = parse_json_object(result.output)
 
-    config_obj = payload.get("config")
+    config_obj: object | None = payload.get("config")
     assert is_mapping(config_obj)
     config: dict[str, object] = as_object_dict(config_obj)
 
-    files_obj = config.get("files")
+    files_obj: object | None = config.get("files")
     assert is_mapping(files_obj)
     files: dict[str, object] = as_object_dict(files_obj)
 
-    config_files_obj = files.get("config_files")
+    config_files_obj: object | None = files.get("config_files")
     assert is_any_list(config_files_obj)
     assert config_file.as_posix() in config_files_obj
 
@@ -252,11 +347,11 @@ def test_config_dump_json_show_layers_uses_posix_paths_for_explicit_config_prove
 
     payload: dict[str, object] = parse_json_object(result.output)
 
-    provenance_obj = payload.get("config_provenance")
+    provenance_obj: object | None = payload.get("config_provenance")
     assert is_mapping(provenance_obj)
     provenance: dict[str, object] = as_object_dict(provenance_obj)
 
-    layers_obj = provenance.get("config_layers")
+    layers_obj: object | None = provenance.get("config_layers")
     assert is_any_list(layers_obj)
 
     matching_layers: list[dict[str, object]] = []
@@ -292,7 +387,7 @@ def test_config_dump_ndjson_kinds() -> None:
 
     record: dict[str, object] = parse_single_ndjson_record(result.output)
 
-    kind_obj = record.get("kind")
+    kind_obj: object | None = record.get("kind")
     assert isinstance(kind_obj, str)
     assert_ndjson_meta(record.get("meta"), expected_detail_level="brief")
     kinds: set[str] = {kind_obj}
@@ -320,13 +415,43 @@ def test_config_dump_ndjson_show_layers_kinds() -> None:
 
     assert record_kinds(records) == ["config_provenance", "config"]
 
-    provenance_obj = records[0].get("config_provenance")
+    provenance_obj: object | None = records[0].get("config_provenance")
     assert is_mapping(provenance_obj)
     provenance: dict[str, object] = as_object_dict(provenance_obj)
 
-    layers_obj = provenance.get("config_layers")
+    layers_obj: object | None = provenance.get("config_layers")
     assert is_any_list(layers_obj)
     assert layers_obj
+
+
+def test_config_dump_ndjson_show_layers_includes_discovery_anchor(tmp_path: Path) -> None:
+    """NDJSON config provenance should expose the resolved discovery anchor."""
+    workspace: Path = tmp_path / "workspace"
+    config_file: Path = workspace / "topmark.toml"
+    _write_minimal_config(config_file)
+
+    result: Result = run_cli_in(
+        workspace,
+        [
+            CliCmd.CONFIG,
+            CliCmd.CONFIG_DUMP,
+            CliOpt.SHOW_CONFIG_LAYERS,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
+        ],
+    )
+    assert_SUCCESS(result)
+
+    records: list[dict[str, object]] = parse_ndjson_records(result.output)
+    assert record_kinds(records) == ["config_provenance", "config"]
+
+    provenance_obj: object | None = records[0].get("config_provenance")
+    assert is_mapping(provenance_obj)
+    provenance: dict[str, object] = as_object_dict(provenance_obj)
+
+    discovery_anchor_obj: object | None = provenance.get("discovery_anchor")
+    assert isinstance(discovery_anchor_obj, str)
+    assert discovery_anchor_obj == workspace.resolve().as_posix()
 
 
 def test_config_dump_ndjson_show_layers_defaults_layer_shape() -> None:
@@ -351,11 +476,11 @@ def test_config_dump_ndjson_show_layers_defaults_layer_shape() -> None:
 
     assert first_record.get("kind") == "config_provenance"
 
-    provenance_obj = first_record.get("config_provenance")
+    provenance_obj: object | None = first_record.get("config_provenance")
     assert is_mapping(provenance_obj)
     provenance: dict[str, object] = as_object_dict(provenance_obj)
 
-    layers_obj = provenance.get("config_layers")
+    layers_obj: object | None = provenance.get("config_layers")
     assert is_any_list(layers_obj)
     layers: list[object] = layers_obj
     assert layers
@@ -368,5 +493,5 @@ def test_config_dump_ndjson_show_layers_defaults_layer_shape() -> None:
     assert first_layer.get("kind") == "default"
     assert first_layer.get("precedence") == 0
 
-    toml_obj = first_layer.get("toml")
+    toml_obj: object | None = first_layer.get("toml")
     assert is_mapping(toml_obj)

--- a/tests/toml/machine/test_toml_machine_payloads.py
+++ b/tests/toml/machine/test_toml_machine_payloads.py
@@ -24,6 +24,10 @@ from topmark.toml.parse import SourceConfigLoadingOptions
 from topmark.toml.parse import SourceTomlOptions
 from topmark.toml.resolution import ResolvedTopmarkTomlSource
 from topmark.toml.resolution import ResolvedTopmarkTomlSources
+from topmark.toml.schema import TOPMARK_TOML_SCHEMA
+from topmark.toml.schema import TomlSection
+from topmark.toml.schema import TomlValidationMode
+from topmark.toml.validation import TomlDiagnosticCode
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -31,6 +35,7 @@ if TYPE_CHECKING:
     from topmark.toml.machine.schemas import TomlProvenanceLayerPayload
     from topmark.toml.machine.schemas import TomlProvenancePayload
     from topmark.toml.types import TomlTable
+    from topmark.toml.validation import TomlValidationIssue
 
 
 @pytest.mark.pipeline
@@ -56,6 +61,7 @@ def test_toml_provenance_payload_uses_posix_paths_for_file_backed_layers(
         toml_fragment=toml_fragment,
     )
     resolved = ResolvedTopmarkTomlSources(
+        discovery_anchor=config_file.parent,
         sources=[
             ResolvedTopmarkTomlSource(
                 path=config_file,
@@ -78,3 +84,48 @@ def test_toml_provenance_payload_uses_posix_paths_for_file_backed_layers(
     file_backed_layer: TomlProvenanceLayerPayload = file_backed_layers[0]
     assert file_backed_layer.scope_root == config_file.parent.as_posix()
     assert file_backed_layer.toml[Toml.SECTION_FIELDS] == {"project": "Demo"}
+
+
+@pytest.mark.pipeline
+def test_toml_provenance_payload_uses_posix_path_for_discovery_anchor(
+    tmp_path: Path,
+) -> None:
+    """TOML provenance should serialize the discovery anchor POSIX-style."""
+    workspace: Path = tmp_path / "workspace"
+    resolved = ResolvedTopmarkTomlSources(
+        sources=[],
+        writer_options=None,
+        strict=None,
+        discovery_anchor=workspace,
+    )
+
+    payload: TomlProvenancePayload = build_toml_provenance_payload(resolved)
+
+    assert payload.discovery_anchor == workspace.as_posix()
+    assert payload.to_dict()["discovery_anchor"] == workspace.as_posix()
+
+
+@pytest.mark.pipeline
+def test_toml_schema_accepts_dump_only_keys_in_provenance_mode() -> None:
+    """Provenance validation should accept dump-only schema keys."""
+    issues: tuple[TomlValidationIssue, ...] = TOPMARK_TOML_SCHEMA.validate_section_keys(
+        TomlSection.CONFIG,
+        {Toml.KEY_CONFIG_FILES: ["/workspace/topmark.toml"]},
+        mode=TomlValidationMode.PROVENANCE,
+    )
+
+    assert issues == ()
+
+
+@pytest.mark.pipeline
+def test_toml_schema_rejects_dump_only_keys_in_input_mode() -> None:
+    """Input validation should reject dump-only schema keys."""
+    issues: tuple[TomlValidationIssue, ...] = TOPMARK_TOML_SCHEMA.validate_section_keys(
+        TomlSection.CONFIG,
+        {Toml.KEY_CONFIG_FILES: ["/workspace/topmark.toml"]},
+        mode=TomlValidationMode.INPUT,
+    )
+
+    assert len(issues) == 1
+    assert issues[0].code is TomlDiagnosticCode.DUMP_ONLY_KEY_IN_INPUT
+    assert issues[0].path == (TomlSection.CONFIG.value, Toml.KEY_CONFIG_FILES)


### PR DESCRIPTION
## Summary

Addresses #112 by exposing the resolved configuration-discovery anchor in
machine-readable provenance output.

The implementation adds a single provenance-oriented field:

- `config_provenance.discovery_anchor`

This field represents the resolved filesystem location from which
project-chain configuration discovery started.

## Design

The change intentionally preserves the distinctions established by the
configuration-discovery and identity-domain reviews:

- discovery anchor
- configuration-source identity
- scope root
- processing target
- filesystem identity

`discovery_anchor` is exported only as provenance metadata and does not alter:

- configuration-source precedence
- scope applicability
- configuration deduplication
- processing-path identity
- runtime configuration snapshots

## Implementation

- Added `discovery_anchor` to `ResolvedTopmarkTomlSources`
- Exported the value through TOML/config provenance payload generation
- Added machine-readable serialization support
- Updated machine-format and configuration-command documentation
- Preserved existing provenance-layer structure and semantics

## Regression Coverage

Added focused coverage for:

- JSON provenance serialization
- NDJSON provenance serialization
- omission when provenance is not requested
- TOML provenance serialization
- provenance-only schema validation behavior
- symlinked discovery-anchor resolution
- POSIX path-formatting expectations

## Compatibility

This is an additive machine-readable change.

Existing fields and semantics remain unchanged.

The new field is emitted only within provenance payloads and follows the
existing path-serialization contract.

Closes #112.

Related: #89, #102, #104, #105, #118