### PR TITLE
Implement typed pipeline view-consumer pruning lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ ______________________________________________________________________
 
 ### Changed - Unreleased
 
+- Pruned consumed pipeline views incrementally between steps when view pruning is enabled, reducing
+  transient retention before later patch/write phases while preserving requested diff output.
+- Replaced string-based pipeline view-pruning decisions with typed `ViewSlot` consumer metadata
+  declared by concrete pipeline steps.
 - Replaced the CLI presentation backend with Rich.
 - Adopted `rich-click` for CLI help rendering while preserving Click runtime semantics.
 - Centralized CLI option metadata and command-applicability groups used by diagnostics.
@@ -243,6 +247,10 @@ ______________________________________________________________________
   memory-baseline findings from issue #134.
 - Added cross-references from development and CI documentation to the performance-baseline workflow
   and benchmark methodology.
+- Documented issue #140 follow-up measurements showing that consumed-view pruning reduces retained
+  memory in header-heavy workloads while preserving the issue #134 baseline comparison modes.
+- Documented pipeline view consumer declarations, `consumes_views`, and typed `ViewSlot` pruning
+  behavior in the developer pipeline documentation.
 
 ### Internal - Unreleased
 
@@ -293,6 +301,10 @@ ______________________________________________________________________
   generated benchmark artifacts from Ruff scanning.
 - Added subprocess-isolated benchmark execution so per-scenario RSS measurements reflect individual
   workload peaks rather than cumulative process high-water marks.
+- Added explicit pruned benchmark modes to measure view-pruning lifecycle behavior without changing
+  the historical benchmark suite modes used for baseline comparability.
+- Added regression coverage for consumed-view release behavior, diff retention, and concrete
+  pipeline step `consumes_views` declarations.
 
 ### Notes - Unreleased
 

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -249,7 +249,7 @@ ______________________________________________________________________
 
 The initial baseline measurements support the conclusions from the ownership audit.
 
-### Baseline results (issue #134)
+### Baseline results (GitHub issue 134)
 
 The following representative measurements were collected from the canonical baseline runs using
 subprocess-isolated RSS measurements.
@@ -276,11 +276,58 @@ The largest measured cases were associated with diff-heavy workloads and large s
 particular, `strip_large_header` / `strip_diff` produced the highest observed peak traced allocation
 (~21.9 MiB) and RSS (~80 MiB).
 
-The measurements therefore suggest that future optimization work should pay particular attention to:
+### Follow-up measurements (GitHub issue 140)
 
