### PR TITLE
Close #135 and #136 with repeatable updated-content composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ ______________________________________________________________________
   transient retention before later patch/write phases while preserving requested diff output.
 - Replaced string-based pipeline view-pruning decisions with typed `ViewSlot` consumer metadata
   declared by concrete pipeline steps.
+- Replaced eager replacement-image composition with a repeatable updated-content abstraction and
+  segment-backed updated-file views, allowing replacement planning to retain composed updated
+  content without requiring one materialized updated-file list.
 - Replaced the CLI presentation backend with Rich.
 - Adopted `rich-click` for CLI help rendering while preserving Click runtime semantics.
 - Centralized CLI option metadata and command-applicability groups used by diagnostics.
@@ -257,6 +260,9 @@ ______________________________________________________________________
   behavior in the developer pipeline documentation.
 - Documented GitHub issue 138 follow-up measurements showing reduced diff-generation allocations in
   diff-heavy workloads after avoiding duplicate INFO-level diff-preview formatting.
+- Documented GitHub issues 135 and 136, including repeatable updated-content architecture, remaining
+  materialization boundaries, follow-up benchmark measurements, and cumulative Track B
+  memory-allocation improvements relative to the GitHub issue 134 baseline.
 
 ### Internal - Unreleased
 
@@ -313,6 +319,10 @@ ______________________________________________________________________
   pipeline step `consumes_views` declarations.
 - Added regression coverage for diff-preview formatting behavior so expensive unified-diff preview
   rendering only occurs when INFO-level pipeline logging is enabled.
+- Added repeatable UpdatedContent pipeline abstractions together with segment-backed updated-file
+  composition for replacement-planning paths.
+- Added regression coverage for repeatable updated-content iteration and updated-view lifecycle
+  behavior.
 
 ### Notes - Unreleased
 

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -15,9 +15,10 @@ topmark:header:end
 This document describes the memory and allocation baseline methodology established for TopMark Track
 B performance work.
 
-The goal of these baselines is to measure current behavior before introducing optimizations. The
-measurements provide a factual reference for future work such as lazy updated-file composition,
-iterable-backed views, streaming writes, diff lifecycle improvements, and view-pruning changes.
+The goal of these baselines is to measure current behavior before and after incremental
+optimizations. The measurements provide a factual reference for work such as lazy updated-file
+composition, iterable-backed views, streaming writes, diff lifecycle improvements, and view-pruning
+changes.
 
 ______________________________________________________________________
 
@@ -379,6 +380,68 @@ The measurements also reinforce the broader findings from GitHub issues 133, 134
 
 These figures should be treated as directional rather than hard thresholds because memory
 measurements remain platform-, allocator-, and workload-sensitive.
