### PR TITLE
Add targeted runtime coverage for issue 129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,8 @@ ______________________________________________________________________
   directions, frozen 1.x contract areas, and GitHub issue-driven execution.
 - Updated `Road to TopMark 1.0` to distinguish historical stabilization decisions from post-1.0
   maintenance work, including the later completion of the Rich and `rich-click` migration.
+- Clarified pytest marker documentation by restoring the `case_insensitive_fs` marker entry and
+  fixing the malformed `pipeline` marker table row in CI test-validation guidance.
 
 ### Internal - Unreleased
 
@@ -255,6 +257,9 @@ ______________________________________________________________________
 - Added a `TOPMARK_REQUIRE_SYMLINKS` test-helper guard so symlink-dependent tests fail loudly in CI
   jobs that are expected to exercise symlink behavior.
 - Aligned generated API-page tooling prose with the current generated documentation path layout.
+- Added targeted coverage tests for coverage-strategy issue #129 across whitespace-policy helpers,
+  pipeline planning and stripping behavior, registry binding validation, and processor insertion
+  mixins.
 
 ### Notes - Unreleased
 

--- a/docs/ci/test-validation.md
+++ b/docs/ci/test-validation.md
@@ -81,18 +81,18 @@ ______________________________________________________________________
 
 Pytest markers are declared in `pyproject.toml` under `[tool.pytest.ini_options]`.
 
-| Marker                                                   | Purpose                                                                                            | CI expectation                                       |
-| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `api`                                                    | Tests that exercise the public API.                                                                | Included in normal test runs.                        |
-| `cli`                                                    | Tests that exercise the command-line interface.                                                    | Included in normal test runs.                        |
-| `config`                                                 | Tests for configuration deserialization, path normalization, strictness, and layer merge behavior. | Included in normal test runs.                        |
-| `dev_validation`                                         | Developer validation tests for internal invariants such as registry consistency.                   | Included in normal test runs.                        |
-| `exit_code`                                              | Tests that validate the CLI exit-code contract.                                                    | Included in normal test runs.                        |
-| `hypothesis_slow`                                        | Long-running property tests.                                                                       | Skipped in CI unless explicitly selected.            |
-| `integration`                                            | Environment-dependent integration checks, such as shell completion.                                | Run selectively where the environment supports them. |
-| `pipeline`                                               | Tests that exercise the processing pipeline, including filesystem-identity evaluation and          |                                                      |
-| processing-target eligibility behavior where applicable. | Included in normal test runs.                                                                      |                                                      |
-| `toml`                                                   | Tests for TopMark TOML loading, extraction, schema validation, and source resolution.              | Included in normal test runs.                        |
+| Marker                | Purpose                                                                                            | CI expectation                                       |
+| --------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `api`                 | Tests that exercise the public API.                                                                | Included in normal test runs.                        |
+| `case_insensitive_fs` | Tests for behavior that depends on case-insensitive filesystem semantics.                          | Run where the host filesystem can exercise them.     |
+| `cli`                 | Tests that exercise the command-line interface.                                                    | Included in normal test runs.                        |
+| `config`              | Tests for configuration deserialization, path normalization, strictness, and layer merge behavior. | Included in normal test runs.                        |
+| `dev_validation`      | Developer validation tests for internal invariants such as registry consistency.                   | Included in normal test runs.                        |
+| `exit_code`           | Tests that validate the CLI exit-code contract.                                                    | Included in normal test runs.                        |
+| `hypothesis_slow`     | Long-running property tests.                                                                       | Skipped in CI unless explicitly selected.            |
+| `integration`         | Environment-dependent integration checks, such as shell completion.                                | Run selectively where the environment supports them. |
+| `pipeline`            | Tests that exercise the processing pipeline, including filesystem-identity and target eligibility. | Included in normal test runs.                        |
+| `toml`                | Tests for TopMark TOML loading, extraction, schema validation, and source resolution.              | Included in normal test runs.                        |
 
 ______________________________________________________________________
 

--- a/tests/pipeline/steps/test_planner.py
+++ b/tests/pipeline/steps/test_planner.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from topmark.config.model import FrozenConfig
+    from topmark.filetypes.model import PreInsertContextView
     from topmark.pipeline.context.model import ProcessingContext
 
 
