### PR TITLE
ci(workflows): reduce superseded PR runs

### DIFF
--- a/.github/workflows/action-pin-audit.yml
+++ b/.github/workflows/action-pin-audit.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   audit-action-pins:
     name: Audit action pin consistency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ name: CI
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     paths:
@@ -46,6 +50,9 @@ jobs:
   changes:
     name: Detect changed file groups
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       python_changed: ${{ steps.filter.outputs.python }}
       docs_changed: ${{ steps.filter.outputs.docs }}
@@ -108,11 +115,24 @@ jobs:
               - 'README.md'
               - 'INSTALL.md'
               - 'CONTRIBUTING.md'
+      - name: Report changed file groups
+        shell: bash
+        run: |
+          {
+            echo "## Changed file groups"
+            echo
+            echo "| Group          | Changed                                    |"
+            echo "| -------------- | ------------------------------------------ |"
+            echo "| Python         | ${{ steps.filter.outputs.python }}         |"
+            echo "| Documentation  | ${{ steps.filter.outputs.docs }}           |"
+            echo "| Markdown links | ${{ steps.filter.outputs.markdown_links }} |"
+            echo "| Pre-commit     | ${{ steps.filter.outputs.precommit }}      |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - run: echo "python_changed=${{ steps.filter.outputs.python }}"
-      - run: echo "docs_changed=${{ steps.filter.outputs.docs }}"
-      - run: echo "markdown_links_changed=${{ steps.filter.outputs.markdown_links }}"
-      - run: echo "precommit_changed=${{ steps.filter.outputs.precommit }}"
+          echo "python_changed=${{ steps.filter.outputs.python }}"
+          echo "docs_changed=${{ steps.filter.outputs.docs }}"
+          echo "markdown_links_changed=${{ steps.filter.outputs.markdown_links }}"
+          echo "precommit_changed=${{ steps.filter.outputs.precommit }}"
 
   python-metadata:
     name: Resolve Python metadata
@@ -181,6 +201,8 @@ jobs:
     needs: [changes, python-metadata]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.precommit_changed == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -372,6 +394,8 @@ jobs:
     needs: [changes, python-metadata, tests]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.python_changed == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -448,6 +472,9 @@ jobs:
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.markdown_links_changed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -464,6 +491,9 @@ jobs:
     needs: [changes, python-metadata]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_changed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ ______________________________________________________________________
   action refs using an already-present preferred pinned ref selected from version-comment metadata.
 - Required symlink-dependent regression tests to execute in the cross-platform filesystem CI job
   instead of silently skipping when symlink creation is unavailable.
+- Added workflow-level concurrency for CI and GitHub Actions pin-audit pull-request runs so
+  superseded PR commits cancel older in-progress runs while preserving `main`, scheduled, manual,
+  and release-tag validation.
+- Clarified CI workflow maintainability by adding explicit job-level permissions for selected
+  third-party-action jobs, bounded link-check jobs with explicit timeouts, and summarized
+  path-filter decisions in the GitHub Actions step summary.
 
 ### Breaking Changes - Unreleased
 

--- a/docs/ci/action-pin-audit.md
+++ b/docs/ci/action-pin-audit.md
@@ -62,7 +62,10 @@ ______________________________________________________________________
 | `workflow_dispatch` | Manual maintainer run                                               | Run the audit on demand                  |
 | `pull_request`      | Pull requests affecting workflows, local actions, or the audit tool | Detect pin inconsistencies before merge  |
 
-Pull-request runs are path-filtered so unrelated repository changes do not trigger the audit.
+Pull-request runs are path-filtered so unrelated repository changes do not trigger the audit. They
+also use workflow-level concurrency keyed by pull-request number. New pushes to the same pull
+request cancel older in-progress audit runs. Scheduled and manual runs are keyed by their Git ref
+and are not canceled once running.
 
 The workflow monitors:
 

--- a/docs/ci/ci-workflow.md
+++ b/docs/ci/ci-workflow.md
@@ -41,10 +41,18 @@ ______________________________________________________________________
 
 Pull-request runs are path-filtered at the workflow level so unrelated changes do not trigger CI.
 Within the workflow, the `changes` job performs finer-grained path filtering so jobs such as lint,
-tests, docs, link checks, pre-commit validation, and API snapshot checks run only when relevant.
+tests, docs, link checks, pre-commit validation, and API snapshot checks run only when relevant. It
+also writes a short GitHub Step Summary showing which changed-file groups were detected, making
+path-filtered job decisions easier to inspect from the workflow run.
 
 Version-tag pushes are not path-filtered by pull-request change groups. They run the
 release-artifact path after the required validation jobs succeed.
+
+The workflow also uses a workflow-level concurrency group keyed by the workflow name and either the
+pull-request number or Git ref. New pushes to the same pull request cancel older in-progress CI
+runs, so contributors see the latest failure signal without spending runner time on superseded
+commits. Pushes to `main` and version tags keep their in-progress runs instead of being canceled,
+preserving post-merge and release-tag validation.
 
 ______________________________________________________________________
 
@@ -57,8 +65,11 @@ permissions:
   contents: read
 ```
 
-The `release-artifacts` job also declares `contents: read` explicitly. The workflow does not publish
-packages, create releases, or request elevated release permissions.
+Jobs that use third-party actions or upload diagnostic artifacts declare the minimum required
+job-level permissions explicitly where useful. For example, the `changes` job grants read-only
+repository access plus read-only pull-request metadata access for path filtering, while link-check,
+pre-commit, coverage, and release-artifact jobs keep read-only repository permissions. The workflow
+does not publish packages, create releases, or request elevated release permissions.
 
 The trust boundary is intentional:
 
@@ -80,7 +91,7 @@ ______________________________________________________________________
 
 | Job                 | Purpose                                                                 | Main tools                                 |
 | ------------------- | ----------------------------------------------------------------------- | ------------------------------------------ |
-| `changes`           | Detect changed file groups for PR job gating                            | `dorny/paths-filter`                       |
+| `changes`           | Detect changed file groups for PR job gating and summarize the result   | `dorny/paths-filter`                       |
 | `python-metadata`   | Resolve supported and canonical Python versions for CI jobs             | `nox`, `pyproject.toml`                    |
 | `lint`              | Validate formatting, linting, typing, and docstring links               | `nox`, `ruff`, `pyright`                   |
 | `pre-commit`        | Run configured pre-commit hooks                                         | `pre-commit`                               |
@@ -252,6 +263,7 @@ failed from the job name and log output.
 When editing this workflow:
 
 - update path filters when adding new source, docs, tooling, or workflow-maintenance files;
+- keep path-filter summaries aligned with the changed-file groups emitted by the `changes` job;
 - keep nox sessions as the canonical stable validation contracts where practical;
 - keep Python-version metadata sourced from `pyproject.toml` through `nox -s print_python_matrix`;
 - keep the coverage job canonical and lightweight rather than instrumenting the full compatibility
@@ -264,6 +276,8 @@ When editing this workflow:
 - keep release artifact building in CI unless the release trust model is deliberately redesigned;
 - avoid moving package publication into this workflow;
 - keep generated-site link validation separate from source Markdown link validation;
+- keep link-check jobs bounded with explicit timeouts so network-dependent validation cannot hang
+  indefinitely;
 - keep action pins synchronized across workflows and local composite actions;
 - keep uv cache ownership explicit and centralized rather than mixing `setup-uv` cache management
   with separate `actions/cache` ownership.


### PR DESCRIPTION
## Summary

- Add workflow-level concurrency for CI and action-pin audit PR runs.
- Preserve `main`, scheduled, manual, and release-tag validation behavior.
- Add explicit job-level permissions for selected CI jobs using third-party actions.
- Add timeouts for source and built-site link-check jobs.
- Add a GitHub Step Summary for CI path-filter decisions.
- Update CI documentation and changelog entries.

## Context

This addresses the CI/workflow maintainability audit in #109, following the recent post-1.0 maintenance work in #106 / #123, #107 / #127, #108 / #125, and #112 / #124.

## Validation

- Review generated workflow YAML.
- Validate in a draft PR that superseded PR runs are canceled.
- Confirm `main`, tag, scheduled, and manual workflow runs are not unintentionally canceled.

Closes #109.