+
+### Lazy updated-content composition follow-up (GitHub issues 135 and 136)
+
+GitHub issues 135 and 136 introduced a repeatable updated-content abstraction for pipeline-generated
+updated views. The implementation is intentionally narrow: replacement planning can now retain a
+segment-backed composition of the original prefix, rendered header, and original suffix instead of
+retaining one eager updated-file list.
+
+The updated-view contract now rejects arbitrary one-shot iterables in favor of repeatable updated
+content or materialized sequences. This preserves current CLI and API behavior while making the
+pipeline ownership model more explicit: pipeline-generated lazy content must be repeatable so
+comparer, patcher, and writer can consume updated content independently.
+
+The issue 135 and 136 measurements were collected using the same explicit `_pruned` benchmark modes
+used for the GitHub issue 140 and GitHub issue 138 follow-up measurements. Representative changes
+relative to the GitHub issue 138 results were:
+
+| Scenario             | Mode                | Peak traced change | RSS change |
+| -------------------- | ------------------- | -----------------: | ---------: |
+| `huge_diff`          | `strip_diff_pruned` |             +1.8 % |     +0.1 % |
+| `strip_large_header` | `strip_diff_pruned` |             +1.9 % |     +0.4 % |
+| `huge_header`        | `check_diff_pruned` |              0.0 % |     +0.3 % |
+| `strip_large_header` | `check_diff_pruned` |             +3.7 % |     +5.0 % |
+
+These results should be interpreted as effectively flat rather than as a regression. The measured
+pathological workloads remain dominated by comparison, patch generation, scanner/header ownership,
+or current consumers that still materialize updated lines when required by existing behavior.
+
+A follow-up materialization audit after the issue 135 and 136 changes did not identify an obvious
+additional low-risk optimization that belonged in the same change set. The remaining relevant
+materialization points are primarily:
+
+- comparison, where old and updated line sequences are currently materialized for equality checks;
+- patch generation, where updated lines and unified diff output are materialized;
+- writer sinks and stdout handling, which remain the focus of GitHub issue 137;
+- scanner/header extraction and processor-local normalization paths.
+
+For historical tracking, the issue 135 and 136 results can also be compared against the original
+GitHub issue 134 baseline measurements. This shows the cumulative effect of the Track B
+optimizations implemented so far.
+
+| Scenario             | Baseline mode | Current mode        | Peak traced change | RSS change |
+| -------------------- | ------------- | ------------------- | -----------------: | ---------: |
+| `huge_header`        | `check_diff`  | `check_diff_pruned` |            -37.2 % |     -9.0 % |
+| `huge_header`        | `strip_diff`  | `strip_diff_pruned` |            -38.6 % |     -5.5 % |
+| `huge_diff`          | `strip_diff`  | `strip_diff_pruned` |            -33.3 % |    -16.8 % |
+| `strip_large_header` | `strip_diff`  | `strip_diff_pruned` |            -39.5 % |    -19.1 % |
+
+Relative to the original GitHub issue 134 baseline, the cumulative Track B improvements remain
+substantial. The largest measured reductions are still attributable to earlier release of consumed
+views and reduced duplicate diff-preview formatting, while the issue 135 and 136 work primarily
+improves the architecture and ownership contract for updated content.
+
+The measurements confirm that lazy updated-content composition is now in place, but they also show
+that the current pathological benchmark set does not expose a large additional memory win from this
+change alone. This is consistent with the benchmark design: the largest measured cases still require
+comparison or unified diff generation, both of which continue to materialize updated content or diff
+text.
+
+GitHub issue 137 therefore remains a separate follow-up focused on streaming updated content through
+writer-related paths. Further diff-generation redesign should also remain separate from issues 135
+and 136 so that benchmark comparisons stay attributable to one architectural change at a time.
 
 ______________________________________________________________________
 

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -66,12 +66,19 @@ Hard-linked selected processing paths remain separate result payloads and are re
 unsupported, policy-blocked processing targets rather than being serialized as a single preferred
 path.
 
-Pipeline steps may also produce and consume phase-scoped view payloads. The `Step` protocol exposes
-`consumes_views`, and `BaseStep` stores those declarations as instance metadata. Runtime view
-pruning uses this typed metadata to release consumed view payloads between steps without relying on
-step-name string matching. The authoritative slot names are exposed by
+Pipeline steps may also produce and consume phase-scoped view payloads. The
+\[`Step`\][topmark.pipeline.protocols.Step] protocol exposes `consumes_views`, and
+\[`BaseStep`\][topmark.pipeline.steps.base.BaseStep] stores those declarations as instance metadata.
+Runtime view pruning uses this typed metadata to release consumed view payloads between steps
+without relying on step-name string matching. The authoritative slot names are exposed by
 \[`ViewSlot`\][topmark.pipeline.views.ViewSlot], and the view bundle is exposed by
 \[`Views`\][topmark.pipeline.views.Views].
+
+The updated-file view may contain either a materialized line sequence or an implementation of the
+repeatable \[`UpdatedContent`\][topmark.pipeline.views.UpdatedContent] protocol. This allows
+pipeline steps to represent updated content without necessarily materializing a full replacement
+file image while still supporting repeated consumption by comparison, patch-generation, and write
+steps.
 
 {% include-markdown "\_snippets/config-strictness.md" %}
 