@@ -269,3 +270,93 @@ def test_planner_skips_when_content_status_blocks_update(tmp_path: Path) -> None
     assert ctx.views.updated is None
     assert ctx.halt_state is not None
     assert ctx.halt_state.reason_code == "Could not update file (status: unsupported)."
+
+
+def test_planner_fails_without_render_view(tmp_path: Path) -> None:
+    """Changed content cannot be planned when the renderer produced no header."""
+    ctx: ProcessingContext = _make_context(tmp_path / "missing_render.py")
+    ctx.views.image = ListFileImageView(["body\n"])
+    ctx.views.render = None
+
+    ctx = run_planner(ctx)
+
+    assert ctx.status.plan is PlanStatus.FAILED
+    assert ctx.views.updated is None
+    assert ctx.halt_state is not None
+    assert ctx.halt_state.reason_code == "Cannot update header: no rendered header available"
+
+
+def test_planner_fails_without_header_processor(tmp_path: Path) -> None:
+    """Rendered headers still require an assigned processor for insertion policy."""
+    ctx: ProcessingContext = _make_context(tmp_path / "missing_processor.py")
+    ctx.header_processor = None
+    _set_image_and_render(
+        ctx,
+        original_lines=["body\n"],
+        rendered_lines=["# header\n"],
+    )
+
+    ctx = run_planner(ctx)
+
+    assert ctx.status.plan is PlanStatus.FAILED
+    assert ctx.views.updated is None
+    assert ctx.halt_state is not None
+    assert ctx.halt_state.reason_code == "Cannot update header: no header processor assigned"
+
+
+def test_planner_identical_replacement_is_skipped(tmp_path: Path) -> None:
+    """Replacing a detected header with identical rendered lines is a no-op."""
+    ctx: ProcessingContext = _make_context(tmp_path / "identical_replace.py")
+    original_lines: list[str] = ["# header\n", "body\n"]
+    _set_image_and_render(
+        ctx,
+        original_lines=original_lines,
+        rendered_lines=["# header\n"],
+    )
+    ctx.status.header = HeaderStatus.DETECTED
+    ctx.views.header = HeaderView(
+        range=(0, 0),
+        lines=["# header\n"],
+        block="# header\n",
+        mapping={},
+    )
+
+    ctx = run_planner(ctx)
+
+    assert ctx.status.plan is PlanStatus.SKIPPED
+    assert materialize_updated_lines(ctx) == original_lines
+    assert ctx.halt_state is None
+
+
+def test_planner_enforces_authoritative_pre_insert_checker_skip(tmp_path: Path) -> None:
+    """A file-type pre-insert checker can authoritatively skip insertion."""
+    from tests.helpers.registry import make_file_type
+    from topmark.filetypes.model import InsertCapability
+    from topmark.filetypes.model import InsertCheckResult
+
+    def _skip_checker(ctx: PreInsertContextView) -> InsertCheckResult:
+        _: PreInsertContextView = ctx
+        return InsertCheckResult(
+            capability=InsertCapability.SKIP_POLICY,
+            reason="test policy refused insertion",
+            origin="tests.planner",
+        )
+
+    ctx: ProcessingContext = _make_context(tmp_path / "checker_skip.py")
+    ctx.file_type = make_file_type(
+        local_key="checker_skip",
+        extensions=[".py"],
+        pre_insert_checker=_skip_checker,
+    )
+    _set_image_and_render(
+        ctx,
+        original_lines=["body\n"],
+        rendered_lines=["# header\n"],
+    )
+
+    ctx = run_planner(ctx)
+
+    assert ctx.status.plan is PlanStatus.SKIPPED
+    assert materialize_updated_lines(ctx) == ["body\n"]
+    assert ctx.halt_state is not None
+    assert ctx.halt_state.reason_code == "test policy refused insertion (origin: tests.planner)"

--- a/tests/pipeline/steps/test_stripper.py
+++ b/tests/pipeline/steps/test_stripper.py
@@ -327,3 +327,194 @@ def test_stripper_preserves_leading_bom_on_remaining_body(tmp_path: Path) -> Non
 
     assert ctx.status.strip is StripStatus.READY
     assert materialize_updated_lines(ctx) == ["\ufeffbody\n"]