-- diff lifecycle management (#138);
-- updated-file ownership and composition (#135, #136, #137);
-- view release timing and pruning (#140).
+GitHub issue 140 introduced incremental consumed-view pruning between pipeline steps when pruning is
+enabled.
+
+To preserve longitudinal comparability with the GitHub issue 134 baseline, the benchmark tool
+continues to use the historical unpruned mode names in its predefined suites. Explicit `_pruned`
+mode variants were added for measuring lifecycle improvements without changing the original baseline
+reference points.
+
+The benchmark harness mirrors the production pruning lifecycle during step sampling whenever a
+pruned mode is used, so retained-view measurements reflect the views that remain available to
+downstream pipeline steps rather than only final cleanup behavior.
+
+Representative issue 140 measurements collected using the explicit pruned benchmark modes were:
+
+These measurements were collected using the explicit pruned benchmark modes introduced by GitHub
+issue 140. The original GitHub issue 134 baseline measurements remain reproducible through the
+historical mode names and predefined benchmark suites.
+
+| Scenario             | Mode                | Peak traced change | RSS change |
+| -------------------- | ------------------- | -----------------: | ---------: |
+| `huge_header`        | `check_diff_pruned` |            -33.6 % |     -8.3 % |
+| `huge_header`        | `strip_diff_pruned` |            -32.9 % |     -4.0 % |
+| `strip_large_header` | `check_diff_pruned` |            -14.7 % |     -1.9 % |
+| `strip_large_header` | `strip_diff_pruned` |             -8.1 % |     +0.1 % |
+
+The strongest improvements were observed in header-heavy workloads where multiple transient views
+(image content, detected headers, rendered headers, and updated content) would otherwise coexist for
+longer periods.
+
+For example, `huge_header` improved by roughly 33% in peak traced allocations in both
+`check_diff_pruned` and `strip_diff_pruned` modes, with corresponding RSS reductions of roughly 4%
+to 8% on the measured platform.
+
+The largest pathological diff workload (`strip_large_header` / `strip_diff_pruned`) showed a more
+modest improvement of roughly 8% in peak traced allocations and essentially unchanged RSS. This is
+consistent with the ownership audit and baseline findings: the remaining dominant costs in that
+scenario are updated-file materialization and diff generation rather than retention of consumed
+header-related views.
+
+These figures should be treated as directional rather than hard thresholds because memory
+measurements are platform-, allocator-, and workload-sensitive.
+
+The GitHub issue 140 results therefore validate that earlier release of consumed views is a
+worthwhile low-risk optimization, while also confirming that the largest remaining memory
+opportunities lie in later roadmap items focused on diff generation and updated-file ownership.
+
+- diff lifecycle management (GitHub issue 138);
+- updated-file ownership and composition (GitHub issues 135, 136, and 137);
+- view release timing and pruning (GitHub issue 140, completed and measured as a baseline-preserving
+  optimization).
 
 ______________________________________________________________________
 
@@ -301,11 +348,11 @@ ______________________________________________________________________
 
 ## Related issues
 
-- #133 Audit pipeline materialization points and memory ownership
-- #134 Establish memory and allocation baselines for pipeline processing
-- #135 Design lazy updated-file composition for pipeline updates
-- #136 Implement iterable-backed UpdatedView generation
-- #137 Stream updated content through WriterStep
-- #138 Audit diff-generation materialization and retention behavior
-- #140 Review view-pruning lifecycle and memory-release opportunities
-- #141 Evaluate alternative FileImageView implementations
+- GitHub issue 133: Audit pipeline materialization points and memory ownership
+- GitHub issue 134: Establish memory and allocation baselines for pipeline processing
+- GitHub issue 135: Design lazy updated-file composition for pipeline updates
+- GitHub issue 136: Implement iterable-backed UpdatedView generation
+- GitHub issue 137: Stream updated content through WriterStep
+- GitHub issue 138: Audit diff-generation materialization and retention behavior
+- GitHub issue 140: Review view-pruning lifecycle and memory-release opportunities
+- GitHub issue 141: Evaluate alternative FileImageView implementations

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -66,6 +66,13 @@ Hard-linked selected processing paths remain separate result payloads and are re
 unsupported, policy-blocked processing targets rather than being serialized as a single preferred
 path.
 
+Pipeline steps may also produce and consume phase-scoped view payloads. The `Step` protocol exposes
+`consumes_views`, and `BaseStep` stores those declarations as instance metadata. Runtime view
+pruning uses this typed metadata to release consumed view payloads between steps without relying on
+step-name string matching. The authoritative slot names are exposed by
+\[`ViewSlot`\][topmark.pipeline.views.ViewSlot], and the view bundle is exposed by
+\[`Views`\][topmark.pipeline.views.Views].
+
 {% include-markdown "\_snippets/config-strictness.md" %}
 
 ## Line-ending handling (contract)
@@ -97,6 +104,11 @@ API module.
 
 - Pipelines module (pipeline definitions and the `Pipeline` enum):
   - [`topmark.pipeline.pipelines`](../api/internals/topmark/pipeline/pipelines.md)
+- Step protocol and base lifecycle contract:
+  - [`topmark.pipeline.protocols`](../api/internals/topmark/pipeline/protocols.md)
+  - [`topmark.pipeline.steps.base`](../api/internals/topmark/pipeline/steps/base.md)
+- Pipeline view slots and view bundle:
+  - [`topmark.pipeline.views`](../api/internals/topmark/pipeline/views.md)
 - Conceptual overview:
   - [`Pipelines (Concepts)`](./pipelines.md)
 

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -159,6 +159,12 @@ TopMark pipelines are:
 Pipeline steps mutate processing context state. CLI views, API DTOs, and machine-readable output
 classify final outcomes from accumulated statuses and hints.
 
+Some intermediate data is stored in phase-scoped pipeline views, such as the original file image,
+detected header data, generated fields, rendered headers, updated content, and unified diffs. Steps
+that read these views declare their dependencies via `consumes_views`. When runtime view pruning is
+enabled, the runner uses those declarations to release consumed view payloads after the last
+remaining consumer has run, while preserving requested output such as retained diffs.
+
 For filesystem inputs, the processing context path is the selected processing path. It may differ
 from the path spelling supplied on the command line or in configuration when symlinks or equivalent
 relative spellings are involved.
@@ -481,6 +487,7 @@ ______________________________________________________________________
 Each step implements the \[`Step`\][topmark.pipeline.protocols.Step] protocol and:
 
 - Declares which **status axes** it may write
+- Declares which pipeline view slots it may consume via `consumes_views`
 - May halt execution via `ctx.flow.halt`
 - Emits structured hints for diagnostics
 
@@ -498,6 +505,36 @@ Each step implements the \[`Step`\][topmark.pipeline.protocols.Step] protocol an
 | \[`PlannerStep`\][topmark.pipeline.steps.planner.PlannerStep]    | Decide insert / replace / remove plan                                                                     |
 | \[`PatcherStep`\][topmark.pipeline.steps.patcher.PatcherStep]    | Generate unified diff with human-facing display labels                                                    |
 | \[`WriterStep`\][topmark.pipeline.steps.writer.WriterStep]       | Persist changes                                                                                           |
+
+### View consumer declarations
+
+Pipeline view consumer declarations are part of the step contract. They describe which large,
+phase-scoped view payloads a step may read during `run()` or `hint()`.
+
+These declarations are intentionally separate from `axes_written`: axes describe status ownership,
+while `consumes_views` describes data dependencies. The runner aggregates the declarations of
+remaining steps and releases views that no later step can consume. This keeps pruning tied to typed
+view slots instead of brittle step-name string checks.
+
+Current consumer declarations are:
+
+| Step                                                             | Consumed view slots                             |
+| ---------------------------------------------------------------- | ----------------------------------------------- |
+| \[`ProberStep`\][topmark.pipeline.steps.prober.ProberStep]       | none                                            |
+| \[`ResolverStep`\][topmark.pipeline.steps.resolver.ResolverStep] | none                                            |
+| \[`SnifferStep`\][topmark.pipeline.steps.sniffer.SnifferStep]    | none                                            |
+| \[`ReaderStep`\][topmark.pipeline.steps.reader.ReaderStep]       | none                                            |
+| \[`ScannerStep`\][topmark.pipeline.steps.scanner.ScannerStep]    | `image`                                         |
+| \[`BuilderStep`\][topmark.pipeline.steps.builder.BuilderStep]    | none                                            |
+| \[`RendererStep`\][topmark.pipeline.steps.renderer.RendererStep] | `image`, `header`, `build`                      |
+| \[`ComparerStep`\][topmark.pipeline.steps.comparer.ComparerStep] | `image`, `header`, `build`, `render`, `updated` |
+| \[`StripperStep`\][topmark.pipeline.steps.stripper.StripperStep] | `image`, `header`                               |
+| \[`PlannerStep`\][topmark.pipeline.steps.planner.PlannerStep]    | `image`, `header`, `render`, `updated`          |
+| \[`PatcherStep`\][topmark.pipeline.steps.patcher.PatcherStep]    | `image`, `updated`                              |
+| \[`WriterStep`\][topmark.pipeline.steps.writer.WriterStep]       | `updated`                                       |
+
+`ReaderStep` and `BuilderStep` produce views but do not consume existing view slots. `RendererStep`
+consumes the original image because it may preserve insertion indentation from the source file.
 
 ______________________________________________________________________
 

--- a/src/topmark/pipeline/protocols.py
+++ b/src/topmark/pipeline/protocols.py
@@ -28,6 +28,10 @@ name : str
     Fully qualified name used for tracing/telemetry.
 axes_written : tuple[Axis, ...]
     Declares which status axes this step is allowed to set (e.g. ("fs", "content")).
+
+    Steps also declare the view slots they consume. The runner uses this metadata
+    to release consumed view payloads after the last remaining consumer has run,
+    without keying pruning behavior to step-name strings.
 """
 
 from __future__ import annotations
@@ -41,6 +45,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from topmark.pipeline.hints import Axis
+    from topmark.pipeline.views import ViewSlot
 
 
 Ctx = TypeVar("Ctx")
@@ -63,6 +68,7 @@ class Step(Protocol[Ctx]):
     name: str
     primary_axis: Axis | None
     axes_written: tuple[Axis, ...]
+    consumes_views: frozenset[ViewSlot]
 
     def may_proceed(self, ctx: Ctx) -> bool:
         """Return whether the step should run given the current context.

--- a/src/topmark/pipeline/runner.py
+++ b/src/topmark/pipeline/runner.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from topmark.core.logging import TopmarkLogger
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.protocols import Step
+    from topmark.pipeline.views import ViewSlot
 
 logger: TopmarkLogger = get_logger(__name__)
 
@@ -44,14 +45,24 @@ def run(
     Args:
         ctx: Mutable processing context.
         steps: Ordered sequence of pipeline steps. Each step takes and returns a context.
-        prune_views: Trim the views at the end of a run to reduce memory usage (default: `True`).
+        prune_views: Release consumed view payloads between steps and trim remaining views at the
+            end of a run to reduce memory usage (default: `True`).
         keep_diff_view: Whether to preserve the diff view.
 
     Returns:
         The final processing context after all steps have run.
     """
-    for step in steps:
+    step_count: int = len(steps)
+    for index, step in enumerate(steps):
         ctx = step(ctx)
+        if prune_views is True:
+            remaining_view_consumers: set[ViewSlot] = set()
+            for remaining_step in steps[index + 1 : step_count]:
+                remaining_view_consumers.update(remaining_step.consumes_views)
+            ctx.views.release_consumed(
+                remaining_view_consumers=remaining_view_consumers,
+                keep_diff_view=keep_diff_view,
+            )
 
     if prune_views is True:
         # Drops large in-memory buffers from heavy in-memory views;

--- a/src/topmark/pipeline/steps/base.py
+++ b/src/topmark/pipeline/steps/base.py
@@ -25,9 +25,11 @@ Design goals
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field
 from typing import TYPE_CHECKING
 
 from topmark.core.logging import get_logger
+from topmark.pipeline.views import ViewSlot
 
 if TYPE_CHECKING:
     from topmark.core.logging import TopmarkLogger
@@ -49,11 +51,13 @@ class BaseStep:
         name: Fully qualified, stable step identifier for logs/tracing.
         primary_axis: The axis this step "represents" in summaries
         axes_written: Status axes this step is allowed to write (e.g. ("fs",)).
+        consumes_views: View slots this step may read during `run()` or `hint()`.
     """
 
     name: str
     primary_axis: Axis | None  # new: axis this step "represents" in summaries
     axes_written: tuple[Axis, ...] = ()
+    consumes_views: frozenset[ViewSlot] = field(default_factory=frozenset[ViewSlot])
 
     def __call__(self, ctx: ProcessingContext) -> ProcessingContext:
         """Invoke the step lifecycle: gate → run (if allowed) → hint.

--- a/src/topmark/pipeline/steps/comparer.py
+++ b/src/topmark/pipeline/steps/comparer.py
@@ -45,6 +45,7 @@ from topmark.pipeline.status import GenerationStatus
 from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import RenderStatus
 from topmark.pipeline.steps.base import BaseStep
+from topmark.pipeline.views import ViewSlot
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -78,6 +79,15 @@ class ComparerStep(BaseStep):
             name=self.__class__.__name__,
             primary_axis=Axis.COMPARISON,
             axes_written=(Axis.COMPARISON,),
+            consumes_views=frozenset(
+                {
+                    ViewSlot.IMAGE,
+                    ViewSlot.HEADER,
+                    ViewSlot.BUILD,
+                    ViewSlot.RENDER,
+                    ViewSlot.UPDATED,
+                }
+            ),
         )
 
     def may_proceed(self, ctx: ProcessingContext) -> bool:

--- a/src/topmark/pipeline/steps/patcher.py
+++ b/src/topmark/pipeline/steps/patcher.py
@@ -40,6 +40,7 @@ from topmark.pipeline.status import PatchStatus
 from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import DiffView
 from topmark.pipeline.views import UpdatedView
+from topmark.pipeline.views import ViewSlot
 from topmark.presentation.formatters.unified_diff import format_patch_plain
 from topmark.presentation.shared.paths import get_display_path
 from topmark.utils.timestamp import format_gnu_diff_timestamp
@@ -80,6 +81,12 @@ class PatcherStep(BaseStep):
             axes_written=(
                 Axis.COMPARISON,  # For one edge case
                 Axis.PATCH,
+            ),
+            consumes_views=frozenset(
+                {
+                    ViewSlot.IMAGE,
+                    ViewSlot.UPDATED,
+                }
             ),
         )
 

--- a/src/topmark/pipeline/steps/planner.py
+++ b/src/topmark/pipeline/steps/planner.py
@@ -63,6 +63,7 @@ from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import HeaderView
 from topmark.pipeline.views import RenderView
 from topmark.pipeline.views import UpdatedView
+from topmark.pipeline.views import ViewSlot
 from topmark.processors.base import NO_LINE_ANCHOR
 
 if TYPE_CHECKING:
@@ -215,6 +216,14 @@ class PlannerStep(BaseStep):
             name=self.__class__.__name__,
             primary_axis=Axis.PLAN,
             axes_written=(Axis.PLAN,),
+            consumes_views=frozenset(
+                {
+                    ViewSlot.IMAGE,
+                    ViewSlot.HEADER,
+                    ViewSlot.RENDER,
+                    ViewSlot.UPDATED,
+                }
+            ),
         )
 
     def may_proceed(self, ctx: ProcessingContext) -> bool:

--- a/src/topmark/pipeline/steps/renderer.py
+++ b/src/topmark/pipeline/steps/renderer.py
@@ -37,6 +37,7 @@ from topmark.pipeline.status import GenerationStatus
 from topmark.pipeline.status import RenderStatus
 from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import RenderView
+from topmark.pipeline.views import ViewSlot
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -68,6 +69,13 @@ class RendererStep(BaseStep):
             name=self.__class__.__name__,
             primary_axis=Axis.RENDER,
             axes_written=(Axis.RENDER,),
+            consumes_views=frozenset(
+                {
+                    ViewSlot.IMAGE,
+                    ViewSlot.HEADER,
+                    ViewSlot.BUILD,
+                }
+            ),
         )
 
     def may_proceed(self, ctx: ProcessingContext) -> bool:

--- a/src/topmark/pipeline/steps/scanner.py
+++ b/src/topmark/pipeline/steps/scanner.py
@@ -38,6 +38,7 @@ from topmark.pipeline.status import FsStatus
 from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import HeaderView
+from topmark.pipeline.views import ViewSlot
 from topmark.processors.types import BoundsKind
 from topmark.processors.types import HeaderBounds
 
@@ -72,6 +73,11 @@ class ScannerStep(BaseStep):
             name=self.__class__.__name__,
             primary_axis=Axis.HEADER,
             axes_written=(Axis.HEADER,),
+            consumes_views=frozenset(
+                {
+                    ViewSlot.IMAGE,
+                }
+            ),
         )
 
     def may_proceed(self, ctx: ProcessingContext) -> bool:

--- a/src/topmark/pipeline/steps/stripper.py
+++ b/src/topmark/pipeline/steps/stripper.py
@@ -31,6 +31,7 @@ from topmark.pipeline.status import StripStatus
 from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import HeaderView
 from topmark.pipeline.views import UpdatedView
+from topmark.pipeline.views import ViewSlot
 from topmark.processors.types import StripDiagKind
 from topmark.processors.types import StripDiagnostic
 from topmark.processors.types import StripHeaderResult
@@ -111,6 +112,12 @@ class StripperStep(BaseStep):
             name=self.__class__.__name__,
             primary_axis=Axis.STRIP,
             axes_written=(Axis.STRIP,),
+            consumes_views=frozenset(
+                {
+                    ViewSlot.IMAGE,
+                    ViewSlot.HEADER,
+                }
+            ),
         )
 
     def may_proceed(self, ctx: ProcessingContext) -> bool:

--- a/src/topmark/pipeline/steps/writer.py
+++ b/src/topmark/pipeline/steps/writer.py
@@ -58,6 +58,7 @@ from topmark.pipeline.status import PlanStatus
 from topmark.pipeline.status import WriteStatus
 from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import UpdatedView
+from topmark.pipeline.views import ViewSlot
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -394,6 +395,11 @@ class WriterStep(BaseStep):
             name=self.__class__.__name__,
             primary_axis=Axis.WRITE,
             axes_written=(Axis.WRITE,),
+            consumes_views=frozenset(
+                {
+                    ViewSlot.UPDATED,
+                }
+            ),
         )
 
     def may_proceed(self, ctx: ProcessingContext) -> bool:

--- a/src/topmark/pipeline/views.py
+++ b/src/topmark/pipeline/views.py
@@ -23,6 +23,7 @@ dataclasses per phase.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING
 from typing import Protocol
 from typing import runtime_checkable
@@ -38,6 +39,21 @@ if TYPE_CHECKING:
 
 
 logger: TopmarkLogger = get_logger(__name__)
+
+
+class ViewSlot(str, Enum):
+    """Named view slots that pipeline steps may consume.
+
+    The values are intentionally plain strings so they remain stable in logs,
+    tests, and machine-oriented diagnostics if exposed later.
+    """
+
+    IMAGE = "image"
+    HEADER = "header"
+    BUILD = "build"
+    RENDER = "render"
+    UPDATED = "updated"
+    DIFF = "diff"
 
 
 @runtime_checkable
@@ -277,21 +293,75 @@ class Views:
             keep_diff_view: Whether to preserve the diff view.
         """
         logger.debug("keep_diff_view: %r", keep_diff_view)
+        self.release_image()
+        self.release_header()
+        self.release_build()
+        self.release_render()
+        self.release_updated()
+
+        if not keep_diff_view:
+            self.release_diff()
+
+    def release_image(self) -> None:
+        """Release the original file image view when it is no longer needed."""
         if self.image:
             self.image.release()
+
+    def release_header(self) -> None:
+        """Release detected-header payloads when they are no longer needed."""
         if self.header:
             self.header.release()
+
+    def release_build(self) -> None:
+        """Release builder payloads when they are no longer needed."""
         if self.build:
             self.build.release()
+
+    def release_render(self) -> None:
+        """Release rendered-header payloads when they are no longer needed."""
         if self.render:
             self.render.release()
+
+    def release_updated(self) -> None:
+        """Release updated-file payloads when they are no longer needed."""
         if self.updated:
             self.updated.release()
 
-        if self.diff and not keep_diff_view:
+    def release_diff(self) -> None:
+        """Release diff payloads when they are no longer needed."""
+        if self.diff:
             self.diff.release()
 
-        # HeaderView is intentionally light; no release.
+    def release_consumed(
+        self,
+        *,
+        remaining_view_consumers: set[ViewSlot],
+        keep_diff_view: bool = False,
+    ) -> None:
+        """Release views that no remaining pipeline step declares as consumed.
+
+        Args:
+            remaining_view_consumers: View slots consumed by steps that have not run yet.
+            keep_diff_view: Whether to preserve the diff view for callers that render it after the
+                pipeline completes.
+        """
+        if ViewSlot.IMAGE not in remaining_view_consumers:
+            self.release_image()
+
+        if ViewSlot.HEADER not in remaining_view_consumers:
+            self.release_header()
+
+        if ViewSlot.BUILD not in remaining_view_consumers:
+            self.release_build()
+
+        if ViewSlot.RENDER not in remaining_view_consumers:
+            self.release_render()
+
+        if ViewSlot.UPDATED not in remaining_view_consumers:
+            self.release_updated()
+
+        if not keep_diff_view and ViewSlot.DIFF not in remaining_view_consumers:
+            self.release_diff()
 
     def as_dict(self) -> dict[str, object]:
         """Short machine-friendly summary; avoid heavy text blobs."""

--- a/tests/pipeline/test_view_pruning.py
+++ b/tests/pipeline/test_view_pruning.py
@@ -1,0 +1,172 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_view_pruning.py
+#   file_relpath : tests/pipeline/test_view_pruning.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for pipeline view-pruning lifecycle helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from topmark.pipeline.pipelines import Pipeline
+from topmark.pipeline.views import BuilderView
+from topmark.pipeline.views import DiffView
+from topmark.pipeline.views import HeaderView
+from topmark.pipeline.views import ListFileImageView
+from topmark.pipeline.views import RenderView
+from topmark.pipeline.views import UpdatedView
+from topmark.pipeline.views import Views
+from topmark.pipeline.views import ViewSlot
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.protocols import Step
+
+
+@pytest.mark.pipeline
+def test_release_consumed_keeps_views_needed_by_remaining_steps() -> None:
+    """The lifecycle helper must not release payloads with downstream consumers."""
+    header_mapping: Mapping[str, str] = {"project": "TopMark"}
+    build_mapping: Mapping[str, str] = {"project": "TopMark"}
+    views = Views(
+        image=ListFileImageView(["print('hello')\n"]),
+        header=HeaderView(
+            range=(0, 4),
+            lines=["# topmark:header:start\n"],
+            block="# topmark:header:start\n",
+            mapping=header_mapping,
+        ),
+        build=BuilderView(builtins=build_mapping, selected=build_mapping),
+        render=RenderView(lines=["# rendered\n"], block="# rendered\n"),
+        updated=UpdatedView(lines=["# rendered\n", "print('hello')\n"]),
+        diff=DiffView(text="--- current\n+++ updated\n"),
+    )
+
+    views.release_consumed(
+        remaining_view_consumers={
+            ViewSlot.IMAGE,
+            ViewSlot.HEADER,
+            ViewSlot.BUILD,
+            ViewSlot.RENDER,
+            ViewSlot.UPDATED,
+        },
+        keep_diff_view=True,
+    )
+
+    assert views.image is not None
+    assert views.image.line_count() == 1
+    assert views.header is not None
+    assert views.header.lines is not None
+    assert views.header.block is not None
+    assert views.header.mapping is not None
+    assert views.build is not None
+    assert views.build.selected is not None
+    assert views.render is not None
+    assert views.render.lines is not None
+    assert views.updated is not None
+    assert views.updated.lines is not None
+    assert views.diff is not None
+    assert views.diff.text is not None
+
+
+@pytest.mark.pipeline
+def test_release_consumed_releases_payloads_not_needed_before_writer() -> None:
+    """Only the updated image and requested diff need to survive before the writer."""
+    header_mapping: Mapping[str, str] = {"project": "TopMark"}
+    build_mapping: Mapping[str, str] = {"project": "TopMark"}
+    views = Views(
+        image=ListFileImageView(["print('hello')\n"]),
+        header=HeaderView(
+            range=(0, 4),
+            lines=["# topmark:header:start\n"],
+            block="# topmark:header:start\n",
+            mapping=header_mapping,
+        ),
+        build=BuilderView(builtins=build_mapping, selected=build_mapping),
+        render=RenderView(lines=["# rendered\n"], block="# rendered\n"),
+        updated=UpdatedView(lines=["# rendered\n", "print('hello')\n"]),
+        diff=DiffView(text="--- current\n+++ updated\n"),
+    )
+
+    views.release_consumed(
+        remaining_view_consumers={ViewSlot.UPDATED},
+        keep_diff_view=True,
+    )
+
+    assert views.image is not None
+    assert views.image.line_count() == 0
+    assert views.header is not None
+    assert views.header.lines is None
+    assert views.header.block is None
+    assert views.header.mapping is None
+    assert views.build is not None
+    assert views.build.selected is None
+    assert views.render is not None
+    assert views.render.lines is None
+    assert views.updated is not None
+    assert views.updated.lines is not None
+    assert views.diff is not None
+    assert views.diff.text is not None
+
+
+@pytest.mark.pipeline
+def test_release_consumed_releases_diff_unless_caller_keeps_it() -> None:
+    """Diff payloads are retained only when explicitly requested."""
+    views = Views(diff=DiffView(text="--- current\n+++ updated\n"))
+
+    views.release_consumed(remaining_view_consumers=set(), keep_diff_view=False)
+
+    assert views.diff is not None
+    assert views.diff.text is None
+
+
+@pytest.mark.pipeline
+def test_pipeline_steps_declare_expected_view_consumers() -> None:
+    """Concrete pipeline steps must declare view consumers for lifecycle pruning."""
+    expected_by_step_name: dict[str, frozenset[ViewSlot]] = {
+        "ReaderStep": frozenset(),
+        "ResolverStep": frozenset(),
+        "SnifferStep": frozenset(),
+        "ScannerStep": frozenset({ViewSlot.IMAGE}),
+        "BuilderStep": frozenset(),
+        "RendererStep": frozenset({ViewSlot.IMAGE, ViewSlot.HEADER, ViewSlot.BUILD}),
+        "ComparerStep": frozenset(
+            {
+                ViewSlot.IMAGE,
+                ViewSlot.HEADER,
+                ViewSlot.BUILD,
+                ViewSlot.RENDER,
+                ViewSlot.UPDATED,
+            }
+        ),
+        "PlannerStep": frozenset(
+            {
+                ViewSlot.IMAGE,
+                ViewSlot.HEADER,
+                ViewSlot.RENDER,
+                ViewSlot.UPDATED,
+            }
+        ),
+        "StripperStep": frozenset({ViewSlot.IMAGE, ViewSlot.HEADER}),
+        "PatcherStep": frozenset({ViewSlot.IMAGE, ViewSlot.UPDATED}),
+        "WriterStep": frozenset({ViewSlot.UPDATED}),
+    }
+
+    steps_by_name: dict[str, Step[ProcessingContext]] = {
+        step.name: step
+        for step in (*Pipeline.CHECK_APPLY_PATCH.steps, *Pipeline.STRIP_APPLY_PATCH.steps)
+    }
+
+    assert set(steps_by_name) == set(expected_by_step_name)
+    for step_name, expected_consumers in expected_by_step_name.items():
+        assert steps_by_name[step_name].consumes_views == expected_consumers

--- a/tools/perf/pipeline_memory_baseline.py
+++ b/tools/perf/pipeline_memory_baseline.py
@@ -8,15 +8,21 @@
 #
 # topmark:header:end
 
-"""Measure baseline memory behavior for TopMark pipeline processing.
+"""Measure memory behavior for TopMark pipeline processing.
 
-This script is intentionally measurement-only. It generates temporary benchmark
-files, runs selected TopMark pipeline variants against those files, and writes a
-JSON report containing elapsed time, tracemalloc peaks, RSS observations where
-available, per-step samples, and retained view summaries.
+The tool generates deterministic benchmark files, runs selected TopMark pipeline
+variants against them, and writes JSON plus optional Markdown summaries containing
+elapsed time, tracemalloc peaks, RSS observations where available, per-step
+samples, and retained-view summaries.
 
-The script avoids optional profiling dependencies so it can be used before the
-project decides whether tools such as memray or pympler are warranted.
+The default scenario and mode suites are intentionally stable. They preserve the
+historical baseline lifecycle established by issue #134 so memory evolution can be
+compared across later performance work. Optimized lifecycle variants are exposed
+as explicit `*_pruned` modes instead of replacing the historical mode names.
+
+The script avoids optional profiling dependencies so it can run in CI and on
+fresh source checkouts before the project decides whether heavier tools such as
+memray or pympler are warranted.
 """
 
 from __future__ import annotations
@@ -59,6 +65,7 @@ if TYPE_CHECKING:
     from topmark.config.policy import PolicyRegistry
     from topmark.core.exit_codes import ExitCode
     from topmark.pipeline.protocols import Step
+    from topmark.pipeline.views import ViewSlot
 
 
 # Allow running this tool directly from a source checkout without requiring an editable install.
@@ -84,6 +91,8 @@ ScenarioName = Literal[
     "bom_file",
 ]
 
+# ---- Benchmark scenario definitions ----
+
 DEFAULT_SCENARIOS: Final[tuple[ScenarioName, ...]] = (
     "small_1kb_missing_header",
     "small_10kb_existing_header",
@@ -97,6 +106,8 @@ DEFAULT_SCENARIOS: Final[tuple[ScenarioName, ...]] = (
     "bom_file",
 )
 LARGE_SCENARIOS: Final[tuple[ScenarioName, ...]] = ("large_10mb_missing_header",)
+
+# ---- Pipeline mode definitions ----
 DEFAULT_MODES: Final[tuple[str, ...]] = (
     "check",
     "check_diff",
@@ -106,7 +117,23 @@ DEFAULT_MODES: Final[tuple[str, ...]] = (
     "strip_diff",
 )
 
-# Scenario and mode suites for --suite argument
+# Historical modes intentionally keep the unpruned lifecycle used by the #134
+# baseline. Use explicit `*_pruned` variants for #140 lifecycle measurements.
+PRUNED_MODES: Final[tuple[str, ...]] = (
+    "check_pruned",
+    "check_diff_pruned",
+    "check_apply_pruned",
+    "check_stdout_pruned",
+    "strip_pruned",
+    "strip_diff_pruned",
+)
+ALL_MODES: Final[tuple[str, ...]] = DEFAULT_MODES + PRUNED_MODES
+
+# ---- Predefined benchmark suites ----
+
+# Suites use historical mode names by default. This keeps repeated `--suite`
+# measurements comparable with the original #134 baseline unless callers opt in
+# to pruned modes explicitly via `--mode`.
 SUITE_SCENARIOS: Final[dict[SuiteName, tuple[ScenarioName, ...]]] = {
     "smoke": ("small_1kb_missing_header",),
     "baseline": (
@@ -209,6 +236,7 @@ class RunMeasurement:
     steps: list[StepSample]
 
 
+# ---- Lightweight measurement helpers ----
 def _rss_bytes() -> int | None:
     """Return current process max RSS where the platform exposes it.
 
@@ -346,6 +374,7 @@ def _write_summary(path: Path, measurements: Sequence[RunMeasurement]) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+# ---- Benchmark input and output setup ----
 def _resolve_destination(args: argparse.Namespace, *, suite: SuiteName | None) -> RunDestination:
     """Resolve file and directory destinations for benchmark output."""
     output: Path | None = args.output
@@ -492,8 +521,14 @@ def _build_scenarios(root: Path, *, include_large: bool) -> list[Scenario]:
     return scenarios
 
 
+# ---- Mode resolution and pipeline execution ----
 def _mode_from_name(name: str) -> Mode:
-    """Return a configured benchmark mode by name."""
+    """Return a configured benchmark mode by name.
+
+    Historical mode names keep `prune_views=False` to preserve comparability with
+    the original #134 baseline. Names ending in `_pruned` opt into the #140
+    lifecycle policy and make before/after comparisons explicit in reports.
+    """
     match name:
         case "check":
             return Mode(
@@ -555,8 +590,68 @@ def _mode_from_name(name: str) -> Mode:
                 prune_views=False,
                 keep_diff_view=True,
             )
+        case "check_pruned":
+            return Mode(
+                name=name,
+                kind="check",
+                apply=False,
+                diff=False,
+                output_target=OutputTarget.FILE,
+                prune_views=True,
+                keep_diff_view=False,
+            )
+        case "check_diff_pruned":
+            return Mode(
+                name=name,
+                kind="check",
+                apply=False,
+                diff=True,
+                output_target=OutputTarget.FILE,
+                prune_views=True,
+                keep_diff_view=True,
+            )
+        case "check_apply_pruned":
+            return Mode(
+                name=name,
+                kind="check",
+                apply=True,
+                diff=False,
+                output_target=OutputTarget.FILE,
+                prune_views=True,
+                keep_diff_view=False,
+            )
+        case "check_stdout_pruned":
+            return Mode(
+                name=name,
+                kind="check",
+                apply=False,
+                diff=False,
+                output_target=OutputTarget.STDOUT,
+                prune_views=True,
+                keep_diff_view=False,
+            )
+        case "strip_pruned":
+            return Mode(
+                name=name,
+                kind="strip",
+                apply=False,
+                diff=False,
+                output_target=OutputTarget.FILE,
+                prune_views=True,
+                keep_diff_view=False,
+            )
+        case "strip_diff_pruned":
+            return Mode(
+                name=name,
+                kind="strip",
+                apply=False,
+                diff=True,
+                output_target=OutputTarget.FILE,
+                prune_views=True,
+                keep_diff_view=True,
+            )
         case _:
-            choices: str = ", ".join(DEFAULT_MODES)
+            choices: str = ", ".join(ALL_MODES)
             raise ValueError(f"Unknown mode {name!r}; expected one of: {choices}")
 
 
@@ -589,10 +684,21 @@ def _run_steps_with_samples(
     samples: list[StepSample] = []
     stdout_capture = io.StringIO()
 
+    step_count: int = len(pipeline)
     with contextlib.redirect_stdout(stdout_capture):
-        for step in pipeline:
+        for index, step in enumerate(pipeline):
             step_start: int = time.perf_counter_ns()
             ctx = step(ctx)
+            # Mirror the production runner lifecycle so per-step samples reflect
+            # the retained views available to later steps, not only final cleanup.
+            if mode.prune_views:
+                remaining_view_consumers: set[ViewSlot] = set()
+                for remaining_step in pipeline[index + 1 : step_count]:
+                    remaining_view_consumers.update(remaining_step.consumes_views)
+                ctx.views.release_consumed(
+                    remaining_view_consumers=remaining_view_consumers,
+                    keep_diff_view=mode.keep_diff_view,
+                )
             elapsed_ns: int = time.perf_counter_ns() - step_start
             current_bytes, peak_bytes = tracemalloc.get_traced_memory()
             views: dict[str, int | bool] = _view_sizes(ctx)
@@ -670,7 +776,7 @@ def _measure_one(
     )
 
 
-# --- Subprocess measurement helpers ---
+# ---- Subprocess isolation and JSON rehydration helpers ----
 
 
 def _object_mapping(value: object, *, message: str) -> dict[str, object]:
@@ -924,6 +1030,7 @@ def _json_default(value: object) -> object:
     raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
+# ---- CLI argument parsing and orchestration ----
 def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -965,8 +1072,11 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--mode",
         action="append",
-        choices=DEFAULT_MODES,
-        help="Mode to run. May be repeated. Defaults to the standard mode set.",
+        choices=ALL_MODES,
+        help=(
+            "Mode to run. May be repeated. Defaults to historical unpruned modes; "
+            "use *_pruned modes to measure view-pruning lifecycle behavior explicitly."
+        ),
     )
     parser.add_argument(
         "--scenario",


### PR DESCRIPTION
## Summary

This PR completes GitHub issue #140 by introducing typed view-consumer
declarations and incremental runtime view pruning.

### Changes

- add `ViewSlot` and typed `consumes_views` declarations to pipeline steps
- replace string-based pruning decisions with typed consumer metadata
- release consumed view payloads incrementally between pipeline steps
- preserve requested diff output through existing `keep_diff_view` behavior
- add regression coverage for:
  - consumed-view release behavior
  - diff retention behavior
  - concrete step `consumes_views` declarations
- extend benchmark tooling with explicit `*_pruned` modes
- preserve GitHub issue #134 baseline comparability by keeping historical suite
  modes unchanged
- document:
  - runtime view-pruning behavior
  - step view-consumer declarations
  - GitHub issue #140 benchmark results
  - benchmark comparability guidance

### Results

Measurements collected for GitHub issue #140 showed meaningful reductions in
retained memory for header-heavy workloads while preserving existing pipeline
behavior and benchmark reproducibility.

The largest improvements were observed in `huge_header` scenarios, with peak
traced allocations reduced by roughly one third. Diff-heavy pathological
workloads showed smaller improvements, confirming that future memory work should
continue focusing on diff generation and updated-file ownership.

### Validation

- all tests passing
- lifecycle regression tests added
- benchmark tooling exercised with explicit pruned modes
- developer documentation updated

### Related issues

Part of #132.
Builds on #133 and #134.
Closes #140.

### Breaking changes

None.

This change affects internal pipeline lifecycle management only. Public CLI
behavior, machine-readable output, configuration semantics, and file-processing
results remain unchanged.