@@ -107,7 +114,7 @@ API module.
 - Step protocol and base lifecycle contract:
   - [`topmark.pipeline.protocols`](../api/internals/topmark/pipeline/protocols.md)
   - [`topmark.pipeline.steps.base`](../api/internals/topmark/pipeline/steps/base.md)
-- Pipeline view slots and view bundle:
+- Pipeline view slots, view models, and repeatable updated-content abstractions:
   - [`topmark.pipeline.views`](../api/internals/topmark/pipeline/views.md)
 - Conceptual overview:
   - [`Pipelines (Concepts)`](./pipelines.md)

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -165,6 +165,11 @@ that read these views declare their dependencies via `consumes_views`. When runt
 enabled, the runner uses those declarations to release consumed view payloads after the last
 remaining consumer has run, while preserving requested output such as retained diffs.
 
+Updated-file views may be represented either as materialized line sequences or as repeatable
+updated-content abstractions. This allows replacement planning to compose updated content lazily
+while preserving existing comparer, patcher, and writer behavior. Pipeline-generated lazy updated
+content must remain repeatable because multiple downstream steps may consume the same updated view.
+
 For filesystem inputs, the processing context path is the selected processing path. It may differ
 from the path spelling supplied on the command line or in configuration when symlinks or equivalent
 relative spellings are involved.

--- a/src/topmark/pipeline/context/model.py
+++ b/src/topmark/pipeline/context/model.py
@@ -28,6 +28,7 @@ Sections:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from dataclasses import field
 from typing import TYPE_CHECKING
@@ -50,6 +51,7 @@ from topmark.pipeline.hints import HintLog
 from topmark.pipeline.hints import KnownCode
 from topmark.pipeline.hints import make_hint
 from topmark.pipeline.status import FsStatus
+from topmark.pipeline.views import UpdatedContent
 from topmark.pipeline.views import UpdatedView
 from topmark.pipeline.views import Views
 from topmark.utils.path import format_machine_path
@@ -307,6 +309,15 @@ class ProcessingContext:
             return self.views.image.iter_lines()
         return iter(())  # empty
 
+    def materialize_image_lines(self) -> list[str]:
+        """Return the original file image as a materialized list of lines.
+
+        Returns:
+            List of logical lines from the current image view. An empty list is returned if no image
+            is available.
+        """
+        return list(self.iter_image_lines())
+
     def image_line_count(self) -> int:
         """Return the number of logical lines without materializing.
 
@@ -325,23 +336,12 @@ class ProcessingContext:
             returns an empty iterator.
         """
         uv: UpdatedView | None = self.views.updated
-        if not uv or uv.lines is None:
+        if uv is None or uv.lines is None:
             return iter(())
-        seq_or_it: Sequence[str] | Iterable[str] = uv.lines
-        # If it's already a concrete sequence, avoid copying:
-        if isinstance(seq_or_it, list | tuple):
-            return iter(seq_or_it)
-        # Fallback: it's an arbitrary iterable (possibly a generator)
-        return iter(seq_or_it)
-
-    def materialize_image_lines(self) -> list[str]:
-        """Return the original file image as a materialized list of lines.
-
-        Returns:
-            List of logical lines from the current image view. An empty list is returned if no image
-            is available.
-        """
-        return list(self.iter_image_lines())
+        lines: UpdatedContent | Sequence[str] = uv.lines
+        if isinstance(lines, UpdatedContent):
+            return lines.iter_lines()
+        return iter(lines)
 
     def materialize_updated_lines(self) -> list[str]:
         """Return the updated file image as a materialized list of lines.
@@ -350,10 +350,12 @@ class ProcessingContext:
             List of updated lines if present, otherwise an empty list.
         """
         uv: UpdatedView | None = self.views.updated
-        if not uv or uv.lines is None:
+        if uv is None or uv.lines is None:
             return []