+
+
+class _NoopEmptyStripProcessor(HeaderProcessor):
+    """Processor stub that reports an empty/no-op strip result."""
+
+    namespace = "test"
+    local_key = "noop_empty_strip"
+
+    def strip_header_block(
+        self,
+        *,
+        lines: list[str],
+        span: tuple[int, int] | None = None,
+        newline_style: str = "\n",
+        ends_with_newline: bool | None = None,
+    ) -> StripHeaderResult:
+        """Return a NOOP_EMPTY diagnostic."""
+        return StripHeaderResult(
+            lines=lines,
+            removed_span=None,
+            diagnostic=StripDiagnostic(
+                kind=StripDiagKind.NOOP_EMPTY,
+                reason="stub empty no-op",
+            ),
+        )
+
+
+class _MalformedRefusedStripProcessor(HeaderProcessor):
+    """Processor stub that refuses malformed header removal."""
+
+    namespace = "test"
+    local_key = "malformed_refused_strip"
+
+    def strip_header_block(
+        self,
+        *,
+        lines: list[str],
+        span: tuple[int, int] | None = None,
+        newline_style: str = "\n",
+        ends_with_newline: bool | None = None,
+    ) -> StripHeaderResult:
+        """Return a MALFORMED_REFUSED diagnostic."""
+        return StripHeaderResult(
+            lines=lines,
+            removed_span=None,
+            diagnostic=StripDiagnostic(
+                kind=StripDiagKind.MALFORMED_REFUSED,
+                reason="stub malformed refused",
+            ),
+        )
+
+
+class _RemovedWithWhitespaceBodyStripProcessor(HeaderProcessor):
+    """Processor stub that leaves user whitespace after removal."""
+
+    namespace = "test"
+    local_key = "removed_with_whitespace_body_strip"
+
+    def strip_header_block(
+        self,
+        *,
+        lines: list[str],
+        span: tuple[int, int] | None = None,
+        newline_style: str = "\n",
+        ends_with_newline: bool | None = None,
+    ) -> StripHeaderResult:
+        """Return a removed header with a whitespace-only body line remaining."""
+        return StripHeaderResult(
+            lines=[" \n", "body\n"],
+            removed_span=(0, 2),
+            diagnostic=StripDiagnostic(
+                kind=StripDiagKind.REMOVED,
+                reason="stub removed",
+            ),
+        )
+
+
+class _RemovedWithoutSpanStripProcessor(HeaderProcessor):
+    """Processor stub that reports removal without a removed span."""
+
+    namespace = "test"
+    local_key = "removed_without_span_strip"
+
+    def strip_header_block(
+        self,
+        *,
+        lines: list[str],
+        span: tuple[int, int] | None = None,
+        newline_style: str = "\n",
+        ends_with_newline: bool | None = None,
+    ) -> StripHeaderResult:
+        """Return changed lines with an invalid missing span."""
+        return StripHeaderResult(
+            lines=lines[1:],
+            removed_span=None,
+            diagnostic=StripDiagnostic(
+                kind=StripDiagKind.REMOVED,
+                reason="stub removed without span",
+            ),
+        )
+
+
+def test_stripper_empty_image_is_not_needed(tmp_path: Path) -> None:
+    """A processable but empty image has no removable header."""
+    ctx: ProcessingContext = _make_strip_context(tmp_path / "empty.py", [])
+
+    ctx = run_stripper(ctx)
+
+    assert ctx.status.strip is StripStatus.NOT_NEEDED
+    assert ctx.views.updated is None
+    assert ctx.halt_state is None
+
+
+def test_stripper_noop_empty_diagnostic_is_not_needed(tmp_path: Path) -> None:
+    """Processor NOOP_EMPTY diagnostics should not produce updated lines."""
+    ctx: ProcessingContext = _make_strip_context(tmp_path / "noop.py", ["\n"])
+    ctx.header_processor = _NoopEmptyStripProcessor()
+    ctx.status.header = HeaderStatus.EMPTY
+
+    ctx = run_stripper(ctx)
+
+    assert ctx.status.strip is StripStatus.NOT_NEEDED
+    assert ctx.views.updated is None
+    assert ctx.halt_state is None
+
+
+def test_stripper_malformed_refused_diagnostic_halts_without_update(tmp_path: Path) -> None:
+    """Processor MALFORMED_REFUSED diagnostics are policy blocks, not removals."""
+    ctx: ProcessingContext = _make_strip_context(tmp_path / "refused.py", ["# broken\n"])
+    ctx.header_processor = _MalformedRefusedStripProcessor()
+    ctx.status.header = HeaderStatus.EMPTY
+
+    ctx = run_stripper(ctx)
+
+    assert ctx.status.strip is StripStatus.NOT_NEEDED
+    assert ctx.views.updated is None
+    assert ctx.halt_state is not None
+    assert ctx.halt_state.reason_code == "stub malformed refused"
+
+
+def test_stripper_removed_without_span_is_treated_as_not_needed(tmp_path: Path) -> None:
+    """A processor must provide a removed span for strip normalization to proceed."""
+    ctx: ProcessingContext = _make_strip_context(
+        tmp_path / "missing_span.py",
+        ["# header\n", "body\n"],
+    )
+    ctx.header_processor = _RemovedWithoutSpanStripProcessor()
+    ctx.views.header = HeaderView(
+        range=(0, 0),
+        lines=["# header\n"],
+        block="# header\n",
+        mapping={},
+    )
+
+    ctx = run_stripper(ctx)
+
+    assert ctx.status.strip is StripStatus.NOT_NEEDED
+    assert ctx.views.updated is None
+    assert ctx.halt_state is None
+
+
+def test_stripper_drops_only_owned_exact_blank_separator(tmp_path: Path) -> None:
+    """Strip removes an owned exact blank after the header but preserves user whitespace."""
+    from tests.helpers.registry import make_file_type
+    from topmark.filetypes.policy import FileTypeHeaderPolicy
+
+    lines: list[str] = [
+        f"# {TOPMARK_START_MARKER}\n",
+        "# h\n",
+        f"# {TOPMARK_END_MARKER}\n",
+        " \n",
+        "body\n",
+    ]
+    ctx: ProcessingContext = _make_strip_context(tmp_path / "spacer.py", lines)
+    ctx.header_processor = _RemovedWithWhitespaceBodyStripProcessor()
+    ctx.file_type = make_file_type(
+        local_key="spacer_policy",
+        extensions=[".py"],
+        header_policy=FileTypeHeaderPolicy(ensure_blank_after_header=True),
+    )
+    ctx.views.header = HeaderView(
+        range=(0, 2),
+        lines=lines[:3],
+        block="".join(lines[:3]),
+        mapping={},
+    )
+
+    ctx = run_stripper(ctx)
+
+    assert ctx.status.strip is StripStatus.READY
+    assert materialize_updated_lines(ctx) == [" \n", "body\n"]

