### PR TITLE
docs: complete documentation consistency review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ ______________________________________________________________________
   configuration-file target for precedence, scope applicability, layered provenance, and
   machine-readable configuration provenance.
 - Deduplicated repeated resolved configuration-source identities during TOML-side resolution,
-- Deduplicated repeated resolved configuration-source identities during TOML-side resolution,
   keeping the highest-precedence occurrence for layered configuration and provenance.
 - Extended machine-readable configuration provenance to expose the resolved configuration-discovery
   anchor separately from configuration-source identity, scope roots, processing targets, and
@@ -193,6 +192,10 @@ ______________________________________________________________________
   Actions pin audit, including the new `--fix` mode.
 - Documented that the filesystem CI job requires symlink capability through
   `TOPMARK_REQUIRE_SYMLINKS=1` on Ubuntu, macOS, and Windows.
+- Reviewed documentation clarity, consistency, governance, tooling, structure, duplication, and
+  snippet usage for issue #108.
+- Synchronized documentation-governance guidance with the current generated-reference layout and
+  snippet inventory.
 
 ### Internal - Unreleased
 
@@ -235,6 +238,7 @@ ______________________________________________________________________
   replacement behavior.
 - Added a `TOPMARK_REQUIRE_SYMLINKS` test-helper guard so symlink-dependent tests fail loudly in CI
   jobs that are expected to exercise symlink behavior.
+- Aligned generated API-page tooling prose with the current generated documentation path layout.
 
 ### Notes - Unreleased
 

--- a/docs/dev/documentation-conventions.md
+++ b/docs/dev/documentation-conventions.md
@@ -667,20 +667,27 @@ content composition.
 
 Reusable snippets live in `docs/_snippets/`.
 
-| Snippet                       | Purpose                                                                                                                          | Status           |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `api-internal-overrides.md`   | Explains the API-only internal override boundary for configuration behavior.                                                     | Keep             |
-| `config-strictness.md`        | Defines the short reusable staged config-loading strictness contract.                                                            | Keep             |
-| `file-type-identifiers.md`    | Defines the short reusable local/qualified file type identifier contract.                                                        | Keep             |
-| `option-spelling.md`          | Explains CLI, TOML, and API option spelling conventions.                                                                         | Keep             |
-| `output-contract.md`          | Defines shared TEXT, quiet-mode, Markdown, and machine-readable output guarantees for commands that support quiet mode.          | Keep             |
-| `output-contract-no-quiet.md` | Defines shared TEXT, Markdown, and machine-readable output guarantees for informational commands that do not support quiet mode. | Keep             |
-| `report-scope.md`             | Defines shared report-scope behavior for sibling mutation commands.                                                              | Keep but monitor |
-| `terminology.md`              | Defines the shared terminology note that links to the project-wide canonical vocabulary page.                                    | Keep             |
-| `ci/related-pages.md`         | Defines the shared related-pages block for CI workflow documentation pages.                                                      | Keep             |
+| Snippet                          | Purpose                                                                                                                          | Status           |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `api-internal-overrides.md`      | Explains the API-only internal override boundary for configuration behavior.                                                     | Keep             |
+| `config-strictness.md`           | Defines the short reusable staged config-loading strictness contract.                                                            | Keep             |
+| `file-type-identifiers.md`       | Defines the short reusable local/qualified file type identifier contract.                                                        | Keep             |
+| `option-spelling.md`             | Explains CLI, TOML, and API option spelling conventions.                                                                         | Keep             |
+| `output-contract.md`             | Defines shared TEXT, quiet-mode, Markdown, and machine-readable output guarantees for commands that support quiet mode.          | Keep             |
+| `output-contract-no-quiet.md`    | Defines shared TEXT, Markdown, and machine-readable output guarantees for informational commands that do not support quiet mode. | Keep             |
+| `path-serialization-contract.md` | Defines the shared path serialization presentation contract and distinguishes it from filesystem identity.                       | Keep             |
+| `report-scope.md`                | Defines shared report-scope behavior for sibling mutation commands.                                                              | Keep but monitor |
+| `runtime-configuration-model.md` | Defines the short layered runtime-configuration model reused by configuration overview pages.                                    | Keep             |
+| `runtime-validation-model.md`    | Defines the short staged runtime-validation model reused by policy and pre-commit pages.                                         | Keep             |
+| `terminology.md`                 | Defines the shared terminology note that links to the project-wide canonical vocabulary page.                                    | Keep             |
+| `ci/related-pages.md`            | Defines the shared related-pages block for CI workflow documentation pages.                                                      | Keep             |
 
 `docs/_snippets/.markdownlint.jsonc` configures Markdown linting for snippet files and is not a
 reusable content snippet.
+
+Keep this inventory synchronized with `docs/_snippets/` whenever snippets are added, removed, or
+repurposed. The inventory is intentionally human-maintained because it records why a snippet exists,
+not just whether the file is present.
 
 ### Appropriate snippet usage
 

--- a/docs/dev/documentation-pipeline.md
+++ b/docs/dev/documentation-pipeline.md
@@ -156,8 +156,11 @@ Public API stability expectations and snapshot validation are documented in:
 Generated from live TopMark output:
 
 ```text
-usage/generated-filetypes.md
-usage/generated-processors.md
+usage/generated/filetypes.md
+usage/generated/processors.md
+usage/generated/bindings.md
+configuration/generated/example-config.md
+configuration/generated/config-defaults.md
 ```
 
 via:

--- a/tools/docs/gen_api_pages.py
+++ b/tools/docs/gen_api_pages.py
@@ -181,7 +181,7 @@ def generate_cli_reference_pages() -> None:
         """Write a standalone generated Markdown page under `docs/`.
 
         Args:
-            dest: Docs-relative output path (e.g. `usage/generated-filetypes.md`).
+            dest: Docs-relative output path (e.g. `usage/generated/filetypes.md`).
             title: Page title to render at the top.
             body: Pre-rendered Markdown emitted by `topmark ... --output-format markdown`.
         """


### PR DESCRIPTION
## Summary

- Reviewed the documentation tree for issue #108 across user docs, configuration docs, CI docs, developer docs, generated reference pages, snippets, and repository-level docs.
- Audited documentation governance against `docs/dev/documentation-conventions.md` and `docs/dev/documentation-pipeline.md`.
- Confirmed the existing docs hygiene tooling already covers the main validation needs for this scope.
- Updated documentation-governance prose to match the current generated-reference layout and snippet inventory.
- Aligned generated API-page tooling prose with the current generated docs path layout.
- Cleaned up a duplicate Unreleased changelog bullet around configuration-source identity deduplication.

## Outcome

This closes the documentation clarity and consistency review for #108 without introducing a larger documentation-system redesign. Roadmap-specific observations remain input for #107.

## Issue Resolution

Closes #108.

The review found only minor documentation-governance drift (stale snippet inventory
and generated-reference path references). No significant structural, governance,
or tooling deficiencies were identified. Existing documentation hygiene tooling
was found to provide adequate coverage for the issues reviewed.