-        seq_or_it: Sequence[str] | Iterable[str] = uv.lines
-        return seq_or_it if isinstance(seq_or_it, list) else list(seq_or_it)
+        lines: UpdatedContent | Sequence[str] = uv.lines
+        if isinstance(lines, UpdatedContent):
+            return list(lines.iter_lines())
+        return list(lines)
 
     def to_dict(self) -> dict[str, object]:
         """Return a machine-readable representation of this processing result.

--- a/src/topmark/pipeline/steps/planner.py
+++ b/src/topmark/pipeline/steps/planner.py
@@ -62,8 +62,10 @@ from topmark.pipeline.status import StripStatus
 from topmark.pipeline.steps.base import BaseStep
 from topmark.pipeline.views import HeaderView
 from topmark.pipeline.views import RenderView
+from topmark.pipeline.views import UpdatedContent
 from topmark.pipeline.views import UpdatedView
 from topmark.pipeline.views import ViewSlot
+from topmark.pipeline.views import compose_updated_content
 from topmark.processors.base import NO_LINE_ANCHOR
 
 if TYPE_CHECKING:
@@ -335,8 +337,17 @@ class PlannerStep(BaseStep):
                 return
 
             # ✅ Preserve empty list as a valid updated image
-            seq: Sequence[str] | Iterable[str] = updated_view.lines
-            stripped_lines: list[str] = seq if isinstance(seq, list) else list(seq)
+            seq: UpdatedContent | Sequence[str] | Iterable[str] = updated_view.lines
+            if not ctx.leading_bom:
+                ctx.views.updated = UpdatedView(lines=seq)
+                ctx.status.plan = PlanStatus.REMOVED if apply else PlanStatus.PREVIEWED
+                return
+
+            stripped_lines: list[str]
+            if isinstance(seq, UpdatedContent):
+                stripped_lines = list(seq.iter_lines())
+            else:
+                stripped_lines = seq if isinstance(seq, list) else list(seq)
 
             # Re-attach BOM only if needed (no-op for empty)
             stripped_lines = _prepend_bom_to_lines_if_needed(stripped_lines, ctx)
@@ -470,20 +481,36 @@ class PlannerStep(BaseStep):
             start: int
             end: int
             start, end = existing_range
-            new_lines: list[str] = (
-                original_lines[:start] + rendered_expected_header_lines + original_lines[end + 1 :]
+            new_content: UpdatedContent | list[str]
+            if ctx.leading_bom:
+                # BOM reattachment may need to alter the first line, so keep this
+                # uncommon path materialized and policy-identical to the previous
+                # implementation.
+                new_lines: list[str] = (
+                    original_lines[:start]
+                    + rendered_expected_header_lines
+                    + original_lines[end + 1 :]
+                )
+                new_content = _prepend_bom_to_lines_if_needed(new_lines, ctx)
+            else:
+                new_content = compose_updated_content(
+                    original_lines[:start],
+                    rendered_expected_header_lines,
+                    original_lines[end + 1 :],
+                )
+
+            materialized_new_lines: list[str] = (
+                new_content if isinstance(new_content, list) else list(new_content.iter_lines())
             )
-            # Prepend BOM if needed
-            new_lines = _prepend_bom_to_lines_if_needed(new_lines, ctx)
             # If replacement is identical to the original, treat as a no-op.
-            if new_lines == original_lines:
+            if materialized_new_lines == original_lines:
                 ctx.status.plan = PlanStatus.SKIPPED
                 ctx.views.updated = UpdatedView(lines=original_lines)
                 logger.trace("Updater: replacement yields no changes for %s", ctx.path)
                 return
             ctx.status.plan = PlanStatus.REPLACED if apply else PlanStatus.PREVIEWED
-            ctx.views.updated = UpdatedView(lines=new_lines)
-            logger.trace("Updated file (replace):\n%s", "".join(new_lines))
+            ctx.views.updated = UpdatedView(lines=new_content)
+            logger.trace("Updated file (replace):\n%s", "".join(materialized_new_lines))
             return
 
         # --- Insert: text-based first ---

--- a/src/topmark/pipeline/views.py
+++ b/src/topmark/pipeline/views.py
@@ -32,6 +32,7 @@ from topmark.core.logging import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from collections.abc import Iterator
     from collections.abc import Mapping
     from collections.abc import Sequence
 
@@ -79,6 +80,8 @@ class Releasable(Protocol):
         ...
 
 
+# Keep Protocol explicit so Pyright treats this as a structural protocol,
+# not as a nominal subclass of Releasable.
 class FileImageView(Releasable, Protocol):
     """Protocol for read-only access to a file's logical lines.
 