--- a/tests/pipeline/test_policy_whitespace.py
+++ b/tests/pipeline/test_policy_whitespace.py
@@ -1,0 +1,93 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_policy_whitespace.py
+#   file_relpath : tests/pipeline/test_policy_whitespace.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for policy-aware whitespace classification helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from topmark.filetypes.policy import BlankCollapseMode
+from topmark.filetypes.policy import FileTypeHeaderPolicy
+from topmark.pipeline.policy_whitespace import is_effectively_empty_body
+from topmark.pipeline.policy_whitespace import is_pure_spacer
+
+
+def test_pure_spacer_uses_strict_defaults_without_policy() -> None:
+    """Default spacer classification preserves control characters."""
+    assert is_pure_spacer("", None) is True
+    assert is_pure_spacer("\n", None) is True
+    assert is_pure_spacer(" \t\r\n", None) is True
+    assert is_pure_spacer("\ufeff \t\n", None) is True
+    assert is_pure_spacer("\x0c\n", None) is False
+
+
+def test_pure_spacer_unicode_policy_accepts_unicode_whitespace() -> None:
+    """UNICODE mode treats non-ASCII whitespace as blank content."""
+    policy = FileTypeHeaderPolicy(blank_collapse_mode=BlankCollapseMode.UNICODE)
+
+    assert is_pure_spacer("\u2003\n", policy) is True
+    assert is_pure_spacer("\x0c\n", policy) is True
+    assert is_pure_spacer("x\n", policy) is False
+
+
+def test_pure_spacer_none_policy_preserves_non_empty_lines() -> None:
+    """NONE mode still accepts empty/EOL-only lines but preserves contentful whitespace."""
+    policy = FileTypeHeaderPolicy(blank_collapse_mode=BlankCollapseMode.NONE)
+
+    assert is_pure_spacer("\n", policy) is True
+    assert is_pure_spacer(" \n", policy) is False
+    assert is_pure_spacer("\ufeff\n", policy) is False
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [BlankCollapseMode.STRICT, BlankCollapseMode.UNICODE],
+)
+def test_pure_spacer_respects_extra_collapsible_characters(mode: BlankCollapseMode) -> None:
+    """Extra collapse characters extend both strict and unicode policies."""
+    policy = FileTypeHeaderPolicy(blank_collapse_mode=mode, blank_collapse_extra="-")
+
+    assert is_pure_spacer("---\n", policy) is True
+    assert is_pure_spacer("--x\n", policy) is False
+
+
+def test_effectively_empty_body_uses_strict_defaults_without_policy() -> None:
+    """Default empty-body checks preserve control characters such as form-feed."""
+    assert is_effectively_empty_body(["", "\ufeff", " \t\n"], None) is True
+    assert is_effectively_empty_body([" \t\n", "\x0c\n"], None) is False
+
+
+def test_effectively_empty_body_honors_unicode_policy() -> None:
+    """UNICODE mode allows Unicode whitespace-only bodies to collapse."""
+    policy = FileTypeHeaderPolicy(blank_collapse_mode=BlankCollapseMode.UNICODE)
+
+    assert is_effectively_empty_body(["\u2003\n", "\x0c\n"], policy) is True
+    assert is_effectively_empty_body(["\u2003x\n"], policy) is False
+
+
+def test_effectively_empty_body_honors_none_policy() -> None:
+    """NONE mode treats every non-empty body line as meaningful content."""
+    policy = FileTypeHeaderPolicy(blank_collapse_mode=BlankCollapseMode.NONE)
+
+    assert is_effectively_empty_body([""], policy) is True
+    assert is_effectively_empty_body(["\n"], policy) is False
+    assert is_effectively_empty_body([" \n"], policy) is False
+
+
+def test_effectively_empty_body_respects_extra_collapsible_characters() -> None:
+    """Extra collapse characters can opt selected content into empty-body treatment."""
+    policy = FileTypeHeaderPolicy(
+        blank_collapse_mode=BlankCollapseMode.STRICT,
+        blank_collapse_extra="-",
+    )
+
+    assert is_effectively_empty_body(["---\n", "\ufeff-\r\n"], policy) is True
+    assert is_effectively_empty_body(["--x\n"], policy) is False

