### PR TITLE
Establish pipeline memory/allocation baselines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ coverage.xml
 coverage.json
 htmlcov/
 
+# Performance audit
+artifacts/perf
+
 # PyPI config
 .pypirc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,30 @@ ______________________________________________________________________
 
 ## [Unreleased]
 
+> [!CAUTION] **Breaking changes**
+>
+> This release includes breaking changes to CLI exit-code semantics, `config check` validation
+> failures, option-like path parsing, machine-readable processing-result path serialization, and
+> filename-rule validation/normalization. Consumers should review the **Breaking Changes** and
+> **Notes** sections before upgrading automation, CI jobs, golden tests, or plugin/custom file-type
+> definitions.
+>
+> In particular, `WOULD_CHANGE` now exits with code `3` instead of `2`; Click parser-level usage
+> errors reserve exit code `2`; JSON/NDJSON `check` and `strip` result paths use POSIX `/`
+> separators on all platforms; and invalid `FileType.filenames` rules are rejected during file-type
+> construction.
+
+### Added - Unreleased
+
+- Added `tools/perf/pipeline_memory_baseline.py`, a measurement-only benchmarking tool for
+  establishing memory and allocation baselines for pipeline processing.
+- Added `docs/dev/performance-baselines.md` documenting benchmark methodology, workload definitions,
+  measurement scope, benchmark output layout, and initial baseline results.
+- Added canonical benchmark suites (`smoke`, `pathological`, and `baseline`) together with preserved
+  run metadata, JSON reports, and Markdown summaries under `artifacts/perf/`.
+- Added a local `perf_baseline` Nox session and `make perf-baseline` entry point for reproducible
+  memory/allocation baseline generation.
+
 ### Changed - Unreleased
 
 - Replaced the CLI presentation backend with Rich.
@@ -214,6 +238,11 @@ ______________________________________________________________________
   maintenance work, including the later completion of the Rich and `rich-click` migration.
 - Clarified pytest marker documentation by restoring the `case_insensitive_fs` marker entry and
   fixing the malformed `pipeline` marker table row in CI test-validation guidance.
+- Added dedicated performance-baseline documentation covering subprocess-isolated RSS measurement,
+  tracemalloc methodology, benchmark-corpus scope, benchmark preservation guidance, and initial
+  memory-baseline findings from issue #134.
+- Added cross-references from development and CI documentation to the performance-baseline workflow
+  and benchmark methodology.
 
 ### Internal - Unreleased
 
@@ -260,6 +289,10 @@ ______________________________________________________________________
 - Added targeted coverage tests for coverage-strategy issue #129 across whitespace-policy helpers,
   pipeline planning and stripping behavior, registry binding validation, and processor insertion
   mixins.
+- Extended project validation tooling to type-check benchmark tooling under `tools/` and excluded
+  generated benchmark artifacts from Ruff scanning.
+- Added subprocess-isolated benchmark execution so per-scenario RSS measurements reflect individual
+  workload peaks rather than cumulative process high-water marks.
 
 ### Notes - Unreleased
 
@@ -285,6 +318,8 @@ ______________________________________________________________________
 - Hard-linked selected processing paths are now treated as unsupported processing targets. TopMark
   reports each affected path independently and does not choose a source, target, winner, or loser
   path from the hard-link group.
+- Performance baseline outputs are written to Git-ignored `artifacts/perf/` run directories and are
+  intended for local analysis rather than source control.
 
 ______________________________________________________________________
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
 	links links-all links-site links-src \
 	lint lint-fixall \
 	package-check \
+	perf-baseline \
 	property-test \
 	pytest pytest-full \
 	release-check release-full release-qa-api-% \
@@ -69,6 +70,7 @@ help:
 	@echo "  coverage        Run coverage testing"
 	@echo "  coverage-erase  Erase coverage testing output (.coverage coverage.xml coverage.json htmlcov .coverage.*)"
 	@echo "  property-test   Run Hypothesis hardening tests (manual, opt-in)"
+	@echo "  perf-baseline   Run pipeline memory/allocation baselines (manual, opt-in)"
 	@echo ""
 	@echo "  release-check   Run the deterministic pre-release gate (nox: release_check)"
 	@echo "  release-full    Run the full release gate incl. links + packaging + Python matrix"
@@ -185,6 +187,9 @@ pytest-full:
 
 property-test: check-venv
 	$(NOX) $(NOX_FLAGS) -s property_test
+
+perf-baseline: check-venv
+	$(NOX) $(NOX_FLAGS) -s perf_baseline
 
 docs-build: check-venv
 	$(NOX) $(NOX_FLAGS) -s docs

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -30,6 +30,9 @@ Repository-source validation starts in the main CI workflow and is delegated to 
 practical. The test suite is further organized with pytest markers so contributors can understand
 the intent and expected scope of each test group.
 
+Performance baseline measurements are documented separately because they are opt-in diagnostic
+workflows rather than correctness-validation or release-gating checks.
+
 - [CI workflow](./ci-workflow.md) - validates repository source trees, documentation, tests, typing,
   linting, API snapshots, and release artifacts produced from trusted CI runs.
 - [Setup Python + nox action](./setup-python-nox-action.md) - documents the shared Python, uv,
@@ -74,6 +77,7 @@ Use this family of pages as follows:
 | What runs on pull requests and pushes?                           | [CI workflow](./ci-workflow.md)                                     |
 | How are Python, uv, and nox bootstrapped in CI jobs?             | [Setup Python + nox action](./setup-python-nox-action.md)           |
 | Which tests are included, skipped, slow, or integration-focused? | [Test validation](./test-validation.md)                             |
+| How do I run memory/allocation baseline measurements?            | [Performance baselines](../dev/performance-baselines.md)            |
 | How are release artifacts produced and published?                | [Release workflow](./release-workflow.md)                           |
 | How do we validate packages after publication?                   | [Published artifact validation](./published-artifact-validation.md) |
 | How are dependency updates handled?                              | [Dependabot](./dependabot.md)                                       |
@@ -100,5 +104,7 @@ ______________________________________________________________________
 
 - [Contributing to TopMark](../contributing.md) - contributor workflow and dependency guidance
 - [Release process](../dev/release-process.md) - project-level release workflow and policy
+- [Performance baselines](../dev/performance-baselines.md) - memory and allocation benchmark
+  methodology and results
 - [`Configuration overview`](../configuration/index.md) - configuration entry point and links to
   discovery, precedence, and merge semantics

--- a/docs/ci/test-validation.md
+++ b/docs/ci/test-validation.md
@@ -23,12 +23,12 @@ validation path.
 
 ## Validation Layers
 
-| Layer            | Role                                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------ |
-| GitHub workflows | Repository, release, dependency, and published-artifact validation orchestration.          |
-| nox sessions     | Reusable validation contracts for linting, typing, tests, docs, links, and release checks. |
-| pytest markers   | Semantic grouping of tests by behavior, scope, or runtime expectations.                    |
-| Makefile targets | Local shortcuts for common contributor workflows.                                          |
+| Layer            | Role                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------- |
+| GitHub workflows | Repository, release, dependency, and published-artifact validation orchestration.                                 |
+| nox sessions     | Reusable validation contracts for linting, typing, tests, docs, links, release checks, and performance baselines. |
+| pytest markers   | Semantic grouping of tests by behavior, scope, or runtime expectations.                                           |
+| Makefile targets | Local shortcuts for common contributor workflows.                                                                 |
 
 The preferred mental model is:
 
@@ -215,6 +215,7 @@ Common mappings are:
 | Build documentation                               | `nox -s docs`                      |
 | Validate documentation links                      | `nox -s links`                     |
 | Run release checks                                | `nox -s release_check`             |