@@ -223,13 +226,79 @@ class RenderView(Releasable):
         self.block = None
 
 
+@runtime_checkable
+class UpdatedContent(Protocol):
+    """Repeatable updated-file content abstraction.
+
+    Implementations expose updated file lines without requiring callers to own
+    one eagerly materialized ``list[str]``. Unlike a bare iterator, each call to
+    `iter_lines` must return a fresh iterator so comparer, patcher, and writer
+    can consume the same updated content independently.
+    """
+
+    def iter_lines(self) -> Iterable[str]:
+        """Iterate updated file lines repeatably."""
+        ...
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate updated file lines repeatably."""
+        ...
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SegmentUpdatedContent:
+    """Segment-backed repeatable updated file content.
+
+    The content is represented as ordered line segments, typically slices of the
+    original image plus a rendered-header segment. The segments themselves are
+    not copied by this class. Each iteration walks the segments in order.
+
+    Attributes:
+        segments: Ordered, repeatable line segments composing the updated image.
+    """
+
+    segments: tuple[Sequence[str], ...]
+
+    def iter_lines(self) -> Iterable[str]:
+        """Iterate the composed updated image without materializing it as one list.
+
+        Returns:
+            Iterable[str]: Updated lines from every segment in order.
+        """
+        return iter(self)
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate the composed updated image as a repeatable iterable.
+
+        Yields:
+            str: Updated lines from every segment in order.
+        """
+        for segment in self.segments:
+            yield from segment
+
+
+def compose_updated_content(*segments: Sequence[str]) -> SegmentUpdatedContent:
+    """Create a repeatable segment-backed updated-content view.
+
+    Args:
+        *segments: Ordered line segments. Empty segments are retained only when
+            all segments are empty so an explicitly empty updated image remains
+            representable.
+
+    Returns:
+        SegmentUpdatedContent: Repeatable content composed from the supplied
+        segments.
+    """
+    return SegmentUpdatedContent(segments=tuple(segments))
+
+
 @dataclass(kw_only=True, slots=True)
 class UpdatedView(Releasable):
     """View of the pipeline's updated file image.
 
-    ``lines`` may be a sequence (e.g., ``list[str]``) or a lazy iterable
-    (e.g., a generator composing a three-segment view) to avoid materializing
-    large buffers up-front.
+    ``lines`` may be a sequence or an `UpdatedContent` implementation. Bare
+    iterables remain accepted for backward compatibility, but repeatable
+    `UpdatedContent` is preferred for pipeline-generated updates.
 
     Attributes:
         lines: Updated file image as a sequence or iterable of lines, or ``None`` when no update
@@ -237,11 +306,11 @@ class UpdatedView(Releasable):
 
     Notes:
         Pruning is handled by calling `release()`, which clears the updated file
-        image reference. If ``lines`` is an iterator, callers must treat this view
-        as single-pass.
+        image reference. Pipeline-generated lazy content should be repeatable;
+        arbitrary caller-provided iterables may still be single-pass.
     """
 
-    lines: Sequence[str] | Iterable[str] | None
+    lines: UpdatedContent | Sequence[str] | None
 
     def release(self) -> None:
         """Release the updated file image payload to reduce memory usage."""