--- a/tests/processors/test_mixins.py
+++ b/tests/processors/test_mixins.py
@@ -159,3 +159,152 @@ def test_block_padding_ensures_trailing_newline() -> None:
     lines = ["/*", " header ", "*/"]
     out = b.ensure_block_padding(lines, newline="\n")
     assert out[-1].endswith("\n")
+
+
+def test_line_render_header_line_uses_optional_suffix() -> None:
+    """Line comments with suffix delimiters append that suffix exactly once."""
+
+    class _SuffixProc(LineCommentMixin):
+        line_prefix = "-- "
+        line_suffix = " --"
+
+    assert _SuffixProc().render_header_line("payload") == "-- payload --"
+
+
+def test_line_mixin_invalid_encoding_regex_does_not_break_insertion() -> None:
+    """Invalid configured encoding regexes should fall back to shebang-only skipping."""
+
+    class _P(LineCommentMixin):
+        file_type: FileType
+        line_prefix = "# "
+
+    p = _P()
+    p.file_type = make_file_type(
+        local_key="invalid_regex",
+        extensions=[".py"],
+        filenames=[],
+        patterns=[],
+        description="",
+        header_policy=FileTypeHeaderPolicy(
+            supports_shebang=True,
+            encoding_line_regex="[",
+        ),
+    )
+
+    lines: list[str] = ["#!/usr/bin/env python\n", "# coding: utf-8\n", "print(1)\n"]
+    assert p.find_insertion_index(lines) == 1
+
+
+def test_line_prepare_header_for_insertion_adds_policy_spacers() -> None:
+    """Line insertion adds owned leading/trailing spacers when policy requests them."""
+
+    class _P(LineCommentMixin):
+        file_type: FileType
+        line_prefix = "# "
+
+    p = _P()
+    p.file_type = make_file_type(
+        local_key="line_spacing",
+        extensions=[".py"],
+        filenames=[],
+        patterns=[],
+        description="",
+        header_policy=FileTypeHeaderPolicy(
+            pre_header_blank_after_block=1,
+            ensure_blank_after_header=True,
+        ),
+    )
+
+    out: list[str] = p.prepare_header_for_insertion(
+        original_lines=["preamble\n", "body\n"],
+        insert_index=1,
+        rendered_header_lines=["# header\n"],
+        newline_style="\n",
+    )
+
+    assert out == ["\n", "# header\n", "\n"]
+
+
+def test_line_prepare_header_for_insertion_preserves_user_whitespace_body() -> None:
+    """Whitespace-only body lines are not mistaken for owned exact blank separators."""
+
+    class _P(LineCommentMixin):
+        file_type: FileType
+        line_prefix = "# "
+
+    p = _P()
+    p.file_type = make_file_type(
+        local_key="line_user_whitespace",
+        extensions=[".py"],
+        filenames=[],
+        patterns=[],
+        description="",
+        header_policy=FileTypeHeaderPolicy(ensure_blank_after_header=True),
+    )
+
+    out: list[str] = p.prepare_header_for_insertion(
+        original_lines=[" \n", "body\n"],
+        insert_index=0,
+        rendered_header_lines=["# header\n"],
+        newline_style="\n",
+    )
+
+    assert out == ["# header\n", "\n"]
+
+
+def test_xml_text_insertion_padding_uses_policy() -> None:
+    """XML text insertion pads around a char-offset header according to policy."""
+
+    class _P(XmlPositionalMixin):
+        file_type: FileType
+
+    p = _P()
+    p.file_type = make_file_type(
+        local_key="xml_text_spacing",
+        extensions=[".xml"],
+        filenames=[],
+        patterns=[],
+        description="",
+        header_policy=FileTypeHeaderPolicy(
+            pre_header_blank_after_block=1,
+            ensure_blank_after_header=True,
+        ),
+    )
+
+    out: str = p.prepare_header_for_insertion_text(
+        original_text="<root><child />",
+        insert_offset=len("<root>"),
+        rendered_header_text="<!-- header -->\n",
+        newline_style="\n",
+    )
+
+    assert out == "\n<!-- header -->\n\n"
+
+
+def test_xml_text_insertion_padding_respects_existing_newline_and_blank() -> None:
+    """XML text insertion should not duplicate existing newline or exact blank body."""
+
+    class _P(XmlPositionalMixin):
+        file_type: FileType
+
+    p = _P()
+    p.file_type = make_file_type(
+        local_key="xml_existing_spacing",
+        extensions=[".xml"],
+        filenames=[],
+        patterns=[],
+        description="",
+        header_policy=FileTypeHeaderPolicy(
+            pre_header_blank_after_block=1,
+            ensure_blank_after_header=True,
+        ),
+    )
+
+    out: str = p.prepare_header_for_insertion_text(
+        original_text="<root>\n\n<child />",
+        insert_offset=len("<root>\n"),
+        rendered_header_text="<!-- header -->\n",
+        newline_style="\n",
+    )
+
+    assert out == "<!-- header -->\n"