+| Run pipeline memory/allocation baselines          | `nox -s perf_baseline`             |
 
 The concrete canonical version shown above is expected to move when the supported Python range
 moves. CI consumes the JSON output from `print_python_matrix` so the test matrix and canonical
@@ -223,6 +224,32 @@ workflow.
 
 If a Makefile target wraps one of these commands, the nox session remains the canonical validation
 contract.
+
+______________________________________________________________________
+
+## Performance baseline measurements
+
+TopMark includes an opt-in performance baseline session for memory and allocation investigations.
+
+Run the canonical baseline suite:
+
+```bash
+nox -s perf_baseline
+```
+
+Or use the local convenience target:
+
+```bash
+make perf-baseline
+```
+
+The performance baseline tooling is intentionally separate from the normal quality gates.
+
+Performance measurements are exploratory diagnostics rather than correctness checks. They are not
+currently executed in CI and do not gate releases.
+
+See [Performance baselines](../dev/performance-baselines.md) for benchmark methodology, workload
+definitions, output layout, and baseline results.
 
 ______________________________________________________________________
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -50,6 +50,7 @@ plugin integration.
 - [Configuration schema](configuration-schema.md)
 - [Pipelines](pipelines.md)
 - [Pipelines reference hub](pipelines-reference.md)
+- [Performance baselines](performance-baselines.md) - memory and allocation measurement methodology
 
 ______________________________________________________________________
 

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -1,0 +1,293 @@
+<!--
+topmark:header:start
+
+  project      : TopMark
+  file         : performance-baselines.md
+  file_relpath : docs/dev/performance-baselines.md
+  license      : MIT
+  copyright    : (c) 2025 Olivier Biot
+
+topmark:header:end
+-->
+
+# Performance baselines
+
+This document describes the memory and allocation baseline methodology established for TopMark Track
+B performance work.
+
+The goal of these baselines is to measure current behavior before introducing optimizations. The
+measurements provide a factual reference for future work such as lazy updated-file composition,
+iterable-backed views, streaming writes, diff lifecycle improvements, and view-pruning changes.
+
+______________________________________________________________________
+
+## Scope
+
+The baseline tooling focuses on:
+
+- peak memory usage;
+- Python allocation behavior;
+- retained view ownership;
+- per-step timing;
+- diff-generation costs;
+- updated-file materialization costs.
+
+The tooling is intentionally measurement-only and does not modify pipeline architecture or ownership
+semantics.
+
+______________________________________________________________________
+
+## Benchmark tool
+
+The benchmark driver is:
+
+```text
+tools/perf/pipeline_memory_baseline.py
+```
+
+The script generates synthetic workloads, executes representative pipeline flows, and produces JSON
+and Markdown reports.
+
+______________________________________________________________________
+
+## Benchmark suites
+
+Three suites are currently defined.
+
+### Smoke
+
+Minimal validation suite used to confirm that the benchmark tooling is operational.
+
+```sh
+python tools/perf/pipeline_memory_baseline.py \
+    --suite smoke \
+    --run-id initial-smoke-baseline
+```
+
+### Pathological
+
+Exercises expected memory hotspots.
+
+Examples include:
+
+- huge headers;
+- large diffs;
+- large strip operations.
+
+```sh
+python tools/perf/pipeline_memory_baseline.py \
+    --suite pathological \
+    --run-id initial-pathological-baseline
+```
+
+### Baseline
+
+Comprehensive suite covering representative workloads.
+
+```sh
+python tools/perf/pipeline_memory_baseline.py \
+    --suite baseline \
+    --run-id initial-baseline-suite
+```
+
+A convenience target is also available:
+
+```sh
+make perf-baseline
+```
+
+which executes:
+
+```sh
+python tools/perf/pipeline_memory_baseline.py --suite baseline
+```
+
+______________________________________________________________________
+
+## Output layout
+
+Benchmark outputs are written below:
+
+```text
+artifacts/perf/
+```
+
+The directory is intentionally ignored by Git.
+
+A preserved benchmark run has the following structure:
+
+```text
+artifacts/perf/<run-id>/
+├── manifest.json
+├── report.json
+└── summary.md
+```
+
+Where:
+
+- `manifest.json` contains environment metadata;
+- `report.json` contains full measurement data;
+- `summary.md` contains a human-readable summary table.
+
+Benchmark outputs are not committed to the repository. Only the tooling, documentation, and
+conclusions derived from the measurements are version controlled.
+
+______________________________________________________________________
+
+## Measurement methodology
+
+### Traced allocations
+
+The benchmark tool uses Python's built-in `tracemalloc` module to collect:
+
+- peak traced allocations;
+- final traced allocations;
+- allocation growth throughout pipeline execution.
+
+### RSS measurements
+
+Resident Set Size (RSS) measurements are collected using platform-specific process statistics.
+
+Each scenario/mode pair is executed in a dedicated subprocess.
+
+This isolation is important because RSS measurements are typically reported as a process high-water
+mark. Running all scenarios inside a single Python process would make later measurements inherit
+memory peaks from earlier measurements.
+
+The benchmark report therefore records:
+
+```text
+measurement_isolation = "subprocess"
+```
+
+for the canonical baseline runs.
+
+### Retained views
+
+The benchmark tool records lightweight ownership indicators including:
+
+- image line counts;
+- header line counts;
+- rendered line counts;
+- updated line counts;
+- diff sizes;
+- retained views before pruning;
+- retained views after pruning.
+
+______________________________________________________________________
+
+## Baseline scenarios
+
+The current benchmark corpus includes:
+
+### Small workloads
+
+- 1 KB file without header
+- 10 KB file with header
+
+### Medium workloads
+
+- 100 KB file without header
+- 1 MB file without header
+
+### Pathological workloads
+
+- huge header
+- huge diff
+- insertion-oriented workload
+- large strip workload
+- mixed newline file
+- BOM file
+
+These scenarios were selected to exercise the primary materialization and retention points
+identified during the pipeline ownership audit.
+
+### Scope of current measurements
+
+The current benchmark corpus consists exclusively of single-file workloads.
+
+Each measurement represents:
+
+```text
+one generated file
+× one pipeline mode
+× one isolated Python subprocess
+```
+
+The baseline results therefore characterize per-file pipeline behavior and materialization costs.
+
+The current benchmark suite does not attempt to measure:
+
+- repository-scale traversal;
+- many-file batch execution;
+- cumulative `ProcessingContext` retention across files;
+- aggregate JSON or NDJSON serialization costs;
+- repeated small-file scaling behavior;
+- whole-run memory growth across large file sets.
+
+Those concerns may warrant additional benchmark suites in future performance work if optimization
+efforts extend beyond per-file pipeline processing.
+
+______________________________________________________________________
+
+## Initial findings
+
+The initial baseline measurements support the conclusions from the ownership audit.
+
+### Baseline results (issue #134)
+
+The following representative measurements were collected from the canonical baseline runs using
+subprocess-isolated RSS measurements.
+
+| Scenario                    | Mode         | Diff size | Peak traced |  Max RSS |
+| --------------------------- | ------------ | --------: | ----------: | -------: |
+| `small_1kb_missing_header`  | `check`      |       0 B |   374.3 KiB | 44.5 MiB |
+| `medium_1mb_missing_header` | `check_diff` |   2.0 MiB |    14.4 MiB | 63.4 MiB |
+| `huge_diff`                 | `strip_diff` |   1.9 MiB |    13.5 MiB | 62.8 MiB |
+| `strip_large_header`        | `strip_diff` |   2.3 MiB |    21.9 MiB | 80.1 MiB |
+
+The largest measured workload was `strip_large_header` in `strip_diff` mode. This scenario combines
+a very large detected header, updated-file generation, and diff creation, making it a useful
+upper-bound reference for current pipeline behavior.
+
+Observed hotspots include:
+
+1. diff generation and retention;
+1. updated-file materialization;
+1. large header scanning and ownership;
+1. original file image materialization.
+
+The largest measured cases were associated with diff-heavy workloads and large strip operations. In
+particular, `strip_large_header` / `strip_diff` produced the highest observed peak traced allocation
+(~21.9 MiB) and RSS (~80 MiB).
+
+The measurements therefore suggest that future optimization work should pay particular attention to:
+
+- diff lifecycle management (#138);
+- updated-file ownership and composition (#135, #136, #137);
+- view release timing and pruning (#140).
+
+______________________________________________________________________
+
+## Known caveats
+
+The benchmark corpus is synthetic.
+
+The workloads are designed to provide repeatable measurements and stress representative pipeline
+behavior. They are not intended to model every real-world repository.
+
+The benchmark results should therefore be interpreted as comparative baselines rather than absolute
+production-memory guarantees.
+
+______________________________________________________________________
+
+## Related issues
+
+- #133 Audit pipeline materialization points and memory ownership
+- #134 Establish memory and allocation baselines for pipeline processing
+- #135 Design lazy updated-file composition for pipeline updates
+- #136 Implement iterable-backed UpdatedView generation
+- #137 Stream updated content through WriterStep
+- #138 Audit diff-generation materialization and retention behavior
+- #140 Review view-pruning lifecycle and memory-release opportunities
+- #141 Evaluate alternative FileImageView implementations

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -162,6 +162,21 @@ measurement_isolation = "subprocess"
 
 for the canonical baseline runs.
 
+### Platform support
+
+RSS measurements currently rely on platform-specific process statistics.
+
+- Linux: RSS measurements are collected and reported.
+- macOS: RSS measurements are collected and reported.
+- Windows: RSS measurements are currently reported as unavailable (`None`).
+
+The benchmark framework continues to collect tracemalloc-based allocation metrics on Windows, but
+RSS values are omitted because the current implementation intentionally avoids introducing
+additional platform-specific dependencies solely for benchmark tooling.
+
+As a result, Windows benchmark runs remain useful for allocation analysis and relative comparisons,
+but RSS-based comparisons should be performed using Linux or macOS baseline runs.
+
 ### Retained views
 
 The benchmark tool records lightweight ownership indicators including:
@@ -270,6 +285,9 @@ The measurements therefore suggest that future optimization work should pay part
 ______________________________________________________________________
 
 ## Known caveats
+
+RSS availability is platform-dependent. Canonical RSS baselines are currently generated on Linux and
+macOS. Windows runs record allocation metrics but may report RSS values as unavailable.
 
 The benchmark corpus is synthetic.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -237,6 +237,7 @@ nav:
       - Configuration schema: dev/configuration-schema.md
       - Pipelines (concepts): dev/pipelines.md
       - Pipelines (reference hub): dev/pipelines-reference.md
+      - Performance baselines: dev/performance-baselines.md
       - API Stability: dev/api-stability.md
       - Machine-readable formats: dev/machine-formats.md
       - Documentation pipeline and reference hygiene: dev/documentation-pipeline.md

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,6 +30,7 @@ Sessions:
   - `qa_api`: Per-Python session that runs pytest + API snapshot + pyright in one env.
   - `api_snapshot`: Public API snapshot test (per Python).
   - `property_test`: Long-running property tests (opt-in).
+  - `perf_baseline`: Local pipeline memory/allocation baseline benchmarks (opt-in).
   - `package_check`: Build sdist/wheel and validate metadata (twine).
   - `release_check`: Deterministic pre-release gate (single Python, offline-friendly).
   - `release_full`: Full release gate (serial QA + links + packaging + matrix).
@@ -618,6 +619,24 @@ def property_test(session: nox.Session) -> None:
         "pytest",
         "-vv",
         "tests/pipeline/test_header_bounds_property.py",
+    )
+
+
+@nox.session(python=CANONICAL_PYTHON)
+def perf_baseline(session: nox.Session) -> None:
+    """Run local pipeline memory/allocation baseline benchmarks.
+
+    By default this runs the full `baseline` suite and writes a preserved run
+    under `artifacts/perf/`. Pass arguments after `--` to select another suite,
+    run id, or output directory.
+    """
+    session.install(DEPS_DEV)
+
+    args: list[str] = list(session.posargs) if session.posargs else ["--suite", "baseline"]
+    session.run(
+        "python",
+        "tools/perf/pipeline_memory_baseline.py",
+        *args,
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,6 +70,7 @@ CURRENT_PYTHON_VERSION: Final[str] = f"{sys.version_info[0]}.{sys.version_info[1
 
 DEPS_DEV: Final[str] = ".[dev,typing,test]"
 DEPS_DOCS: Final[str] = ".[docs]"
+DEPS_QA: Final[str] = ".[dev,typing,test,docs]"
 
 
 # Global options
@@ -227,7 +228,7 @@ def qa(session: nox.Session) -> None:
     """Run tests + pyright (per Python version)."""
     session.log("Supported Python versions: " + ", ".join(PYTHONS))
 
-    session.install(DEPS_DEV)
+    session.install(DEPS_QA)
 
     # We add *session.posargs to the end of the command
     session.run(
@@ -263,7 +264,7 @@ def qa_api(session: nox.Session) -> None:
     """
     session.log("Supported Python versions: " + ", ".join(PYTHONS))
 
-    session.install(DEPS_DEV)
+    session.install(DEPS_QA)
 
     # Main test suite (posargs forwarded, e.g. "-n auto")
     session.run(
@@ -657,8 +658,8 @@ def release_check(session: nox.Session) -> None:
       - Packaging build + metadata checks (build, twine)
       - Tests + pyright for the session Python
     """
-    # Tooling / QA deps
-    session.install(DEPS_DEV)
+    # Tooling / QA deps, including docs dependencies because pyright checks tools/docs/.
+    session.install(DEPS_QA)
     # Docs deps (mkdocs, plugins)
     session.install(DEPS_DOCS)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ final-period            = true
 
 # Pyright configuration
 [tool.pyright]
-include = ["src", "tests"]
+include = ["src", "tests", "tools"]
 exclude = [
   "**/__pycache__",
   "**/.*",
@@ -317,7 +317,7 @@ line-length = 100
   docstring-code-format = true
 
   [tool.ruff.lint]
-  exclude = [".git", ".venv", ".vscode", "build", "dist", "venv"]
+  exclude = [".git", ".venv", ".vscode", "artifacts", "build", "dist", "venv"]
   select = [
     "B",      # (flake8-bugbear)
     "B904",   # raise-without-from inside except

--- a/tools/perf/pipeline_memory_baseline.py
+++ b/tools/perf/pipeline_memory_baseline.py
@@ -1,0 +1,1092 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : pipeline_memory_baseline.py
+#   file_relpath : tools/perf/pipeline_memory_baseline.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Measure baseline memory behavior for TopMark pipeline processing.
+
+This script is intentionally measurement-only. It generates temporary benchmark
+files, runs selected TopMark pipeline variants against those files, and writes a
+JSON report containing elapsed time, tracemalloc peaks, RSS observations where
+available, per-step samples, and retained view summaries.
+
+The script avoids optional profiling dependencies so it can be used before the
+project decides whether tools such as memray or pympler are warranted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import gc
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from dataclasses import asdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Final
+from typing import Literal
+
+from topmark.api.runtime import select_pipeline
+from topmark.config.io.deserializers import mutable_config_from_defaults
+from topmark.config.policy import make_policy_registry
+from topmark.config.types import FileWriteStrategy
+from topmark.config.types import OutputTarget
+from topmark.core.typing_guards import as_object_dict
+from topmark.core.typing_guards import is_any_list
+from topmark.core.typing_guards import is_mapping
+from topmark.pipeline.context.model import ProcessingContext
+from topmark.runtime.model import RunOptions
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from collections.abc import Sequence
+    from resource import struct_rusage
+
+    from topmark.config.model import FrozenConfig
+    from topmark.config.model import MutableConfig
+    from topmark.config.policy import PolicyRegistry
+    from topmark.core.exit_codes import ExitCode
+    from topmark.pipeline.protocols import Step
+
+
+# Allow running this tool directly from a source checkout without requiring an editable install.
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+SRC_ROOT: Final[Path] = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+PipelineKind = Literal["check", "strip"]
+SuiteName = Literal["smoke", "baseline", "pathological"]
+ScenarioName = Literal[
+    "small_1kb_missing_header",
+    "small_10kb_existing_header",
+    "medium_100kb_missing_header",
+    "medium_1mb_missing_header",
+    "large_10mb_missing_header",
+    "huge_header",
+    "huge_diff",
+    "insert_near_end",
+    "strip_large_header",
+    "mixed_newlines",
+    "bom_file",
+]
+
+DEFAULT_SCENARIOS: Final[tuple[ScenarioName, ...]] = (
+    "small_1kb_missing_header",
+    "small_10kb_existing_header",
+    "medium_100kb_missing_header",
+    "medium_1mb_missing_header",
+    "huge_header",
+    "huge_diff",
+    "insert_near_end",
+    "strip_large_header",
+    "mixed_newlines",
+    "bom_file",
+)
+LARGE_SCENARIOS: Final[tuple[ScenarioName, ...]] = ("large_10mb_missing_header",)
+DEFAULT_MODES: Final[tuple[str, ...]] = (
+    "check",
+    "check_diff",
+    "check_apply",
+    "check_stdout",
+    "strip",
+    "strip_diff",
+)
+
+# Scenario and mode suites for --suite argument
+SUITE_SCENARIOS: Final[dict[SuiteName, tuple[ScenarioName, ...]]] = {
+    "smoke": ("small_1kb_missing_header",),
+    "baseline": (
+        "small_1kb_missing_header",
+        "small_10kb_existing_header",
+        "medium_100kb_missing_header",
+        "medium_1mb_missing_header",
+        "huge_header",
+        "huge_diff",
+        "insert_near_end",
+        "strip_large_header",
+        "mixed_newlines",
+        "bom_file",
+    ),
+    "pathological": ("huge_header", "huge_diff", "strip_large_header"),
+}
+SUITE_MODES: Final[dict[SuiteName, tuple[str, ...]]] = {
+    "smoke": ("check",),
+    "baseline": DEFAULT_MODES,
+    "pathological": ("check", "check_diff", "strip", "strip_diff"),
+}
+HEADER_LINES: Final[tuple[str, ...]] = (
+    "# topmark:header:start\n",
+    "#\n",
+    "#   project      : TopMarkPerf\n",
+    "#   file         : baseline.py\n",
+    "#   license      : MIT\n",
+    "#   copyright    : (c) 2025 TopMark\n",
+    "#\n",
+    "# topmark:header:end\n",
+)
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class RunDestination:
+    """Resolved output destination for a benchmark run."""
+
+    output_file: Path
+    output_dir: Path | None
+    run_id: str | None
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Scenario:
+    """Generated benchmark file description."""
+
+    name: ScenarioName
+    path: Path
+    size_bytes: int
+    description: str
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Mode:
+    """Pipeline mode to benchmark."""
+
+    name: str
+    kind: PipelineKind
+    apply: bool
+    diff: bool
+    output_target: OutputTarget
+    prune_views: bool
+    keep_diff_view: bool
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class StepSample:
+    """Memory and timing sample captured around one pipeline step."""
+
+    step: str
+    elapsed_ns: int
+    current_tracemalloc_bytes: int
+    peak_tracemalloc_bytes: int
+    rss_bytes: int | None
+    image_lines: int
+    header_lines: int
+    render_lines: int
+    updated_lines: int
+    diff_bytes: int
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class RunMeasurement:
+    """Measurement result for one scenario/mode pair."""
+
+    scenario: str
+    mode: str
+    file_size_bytes: int
+    elapsed_ns: int
+    peak_tracemalloc_bytes: int
+    final_tracemalloc_bytes: int
+    start_rss_bytes: int | None
+    end_rss_bytes: int | None
+    max_observed_rss_bytes: int | None
+    stdout_bytes: int
+    exit_code: str | None
+    status: dict[str, str]
+    views_before_prune: dict[str, int | bool]
+    views_after_prune: dict[str, int | bool]
+    steps: list[StepSample]
+
+
+def _rss_bytes() -> int | None:
+    """Return current process max RSS where the platform exposes it.
+
+    Returns:
+        RSS in bytes when available, otherwise `None`.
+    """
+    try:
+        import resource
+    except ImportError:
+        return None
+
+    usage: struct_rusage = resource.getrusage(resource.RUSAGE_SELF)
+    value = int(usage.ru_maxrss)
+    if sys.platform == "darwin":
+        return value
+    return value * 1024
+
+
+def _line_count(value: object) -> int:
+    """Best-effort count for sequence-like retained view payloads."""
+    if value is None:
+        return 0
+    if hasattr(value, "__len__"):
+        return len(value)  # type: ignore[arg-type]
+    return -1
+
+
+def _view_sizes(ctx: ProcessingContext) -> dict[str, int | bool]:
+    """Return lightweight retained-view size indicators for a context."""
+    image_lines: int = ctx.views.image.line_count() if ctx.views.image is not None else 0
+    header_lines: int = _line_count(ctx.views.header.lines) if ctx.views.header is not None else 0
+    render_lines: int = _line_count(ctx.views.render.lines) if ctx.views.render is not None else 0
+    updated_lines: int = (
+        _line_count(ctx.views.updated.lines) if ctx.views.updated is not None else 0
+    )
+    diff_text: str | None = ctx.views.diff.text if ctx.views.diff is not None else None
+    return {
+        "image_lines": image_lines,
+        "header_lines": header_lines,
+        "header_block_bytes": len(ctx.views.header.block.encode("utf-8"))
+        if ctx.views.header is not None and ctx.views.header.block is not None
+        else 0,
+        "render_lines": render_lines,
+        "render_block_bytes": len(ctx.views.render.block.encode("utf-8"))
+        if ctx.views.render is not None and ctx.views.render.block is not None
+        else 0,
+        "updated_lines": updated_lines,
+        "diff_bytes": len(diff_text.encode("utf-8")) if diff_text is not None else 0,
+        "has_build_view": ctx.views.build is not None,
+    }
+
+
+def _status_dict(ctx: ProcessingContext) -> dict[str, str]:
+    """Return compact final status values for one context."""
+    return {
+        "resolve": ctx.status.resolve.value,
+        "fs": ctx.status.fs.value,
+        "content": ctx.status.content.value,
+        "header": ctx.status.header.value,
+        "generation": ctx.status.generation.value,
+        "render": ctx.status.render.value,
+        "comparison": ctx.status.comparison.value,
+        "strip": ctx.status.strip.value,
+        "plan": ctx.status.plan.value,
+        "patch": ctx.status.patch.value,
+        "write": ctx.status.write.value,
+    }
+
+
+def _format_bytes(value: int | None) -> str:
+    """Format bytes as a compact human-readable string."""
+    if value is None:
+        return "n/a"
+    units = ("B", "KiB", "MiB", "GiB")
+    amount = float(value)
+    for unit in units:
+        if amount < 1024 or unit == units[-1]:
+            return f"{amount:.1f} {unit}" if unit != "B" else f"{value} B"
+        amount /= 1024
+    return f"{value} B"
+
+
+def _format_ms(elapsed_ns: int) -> str:
+    """Format nanoseconds as milliseconds."""
+    return f"{elapsed_ns / 1_000_000:.2f}"
+
+
+def _utc_run_id(suite: SuiteName | None) -> str:
+    """Return a timestamp-based run identifier."""
+    stamp: str = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    return f"{stamp}-{suite}" if suite is not None else stamp
+
+
+def _read_git_commit() -> str | None:
+    """Return the current Git commit when this checkout is inside a Git repository."""
+    head: Path = REPO_ROOT / ".git" / "HEAD"
+    try:
+        ref: str = head.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if ref.startswith("ref: "):
+        ref_path: Path = REPO_ROOT / ".git" / ref.removeprefix("ref: ")
+        try:
+            return ref_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+    return ref or None
+
+
+def _write_summary(path: Path, measurements: Sequence[RunMeasurement]) -> None:
+    """Write a compact Markdown summary for a benchmark run."""
+    lines: list[str] = [
+        "# TopMark pipeline memory baseline",
+        "",
+        "| Scenario | Mode | File size | Image lines | Updated lines | Diff size | Peak traced | "
+        "Max RSS | Elapsed ms |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for measurement in measurements:
+        lines.append(
+            "| "
+            f"{measurement.scenario} | "
+            f"{measurement.mode} | "
+            f"{_format_bytes(measurement.file_size_bytes)} | "
+            f"{measurement.views_before_prune['image_lines']} | "
+            f"{measurement.views_before_prune['updated_lines']} | "
+            f"{_format_bytes(int(measurement.views_before_prune['diff_bytes']))} | "
+            f"{_format_bytes(measurement.peak_tracemalloc_bytes)} | "
+            f"{_format_bytes(measurement.max_observed_rss_bytes)} | "
+            f"{_format_ms(measurement.elapsed_ns)} |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _resolve_destination(args: argparse.Namespace, *, suite: SuiteName | None) -> RunDestination:
+    """Resolve file and directory destinations for benchmark output."""
+    output: Path | None = args.output
+    output_dir: Path | None = args.output_dir
+    run_id: str | None = args.run_id
+
+    if output is not None and (output_dir is not None or run_id is not None):
+        raise ValueError("--output cannot be combined with --output-dir or --run-id")
+
+    if output is not None:
+        return RunDestination(output_file=output, output_dir=None, run_id=None)
+
+    if output_dir is None:
+        output_dir = Path("artifacts/perf")
+    if run_id is None:
+        run_id = _utc_run_id(suite)
+
+    run_dir: Path = output_dir / run_id
+    if run_dir.exists() and not bool(args.overwrite):
+        raise FileExistsError(
+            f"Benchmark run directory already exists: {run_dir}. "
+            "Choose a different --run-id or pass --overwrite."
+        )
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return RunDestination(output_file=run_dir / "report.json", output_dir=run_dir, run_id=run_id)
+
+
+def _make_config(root: Path) -> FrozenConfig:
+    """Create a minimal benchmark config rooted at `root`."""
+    draft: MutableConfig = mutable_config_from_defaults()
+    draft.files = [str(root)]
+    draft.relative_to_raw = str(root)
+    draft.relative_to = root
+    draft.header_fields = ["project", "file", "license", "copyright"]
+    draft.field_values = {
+        "project": "TopMarkPerf",
+        "license": "MIT",
+        "copyright": "(c) 2025 TopMark",
+    }
+    draft.align_fields = True
+    return draft.freeze()
+
+
+def _write_repeated_body(path: Path, *, target_bytes: int, prefix: str = "print") -> None:
+    """Write a deterministic Python-like body of approximately `target_bytes`."""
+    line_template: str = f"{prefix}('topmark performance baseline line')\n"
+    lines_needed: int = max(1, target_bytes // len(line_template.encode("utf-8")))
+    path.write_text(line_template * lines_needed, encoding="utf-8")
+
+
+def _write_with_header(path: Path, *, body_bytes: int) -> None:
+    """Write a deterministic Python file with an existing TopMark header."""
+    body_line = "print('existing header baseline body')\n"
+    lines_needed: int = max(1, body_bytes // len(body_line.encode("utf-8")))
+    path.write_text("".join(HEADER_LINES) + (body_line * lines_needed), encoding="utf-8")
+
+
+def _write_huge_header(path: Path, *, header_lines: int, body_bytes: int) -> None:
+    """Write a file containing a very large detected TopMark header."""
+    lines: list[str] = ["# topmark:header:start\n", "#\n"]
+    for index in range(header_lines):
+        lines.append(f"#   generated_{index:05d} : value {index}\n")
+    lines.extend(["#\n", "# topmark:header:end\n"])
+    body_line = "print('body after huge header')\n"
+    body_count: int = max(1, body_bytes // len(body_line.encode("utf-8")))
+    path.write_text("".join(lines) + (body_line * body_count), encoding="utf-8")
+
+
+def _write_huge_diff(path: Path, *, body_bytes: int) -> None:
+    """Write a file with a malformed/outdated header to force a large diff vicinity."""
+    body_line = "print('huge diff body line with stable content')\n"
+    body_count: int = max(1, body_bytes // len(body_line.encode("utf-8")))
+    header: list[str] = [
+        "# topmark:header:start\n",
+        "#\n",
+        "#   project      : OutdatedProject\n",
+        "#   file         : old.py\n",
+        "#   license      : Proprietary\n",
+        "#   copyright    : (c) 1999 Someone Else\n",
+        "#\n",
+        "# topmark:header:end\n",
+    ]
+    path.write_text("".join(header) + (body_line * body_count), encoding="utf-8")
+
+
+def _build_scenarios(root: Path, *, include_large: bool) -> list[Scenario]:
+    """Generate benchmark files and return their scenario descriptors."""
+    names: tuple[ScenarioName, ...] = DEFAULT_SCENARIOS + (LARGE_SCENARIOS if include_large else ())
+    scenarios: list[Scenario] = []
+
+    for name in names:
+        path: Path = root / f"{name}.py"
+        description: str
+        match name:
+            case "small_1kb_missing_header":
+                _write_repeated_body(path, target_bytes=1_024)
+                description = "Small file without a header; exercises insertion baseline."
+            case "small_10kb_existing_header":
+                _write_with_header(path, body_bytes=10_000)
+                description = "Small file with an existing header; exercises scan/compare baseline."
+            case "medium_100kb_missing_header":
+                _write_repeated_body(path, target_bytes=100_000)
+                description = "Medium file without a header; captures normal insertion scaling."
+            case "medium_1mb_missing_header":
+                _write_repeated_body(path, target_bytes=1_000_000)
+                description = (
+                    "One-megabyte file without a header; captures list-backed image costs."
+                )
+            case "large_10mb_missing_header":
+                _write_repeated_body(path, target_bytes=10_000_000)
+                description = "Large file without a header; optional heavier baseline workload."
+            case "huge_header":
+                _write_huge_header(path, header_lines=10_000, body_bytes=10_000)
+                description = "Huge detected header; stresses scanner/header view retention."
+            case "huge_diff":
+                _write_huge_diff(path, body_bytes=1_000_000)
+                description = "Large changed file with outdated header; stresses diff generation."
+            case "insert_near_end":
+                # Python inserts after shebang/encoding at the top, so use a large body to
+                # approximate the retained-image cost of preserving content around insertion.
+                _write_repeated_body(path, target_bytes=1_000_000, prefix="value")
+                description = "Large insertion workload; approximates insertion composition cost."
+            case "strip_large_header":
+                _write_huge_header(path, header_lines=10_000, body_bytes=1_000_000)
+                description = (
+                    "Large strip workload; stresses removed-header and updated-image costs."
+                )
+            case "mixed_newlines":
+                path.write_bytes(b"print('a')\nprint('b')\r\nprint('c')\n")
+                description = "Mixed newline file; should stop before expensive update paths."
+            case "bom_file":
+                path.write_bytes("\ufeffprint('bom baseline')\n".encode("utf-8"))
+                description = (
+                    "BOM-bearing file; exercises BOM normalization and retention behavior."
+                )
+        scenarios.append(
+            Scenario(
+                name=name,
+                path=path,
+                size_bytes=path.stat().st_size,
+                description=description,
+            )
+        )
+    return scenarios
+
+
+def _mode_from_name(name: str) -> Mode:
+    """Return a configured benchmark mode by name."""
+    match name:
+        case "check":
+            return Mode(
+                name=name,
+                kind="check",
+                apply=False,
+                diff=False,
+                output_target=OutputTarget.FILE,
+                prune_views=False,
+                keep_diff_view=False,
+            )
+        case "check_diff":
+            return Mode(
+                name=name,
+                kind="check",
+                apply=False,
+                diff=True,
+                output_target=OutputTarget.FILE,
+                prune_views=False,
+                keep_diff_view=True,
+            )
+        case "check_apply":
+            return Mode(
+                name=name,
+                kind="check",
+                apply=True,
+                diff=False,
+                output_target=OutputTarget.FILE,
+                prune_views=False,
+                keep_diff_view=False,
+            )
+        case "check_stdout":
+            return Mode(
+                name=name,
+                kind="check",
+                apply=False,
+                diff=False,
+                output_target=OutputTarget.STDOUT,
+                prune_views=False,
+                keep_diff_view=False,
+            )
+        case "strip":
+            return Mode(
+                name=name,
+                kind="strip",
+                apply=False,
+                diff=False,
+                output_target=OutputTarget.FILE,
+                prune_views=False,
+                keep_diff_view=False,
+            )
+        case "strip_diff":
+            return Mode(
+                name=name,
+                kind="strip",
+                apply=False,
+                diff=True,
+                output_target=OutputTarget.FILE,
+                prune_views=False,
+                keep_diff_view=True,
+            )
+        case _:
+            choices: str = ", ".join(DEFAULT_MODES)
+            raise ValueError(f"Unknown mode {name!r}; expected one of: {choices}")
+
+
+def _run_steps_with_samples(
+    *,
+    scenario: Scenario,
+    mode: Mode,
+    config: FrozenConfig,
+    policy_registry: PolicyRegistry,
+) -> tuple[ProcessingContext, list[StepSample], str]:
+    """Run one scenario/mode pair and collect step-level samples."""
+    run_options = RunOptions(
+        apply_changes=mode.apply,
+        output_target=mode.output_target,
+        file_write_strategy=FileWriteStrategy.ATOMIC,
+        prune_views=mode.prune_views,
+        keep_diff_view=mode.keep_diff_view,
+    )
+    ctx: ProcessingContext = ProcessingContext.bootstrap(
+        path=scenario.path,
+        config=config,
+        run_options=run_options,
+        policy_registry_override=policy_registry,
+    )
+    pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
+        mode.kind,
+        apply=mode.apply,
+        diff=mode.diff,
+    )
+    samples: list[StepSample] = []
+    stdout_capture = io.StringIO()
+
+    with contextlib.redirect_stdout(stdout_capture):
+        for step in pipeline:
+            step_start: int = time.perf_counter_ns()
+            ctx = step(ctx)
+            elapsed_ns: int = time.perf_counter_ns() - step_start
+            current_bytes, peak_bytes = tracemalloc.get_traced_memory()
+            views: dict[str, int | bool] = _view_sizes(ctx)
+            samples.append(
+                StepSample(
+                    step=step.name,
+                    elapsed_ns=elapsed_ns,
+                    current_tracemalloc_bytes=current_bytes,
+                    peak_tracemalloc_bytes=peak_bytes,
+                    rss_bytes=_rss_bytes(),
+                    image_lines=int(views["image_lines"]),
+                    header_lines=int(views["header_lines"]),
+                    render_lines=int(views["render_lines"]),
+                    updated_lines=int(views["updated_lines"]),
+                    diff_bytes=int(views["diff_bytes"]),
+                )
+            )
+
+    return ctx, samples, stdout_capture.getvalue()
+
+
+def _measure_one(
+    *,
+    scenario: Scenario,
+    mode: Mode,
+    config: FrozenConfig,
+    policy_registry: PolicyRegistry,
+) -> RunMeasurement:
+    """Measure one scenario/mode pair."""
+    gc.collect()
+    tracemalloc.start()
+    start_rss: int | None = _rss_bytes()
+    start_ns: int = time.perf_counter_ns()
+    exit_code: ExitCode | None = None
+
+    try:
+        ctx, samples, stdout_text = _run_steps_with_samples(
+            scenario=scenario,
+            mode=mode,
+            config=config,
+            policy_registry=policy_registry,
+        )
+    except Exception:
+        tracemalloc.stop()
+        raise
+
+    elapsed_ns: int = time.perf_counter_ns() - start_ns
+    final_bytes, peak_bytes = tracemalloc.get_traced_memory()
+    end_rss: int | None = _rss_bytes()
+    views_before_prune: dict[str, int | bool] = _view_sizes(ctx)
+    ctx.views.release_all(keep_diff_view=mode.keep_diff_view)
+    views_after_prune: dict[str, int | bool] = _view_sizes(ctx)
+    max_sample_rss: int = max((sample.rss_bytes or 0 for sample in samples), default=0)
+    max_observed_rss: int = max(
+        value for value in (start_rss, end_rss, max_sample_rss or None) if value is not None
+    )
+    tracemalloc.stop()
+
+    return RunMeasurement(
+        scenario=scenario.name,
+        mode=mode.name,
+        file_size_bytes=scenario.size_bytes,
+        elapsed_ns=elapsed_ns,
+        peak_tracemalloc_bytes=peak_bytes,
+        final_tracemalloc_bytes=final_bytes,
+        start_rss_bytes=start_rss,
+        end_rss_bytes=end_rss,
+        max_observed_rss_bytes=max_observed_rss,
+        stdout_bytes=len(stdout_text.encode("utf-8")),
+        exit_code=exit_code.value if exit_code is not None else None,
+        status=_status_dict(ctx),
+        views_before_prune=views_before_prune,
+        views_after_prune=views_after_prune,
+        steps=samples,
+    )
+
+
+# --- Subprocess measurement helpers ---
+
+
+def _object_mapping(value: object, *, message: str) -> dict[str, object]:
+    """Return a string-keyed object mapping.
+
+    Args:
+        value: Candidate JSON object value.
+        message: Error message used when `value` is not a JSON object.
+
+    Returns:
+        A string-keyed object dictionary.
+
+    Raises:
+        TypeError: If `value` is not a JSON object.
+    """
+    if not is_mapping(value):
+        raise TypeError(message)
+    return as_object_dict(value)
+
+
+def _object_list(value: object, *, message: str) -> list[object]:
+    """Return an object list.
+
+    Args:
+        value: Candidate JSON array value.
+        message: Error message used when `value` is not a JSON array.
+
+    Returns:
+        A list of JSON-compatible values.
+
+    Raises:
+        TypeError: If `value` is not a JSON array.
+    """
+    if not is_any_list(value):
+        raise TypeError(message)
+    return list(value)
+
+
+def _required_int(payload: dict[str, object], key: str) -> int:
+    """Return a required integer-compatible payload value.
+
+    Args:
+        payload: JSON object payload.
+        key: Field name to read from `payload`.
+
+    Returns:
+        The selected value converted to `int`.
+
+    Raises:
+        TypeError: If the value cannot be converted to `int`.
+    """
+    value: object = payload[key]
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int | float | str):
+        return int(value)
+    raise TypeError(f"payload field {key!r} is not integer-compatible")
+
+
+def _optional_int(payload: dict[str, object], key: str) -> int | None:
+    """Return an optional integer-compatible payload value.
+
+    Args:
+        payload: JSON object payload.
+        key: Field name to read from `payload`.
+
+    Returns:
+        The selected value converted to `int`, or `None` when the payload value is null.
+
+    Raises:
+        TypeError: If the non-null value cannot be converted to `int`.
+    """
+    value: object = payload[key]
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int | float | str):
+        return int(value)
+    raise TypeError(f"payload field {key!r} is not integer-compatible")
+
+
+def _int_bool_mapping(value: object, *, message: str) -> dict[str, int | bool]:
+    """Return a JSON object as an integer-or-boolean mapping.
+
+    Args:
+        value: Candidate JSON object value.
+        message: Error message used when `value` is not a JSON object.
+
+    Returns:
+        A string-keyed dictionary containing only integers and booleans.
+
+    Raises:
+        TypeError: If `value` is not a JSON object or contains unsupported values.
+    """
+    payload: dict[str, object] = _object_mapping(value, message=message)
+    result: dict[str, int | bool] = {}
+    for key, item in payload.items():
+        if isinstance(item, bool):
+            result[key] = item
+        elif isinstance(item, int | float | str):
+            result[key] = int(item)
+        else:
+            raise TypeError(f"payload field {key!r} is not integer-compatible")
+    return result
+
+
+def _measurement_from_mapping(payload: dict[str, object]) -> RunMeasurement:
+    """Rebuild one [RunMeasurement](RunMeasurement) from JSON-compatible data.
+
+    Args:
+        payload: JSON-compatible measurement object payload.
+
+    Returns:
+        A reconstructed run measurement.
+    """
+    steps_payload: list[object] = _object_list(
+        payload.get("steps"),
+        message="measurement payload is missing a valid steps list",
+    )
+
+    steps: list[StepSample] = []
+    for step_value in steps_payload:
+        step_payload: dict[str, object] = _object_mapping(
+            step_value,
+            message="measurement step payload must be an object",
+        )
+        steps.append(
+            StepSample(
+                step=str(step_payload["step"]),
+                elapsed_ns=_required_int(step_payload, "elapsed_ns"),
+                current_tracemalloc_bytes=_required_int(
+                    step_payload,
+                    "current_tracemalloc_bytes",
+                ),
+                peak_tracemalloc_bytes=_required_int(
+                    step_payload,
+                    "peak_tracemalloc_bytes",
+                ),
+                rss_bytes=_optional_int(step_payload, "rss_bytes"),
+                image_lines=_required_int(step_payload, "image_lines"),
+                header_lines=_required_int(step_payload, "header_lines"),
+                render_lines=_required_int(step_payload, "render_lines"),
+                updated_lines=_required_int(step_payload, "updated_lines"),
+                diff_bytes=_required_int(step_payload, "diff_bytes"),
+            )
+        )
+
+    status_payload: dict[str, object] = _object_mapping(
+        payload.get("status"),
+        message="measurement payload is missing a valid status object",
+    )
+    return RunMeasurement(
+        scenario=str(payload["scenario"]),
+        mode=str(payload["mode"]),
+        file_size_bytes=_required_int(payload, "file_size_bytes"),
+        elapsed_ns=_required_int(payload, "elapsed_ns"),
+        peak_tracemalloc_bytes=_required_int(payload, "peak_tracemalloc_bytes"),
+        final_tracemalloc_bytes=_required_int(payload, "final_tracemalloc_bytes"),
+        start_rss_bytes=_optional_int(payload, "start_rss_bytes"),
+        end_rss_bytes=_optional_int(payload, "end_rss_bytes"),
+        max_observed_rss_bytes=_optional_int(payload, "max_observed_rss_bytes"),
+        stdout_bytes=_required_int(payload, "stdout_bytes"),
+        exit_code=str(payload["exit_code"]) if payload.get("exit_code") is not None else None,
+        status={str(key): str(value) for key, value in status_payload.items()},
+        views_before_prune=_int_bool_mapping(
+            payload.get("views_before_prune"),
+            message="measurement payload is missing a valid views_before_prune object",
+        ),
+        views_after_prune=_int_bool_mapping(
+            payload.get("views_after_prune"),
+            message="measurement payload is missing a valid views_after_prune object",
+        ),
+        steps=steps,
+    )
+
+
+def _measure_one_subprocess(
+    *,
+    scenario_name: ScenarioName,
+    mode_name: str,
+    include_large: bool,
+    work_dir: Path,
+) -> RunMeasurement:
+    """Measure one scenario/mode pair in a fresh Python process for accurate RSS."""
+    output: Path = work_dir / f"{scenario_name}-{mode_name}.json"
+    command: list[str] = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--single-process",
+        "--scenario",
+        scenario_name,
+        "--mode",
+        mode_name,
+        "--output",
+        output.as_posix(),
+    ]
+    if include_large:
+        command.append("--include-large")
+    # The command is constructed from the current Python executable, this script path,
+    # and validated argparse choices; no shell is used.
+    subprocess.run(command, check=True)  # noqa: S603
+
+    raw_payload: object = json.loads(output.read_text(encoding="utf-8"))
+    payload: dict[str, object] = _object_mapping(
+        raw_payload, message="subprocess report payload must be an object"
+    )
+    measurements_payload: list[object] = _object_list(
+        payload.get("measurements"),
+        message="subprocess report measurements payload must be a list",
+    )
+    if len(measurements_payload) != 1:
+        raise ValueError("subprocess report must contain exactly one measurement")
+    measurement_payload: dict[str, object] = _object_mapping(
+        measurements_payload[0],
+        message="subprocess measurement payload must be an object",
+    )
+    return _measurement_from_mapping(measurement_payload)
+
+
+def _measure_all_subprocesses(
+    *,
+    scenarios: Sequence[Scenario],
+    modes: Sequence[Mode],
+    include_large: bool,
+    work_dir: Path,
+) -> list[RunMeasurement]:
+    """Measure all scenario/mode pairs in subprocesses."""
+    measurements: list[RunMeasurement] = []
+    for scenario in scenarios:
+        for mode in modes:
+            measurements.append(
+                _measure_one_subprocess(
+                    scenario_name=scenario.name,
+                    mode_name=mode.name,
+                    include_large=include_large,
+                    work_dir=work_dir,
+                )
+            )
+    return measurements
+
+
+def _json_default(value: object) -> object:
+    """Serialize dataclass values for JSON output."""
+    if isinstance(value, Path):
+        return value.as_posix()
+    if isinstance(value, (Scenario, Mode, StepSample, RunMeasurement, RunDestination)):
+        return asdict(value)
+    if isinstance(value, OutputTarget):
+        return value.value
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate TopMark pipeline memory/allocation baseline measurements.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write JSON report to this path instead of stdout.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Write a preserved run directory below this path. Defaults to artifacts/perf.",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Name for the preserved run directory. Defaults to a UTC timestamp.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow replacing an existing preserved run directory.",
+    )
+    parser.add_argument(
+        "--suite",
+        choices=tuple(SUITE_SCENARIOS),
+        default=None,
+        help="Run a predefined scenario/mode suite instead of specifying every command manually.",
+    )
+    parser.add_argument(
+        "--include-large",
+        action="store_true",
+        help="Include heavier large-file scenarios that may take longer.",
+    )
+    parser.add_argument(
+        "--mode",
+        action="append",
+        choices=DEFAULT_MODES,
+        help="Mode to run. May be repeated. Defaults to the standard mode set.",
+    )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        choices=DEFAULT_SCENARIOS + LARGE_SCENARIOS,
+        help="Scenario to run. May be repeated. Defaults to the standard scenario set.",
+    )
+    parser.add_argument(
+        "--single-process",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args(argv)
+
+
+def _select_scenarios(
+    scenarios: Iterable[Scenario],
+    selected_names: Sequence[str] | None,
+) -> list[Scenario]:
+    """Filter generated scenarios by optional names."""
+    if selected_names is None:
+        return list(scenarios)
+    selected: set[str] = set(selected_names)
+    return [scenario for scenario in scenarios if scenario.name in selected]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the benchmark and emit a JSON report."""
+    args: argparse.Namespace = _parse_args(sys.argv[1:] if argv is None else argv)
+    suite: SuiteName | None = args.suite
+    if suite is not None:
+        scenario_names: Sequence[str] | None = SUITE_SCENARIOS[suite]
+        mode_names: Sequence[str] = SUITE_MODES[suite]
+    else:
+        scenario_names = args.scenario
+        mode_names = args.mode if args.mode is not None else DEFAULT_MODES
+    modes: list[Mode] = [_mode_from_name(name) for name in mode_names]
+    destination: RunDestination = _resolve_destination(args, suite=suite)
+
+    with tempfile.TemporaryDirectory(prefix="topmark-perf-") as tmp:
+        root = Path(tmp)
+        scenarios: list[Scenario] = _select_scenarios(
+            _build_scenarios(root, include_large=args.include_large),
+            scenario_names,
+        )
+        if bool(args.single_process):
+            config: FrozenConfig = _make_config(root)
+            policy_registry: PolicyRegistry = make_policy_registry(config)
+            measurements: list[RunMeasurement] = []
+
+            for scenario in scenarios:
+                for mode in modes:
+                    # Each measurement gets a fresh copy so apply-mode runs do not contaminate
+                    # subsequent dry-run or strip measurements for the same logical scenario.
+                    isolated: Path = root / f"isolated-{scenario.name}-{mode.name}.py"
+                    isolated.write_bytes(scenario.path.read_bytes())
+                    isolated_scenario = Scenario(
+                        name=scenario.name,
+                        path=isolated,
+                        size_bytes=isolated.stat().st_size,
+                        description=scenario.description,
+                    )
+                    measurements.append(
+                        _measure_one(
+                            scenario=isolated_scenario,
+                            mode=mode,
+                            config=config,
+                            policy_registry=policy_registry,
+                        )
+                    )
+        else:
+            measurements = _measure_all_subprocesses(
+                scenarios=scenarios,
+                modes=modes,
+                include_large=bool(args.include_large),
+                work_dir=root,
+            )
+
+        report: dict[str, object] = {
+            "schema_version": 1,
+            "tool": "tools/perf/pipeline_memory_baseline.py",
+            "pid": os.getpid(),
+            "python": sys.version,
+            "platform": sys.platform,
+            "repo_root": REPO_ROOT.as_posix(),
+            "git_commit": _read_git_commit(),
+            "suite": suite,
+            "run_id": destination.run_id,
+            "measurement_isolation": "single-process"
+            if bool(args.single_process)
+            else "subprocess",
+            "scenarios": [asdict(scenario) for scenario in scenarios],
+            "modes": [asdict(mode) for mode in modes],
+            "measurements": measurements,
+        }
+
+    payload: str = json.dumps(report, indent=2, default=_json_default)
+    destination.output_file.parent.mkdir(parents=True, exist_ok=True)
+    destination.output_file.write_text(payload + "\n", encoding="utf-8")
+    if destination.output_dir is not None:
+        _write_summary(destination.output_dir / "summary.md", measurements)
+        manifest: dict[str, int | str | list[str] | None] = {
+            "schema_version": 1,
+            "run_id": destination.run_id,
+            "suite": suite,
+            "report": destination.output_file.name,
+            "summary": "summary.md",
+            "python": sys.version,
+            "platform": sys.platform,
+            "git_commit": _read_git_commit(),
+            "scenarios": [scenario.name for scenario in scenarios],
+            "modes": [mode.name for mode in modes],
+        }
+        (destination.output_dir / "manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(destination.output_dir.as_posix())
+    elif args.output is None:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/perf/pipeline_memory_baseline.py
+++ b/tools/perf/pipeline_memory_baseline.py
@@ -53,7 +53,6 @@ from topmark.runtime.model import RunOptions
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Sequence
-    from resource import struct_rusage
 
     from topmark.config.model import FrozenConfig
     from topmark.config.model import MutableConfig
@@ -216,12 +215,15 @@ def _rss_bytes() -> int | None:
     Returns:
         RSS in bytes when available, otherwise `None`.
     """
+    if sys.platform == "win32":
+        return None
+
     try:
         import resource
     except ImportError:
         return None
 
-    usage: struct_rusage = resource.getrusage(resource.RUSAGE_SELF)
+    usage = resource.getrusage(resource.RUSAGE_SELF)
     value = int(usage.ru_maxrss)
     if sys.platform == "darwin":
         return value


### PR DESCRIPTION
## Summary

This PR establishes the initial memory/allocation baseline framework for
TopMark pipeline processing.

The goal is to collect factual measurements before pursuing Track B
performance work and to replace assumptions from the ownership audit
(#133) with reproducible benchmark data.

### Added

- `tools/perf/pipeline_memory_baseline.py`
- canonical benchmark suites:
  - smoke
  - pathological
  - baseline
- subprocess-isolated RSS measurement
- preserved benchmark-run layout under `artifacts/perf/`
- `perf_baseline` Nox session
- `make perf-baseline`
- dedicated performance-baseline documentation

### Documentation

Added `docs/dev/performance-baselines.md` covering:

- benchmark methodology
- tracemalloc and RSS collection
- benchmark-corpus scope
- single-file measurement boundaries
- benchmark preservation guidance
- initial baseline results
- prioritization implications for future Track B work

Cross-links were also added from development and CI documentation.

### Tooling

- include `tools/` in Pyright validation
- exclude generated benchmark artifacts from Ruff scanning

### Findings

The initial baseline measurements confirm the materialization hotspots
identified during #133.

The largest measured workload was:

- `strip_large_header`
- `strip_diff`
- ~21.9 MiB peak traced allocation
- ~80 MiB peak RSS

The results support prioritizing:

1. #140 Review view-pruning lifecycle and memory-release opportunities
2. #138 Audit diff-generation materialization and retention behavior
3. #135 Design lazy updated-file composition for pipeline updates

### Notes

This PR intentionally does not introduce performance optimizations,
ownership changes, lazy implementations, or pipeline redesign.

It establishes the measurement foundation required for future
performance work.

Refs: #133
Closes: #134