--- a/tests/pipeline/test_updated_content.py
+++ b/tests/pipeline/test_updated_content.py
@@ -1,0 +1,38 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_updated_content.py
+#   file_relpath : tests/pipeline/test_updated_content.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Regression tests for repeatable updated-content views."""
+
+from __future__ import annotations
+
+from topmark.pipeline.views import UpdatedContent
+from topmark.pipeline.views import UpdatedView
+from topmark.pipeline.views import compose_updated_content
+
+
+def test_segment_updated_content_is_repeatable() -> None:
+    """Segment-backed updated content can be consumed more than once."""
+    content: UpdatedContent = compose_updated_content(
+        ["prefix\n"],
+        ["header\n"],
+        ["body\n"],
+    )
+
+    assert list(content.iter_lines()) == ["prefix\n", "header\n", "body\n"]
+    assert list(content.iter_lines()) == ["prefix\n", "header\n", "body\n"]
+
+
+def test_updated_view_releases_segment_content() -> None:
+    """UpdatedView release clears the composed content reference."""
+    view = UpdatedView(lines=compose_updated_content(["a\n"], ["b\n"]))
+
+    view.release()
+
+    assert view.lines is None


### PR DESCRIPTION
## Summary

This PR implements GitHub issues #135 and #136 from the Track B
memory-materialization work under parent issue #132.

The pipeline now supports repeatable updated-content abstractions and
segment-backed updated-file composition for replacement-planning paths.

The goal is to eliminate unnecessary eager updated-file ownership while
preserving existing CLI, API, comparer, patcher, writer, and benchmark
behavior.

Closes #135
Closes #136

## Changes

### Updated-content architecture

- Added repeatable `UpdatedContent` protocol
- Added `SegmentUpdatedContent`
- Added `compose_updated_content()`
- Narrowed updated-view ownership contracts to:
  - `UpdatedContent`
  - `Sequence[str]`
- Removed reliance on arbitrary one-shot iterables for
  pipeline-generated updated content

### Planner changes

- Replacement planning now uses segment-backed composition when BOM
  reattachment is not required
- Existing BOM-sensitive paths remain materialized to preserve behavior
- No-op replacement detection remains unchanged

### Context helpers

- Updated iteration and materialization helpers to consume
  `UpdatedContent`
- Added `materialize_image_lines()` helper for explicit ownership
  boundaries

### Tests

Added focused regression coverage for:

- repeatable updated-content iteration
- repeatable consumption semantics
- UpdatedView lifecycle behavior

### Documentation

Updated:

- `docs/dev/performance-baselines.md`
- `docs/dev/pipelines.md`
- `docs/dev/pipelines-reference.md`

including:

- updated-content ownership model
- repeatable-consumption requirements
- materialization audit findings
- benchmark follow-up measurements

## Benchmark results

Relative to the original GitHub issue #134 baseline, cumulative Track B
improvements remain substantial:

| Scenario | Peak traced | RSS |
|----------|------------:|----:|
| huge_header (check) | -37.2% | -9.0% |
| huge_header (strip) | -38.6% | -5.5% |
| huge_diff (strip) | -33.3% | -16.8% |
| strip_large_header (strip) | -39.5% | -19.1% |

The #135/#136 architectural change itself measured largely flat versus
the #138 checkpoint, indicating that current pathological workloads are
still dominated by comparison and unified-diff generation paths.

## Materialization audit

A follow-up review of remaining pipeline materialization points found no
obvious low-risk optimization that belonged in this change set.

Remaining materialization is primarily located in:

- comparison
- unified diff generation
- writer/stdout paths
- scanner/header extraction
- processor-local normalization

Issue #137 therefore remains a separate follow-up focused on writer-side
streaming behavior.

## Breaking changes

None.

This PR preserves existing CLI behavior, machine-readable output
contracts, public API behavior, and benchmark comparability.

## Issue status

This PR closes:

- #135 Design lazy updated-file composition for pipeline updates
- #136 Implement iterable-backed UpdatedView generation

Follow-up work remains in:

- #137 Stream updated content through WriterStep