--- a/tests/registry/test_register_unregister.py
+++ b/tests/registry/test_register_unregister.py
@@ -101,3 +101,122 @@ def test_register_and_unregister_processors() -> None:
 
     FileTypeRegistry.unregister_by_local_key("tmp")
     assert "tmp" not in FileTypeRegistry.as_mapping_by_local_key()
+
+
+def test_binding_registry_rejects_unknown_processor() -> None:
+    """Binding a known file type to an unknown processor should fail explicitly."""
+    import pytest
+
+    from topmark.core.errors import ProcessorBindingError
+
+    ft: FileType = make_file_type(
+        local_key="tmp_unknown_processor",
+        extensions=[".tup"],
+        filenames=[],
+        patterns=[],
+        description="tmp unknown processor",
+    )
+
+    FileTypeRegistry.register(ft)
+    try:
+        with pytest.raises(ProcessorBindingError, match="Unknown processor qualified key"):
+            BindingRegistry.bind(
+                file_type_key=ft.qualified_key,
+                processor_key="pytest:missing_processor",
+            )
+    finally:
+        FileTypeRegistry.unregister_by_local_key(ft.local_key)
+
+
+def test_binding_registry_rejects_duplicate_binding() -> None:
+    """A file type cannot be rebound without removing the existing binding first."""
+    import pytest
+
+    from topmark.core.errors import ProcessorBindingError
+
+    ft: FileType = make_file_type(
+        local_key="tmp_duplicate_binding",
+        extensions=[".tdb"],
+        filenames=[],
+        patterns=[],
+        description="tmp duplicate binding",
+    )
+
+    class DuplicateBindingProcessor(HeaderProcessor):
+        namespace = "test"
+        local_key = "duplicate_binding_processor"
+
+    proc_def: ProcessorDefinition | None = None
+    FileTypeRegistry.register(ft)
+    try:
+        proc_def = HeaderProcessorRegistry.register(
+            processor_class=DuplicateBindingProcessor,
+        )
+        BindingRegistry.bind(
+            file_type_key=ft.qualified_key,
+            processor_key=proc_def.qualified_key,
+        )
+
+        with pytest.raises(ProcessorBindingError, match="already bound"):
+            BindingRegistry.bind(
+                file_type_key=ft.qualified_key,
+                processor_key=proc_def.qualified_key,
+            )
+    finally:
+        BindingRegistry.unbind(ft.qualified_key)
+        if proc_def is not None:
+            HeaderProcessorRegistry.unregister(proc_def.qualified_key)
+        FileTypeRegistry.unregister_by_local_key(ft.local_key)
+
+
+def test_binding_registry_unbind_reports_absent_binding() -> None:
+    """Unbinding an absent key should be an idempotent no-op signal."""
+    assert BindingRegistry.unbind("pytest:not_bound") is False
+
+
+def test_binding_registry_unbind_processor_removes_all_references() -> None:
+    """Unbinding by processor removes every effective binding referencing it."""
+    fts: list[FileType] = [
+        make_file_type(
+            local_key="tmp_bulk_unbind_a",
+            extensions=[".tba"],
+            filenames=[],
+            patterns=[],
+            description="tmp bulk a",
+        ),
+        make_file_type(
+            local_key="tmp_bulk_unbind_b",
+            extensions=[".tbb"],
+            filenames=[],
+            patterns=[],
+            description="tmp bulk b",
+        ),
+    ]
+
+    class BulkUnbindProcessor(HeaderProcessor):
+        namespace = "test"
+        local_key = "bulk_unbind_processor"
+
+    proc_def: ProcessorDefinition | None = None
+    for ft in fts:
+        FileTypeRegistry.register(ft)
+    try:
+        proc_def = HeaderProcessorRegistry.register(processor_class=BulkUnbindProcessor)
+        for ft in fts:
+            BindingRegistry.bind(
+                file_type_key=ft.qualified_key,
+                processor_key=proc_def.qualified_key,
+            )
+
+        removed: tuple[str, ...] = BindingRegistry.unbind_processor(proc_def.qualified_key)
+
+        assert removed == tuple(sorted(ft.qualified_key for ft in fts))
+        assert all(BindingRegistry.get_processor_key(ft.qualified_key) is None for ft in fts)
+        assert not BindingRegistry.is_processor_bound(proc_def.qualified_key)
+    finally:
+        for ft in fts:
+            BindingRegistry.unbind(ft.qualified_key)
+        if proc_def is not None:
+            HeaderProcessorRegistry.unregister(proc_def.qualified_key)
+        for ft in fts:
+            FileTypeRegistry.unregister_by_local_key(ft.local_key)


### PR DESCRIPTION
## Summary

- Adds targeted coverage tests for the #129 test-quality and coverage-strategy review.
- Covers high-value runtime paths across:
  - whitespace-policy helpers;
  - pipeline planner behavior;
  - pipeline stripper diagnostics;
  - registry binding validation;
  - processor insertion mixins.
- Clarifies CI test-validation documentation for pytest markers, including `case_insensitive_fs` and `pipeline`.

## Validation

- Coverage improved from 89.1% to 90.0%.
- `pipeline/policy_whitespace.py` improved from 36.8% to 98.5%.
- `pipeline/steps/planner.py` improved from 70.3% to 80.5%.
- `pipeline/steps/stripper.py` improved from 65.3% to 74.2%.
- `processors/mixins.py` improved from 69.5% to 87.4%.
- `registry/bindings.py` improved from 79.0% to 90.8%.

```text
1450 passed, 5 skipped, 1 deselected
```

Closes #129.