### PR TITLE
Stream updated content through WriterStep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ ______________________________________________________________________
 - Replaced eager replacement-image composition with a repeatable updated-content abstraction and
   segment-backed updated-file views, allowing replacement planning to retain composed updated
   content without requiring one materialized updated-file list.
+- Streamed writer-owned updated-content consumption through repeatable updated-line iteration for
+  file sinks and STDOUT emission, removing the remaining writer-local eager updated-line
+  materialization while preserving existing comparison, patch-generation, and presentation behavior.
 - Replaced the CLI presentation backend with Rich.
 - Adopted `rich-click` for CLI help rendering while preserving Click runtime semantics.
 - Centralized CLI option metadata and command-applicability groups used by diagnostics.
@@ -263,6 +266,9 @@ ______________________________________________________________________
 - Documented GitHub issues 135 and 136, including repeatable updated-content architecture, remaining
   materialization boundaries, follow-up benchmark measurements, and cumulative Track B
   memory-allocation improvements relative to the GitHub issue 134 baseline.
+- Documented GitHub issue 137, including writer-owned updated-content streaming, remaining
+  materialization boundaries, follow-up benchmark measurements, and the separation between writer
+  streaming and broader stdout-rendering ownership.
 
 ### Internal - Unreleased
 
@@ -319,8 +325,11 @@ ______________________________________________________________________
   pipeline step `consumes_views` declarations.
 - Added regression coverage for diff-preview formatting behavior so expensive unified-diff preview
   rendering only occurs when INFO-level pipeline logging is enabled.
-- Added repeatable UpdatedContent pipeline abstractions together with segment-backed updated-file
+- Added repeatable `UpdatedContent` pipeline abstractions together with segment-backed updated-file
   composition for replacement-planning paths.
+- Added streaming writer helpers and regression coverage for repeatable updated-content consumption
+  through atomic-file, in-place-file, and STDOUT writer paths, including STDOUT write-failure
+  handling.
 - Added regression coverage for repeatable updated-content iteration and updated-view lifecycle
   behavior.
 

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -439,9 +439,39 @@ change alone. This is consistent with the benchmark design: the largest measured
 comparison or unified diff generation, both of which continue to materialize updated content or diff
 text.
 
-GitHub issue 137 therefore remains a separate follow-up focused on streaming updated content through
-writer-related paths. Further diff-generation redesign should also remain separate from issues 135
-and 136 so that benchmark comparisons stay attributable to one architectural change at a time.
+### Stream updated content through WriterStep (GitHub issue 137)
+
+GitHub issue 137 completed the writer-owned part of that follow-up by keeping file sinks streaming
+through `ctx.iter_updated_lines()` and changing the STDOUT sink to emit updated content line by line
+while accounting for UTF-8 bytes incrementally. This removes the remaining writer-local eager
+updated-line materialization without changing comparison, patch generation, or broader stdout
+presentation behavior. Further diff-generation redesign and stdout rendering/materialization work
+should remain separate so that benchmark comparisons stay attributable to one architectural change
+at a time.
+
+Benchmark results after GitHub issue 137 were effectively flat relative to the previous checkpoint
+(GitHub issues 140, 138, 135 and 136). This was expected because the remaining writer-local
+materialization occurred only in STDOUT emission paths, while the pathological benchmark scenarios
+remain dominated by comparison, patch generation, diff retention, scanner ownership, and file-image
+ownership. The change therefore improves ownership clarity and removes the final writer-local eager
+updated-line materialization without producing a measurable benchmark shift in the current benchmark
+suite.
+
+Relative to the
+[lazy updated-content composition follow-up (GitHub issues 135 and 136)](#lazy-updated-content-composition-follow-up-github-issues-135-and-136):
+
+| Scenario           | Mode              | Peak traced | RSS   |
+| ------------------ | ----------------- | ----------- | ----- |
+| huge_diff          | strip_diff_pruned | ~0.0%       | 0.0%  |
+| strip_large_header | strip_diff_pruned | ~0.0%       | -0.6% |
+| huge_header        | check_diff_pruned | 0.0%        | -0.4% |
+
+The results are interpreted as effectively flat.
+
+Follow-up:
+
+- stdout presentation outside writer-owned updated-content emission, which remains the focus of
+  GitHub issue 139;
 
 ______________________________________________________________________
 

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -77,8 +77,9 @@ without relying on step-name string matching. The authoritative slot names are e
 The updated-file view may contain either a materialized line sequence or an implementation of the
 repeatable \[`UpdatedContent`\][topmark.pipeline.views.UpdatedContent] protocol. This allows
 pipeline steps to represent updated content without necessarily materializing a full replacement
-file image while still supporting repeated consumption by comparison, patch-generation, and write
-steps.
+file image while still supporting repeated consumption by comparison, patch generation, and writing.
+`WriterStep` streams both file writes and STDOUT emission through the updated-line iterator;
+comparer and patcher materialization remain explicit algorithm-level ownership points.
 
 {% include-markdown "\_snippets/config-strictness.md" %}
 

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -166,9 +166,11 @@ enabled, the runner uses those declarations to release consumed view payloads af
 remaining consumer has run, while preserving requested output such as retained diffs.
 
 Updated-file views may be represented either as materialized line sequences or as repeatable
-updated-content abstractions. This allows replacement planning to compose updated content lazily
-while preserving existing comparer, patcher, and writer behavior. Pipeline-generated lazy updated
-content must remain repeatable because multiple downstream steps may consume the same updated view.
+updated-content abstractions. This allows replacement planning to compose updated content lazily.
+Pipeline-generated lazy updated content must remain repeatable because comparison, patch generation,
+and writing may consume the same updated view. Writer file sinks and STDOUT emission stream through
+the context's updated-line iterator; comparison and patch generation still materialize updated lines
+where required by their current algorithms.
 
 For filesystem inputs, the processing context path is the selected processing path. It may differ
 from the path spelling supplied on the command line or in configuration when symlinks or equivalent

--- a/src/topmark/pipeline/steps/writer.py
+++ b/src/topmark/pipeline/steps/writer.py
@@ -16,7 +16,9 @@ and public API.
 
 This step is responsible for the final I/O after all other steps have computed
 `ctx.views.updated` and selected the intended `PlanStatus` (INSERTED, REPLACED, REMOVED,
-or PREVIEWED for stdout output).
+or PREVIEWED for stdout output). File and stdout sinks stream from repeatable updated
+content via `ProcessingContext.iter_updated_lines()` instead of requiring an eagerly
+materialized updated-line list.
 It also applies policy gates (e.g., header mutation mode) so that command-line intent
 and config policies are centralized here.
 
@@ -27,7 +29,7 @@ Sinks
   POSIX-only durability and permission helpers such as `os.fchmod()` and `os.O_DIRECTORY` are used
   only when available; Windows falls back to best-effort path-based permission handling and skips
   directory `fsync()`.
-- StdoutSink: writes the updated content to stdout (stdin-content mode).
+- StdoutSink: streams the updated content to stdout (stdin-content mode).
 - NullSink: no-op (dry-run).
 
 The step respects
@@ -42,6 +44,7 @@ import contextlib
 import os
 import secrets
 import stat
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Protocol
@@ -57,11 +60,11 @@ from topmark.pipeline.hints import KnownCode
 from topmark.pipeline.status import PlanStatus
 from topmark.pipeline.status import WriteStatus
 from topmark.pipeline.steps.base import BaseStep
-from topmark.pipeline.views import UpdatedView
 from topmark.pipeline.views import ViewSlot
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import BinaryIO
 
     from topmark.config.policy import FrozenPolicy
     from topmark.core.logging import TopmarkLogger
@@ -73,22 +76,54 @@ logger: TopmarkLogger = get_logger(__name__)
 
 
 # --- DRY helpers for writer sinks ---
-def _updated_lines(ctx: ProcessingContext) -> list[str] | None:
-    """Materialize updated lines or return None if unavailable.
+def _has_updated_lines(ctx: ProcessingContext) -> bool:
+    """Return whether an updated image exists without materializing it.
 
     Args:
         ctx: Processing context.
 
     Returns:
-        Updated lines as a list, or None if no updated image exists.
+        True when the context holds updated content, otherwise False.
     """
     uv: UpdatedView | None = ctx.views.updated
-    if not uv or uv.lines is None:
-        return None
-    return ctx.materialize_updated_lines()
+    return uv is not None and uv.lines is not None
 
 
-# TODO: currently `_normalize_eof` isn't applied by _InplaceFileSink / _AtomicFileSink. Verify
+def _write_encoded_lines(*, ctx: ProcessingContext, file: BinaryIO) -> int:
+    """Stream updated lines to a binary file object.
+
+    Args:
+        ctx: Processing context containing repeatable updated content.
+        file: Binary file object to receive UTF-8 encoded lines.
+
+    Returns:
+        Number of UTF-8 bytes written.
+    """
+    bytes_written: int = 0
+    for line in ctx.iter_updated_lines():
+        encoded: bytes = line.encode("utf-8")
+        file.write(encoded)
+        bytes_written += len(encoded)
+    return bytes_written
+
+
+def _write_stdout_lines(ctx: ProcessingContext) -> int:
+    """Stream updated lines to standard output.
+
+    Args:
+        ctx: Processing context containing repeatable updated content.
+
+    Returns:
+        Number of UTF-8 bytes emitted.
+    """
+    bytes_written: int = 0
+    for line in ctx.iter_updated_lines():
+        bytes_written += len(line.encode("utf-8"))
+        sys.stdout.write(line)
+    return bytes_written
+
+
+# TODO: currently `_normalize_eof` isn't applied by InplaceFileSink / AtomicFileSink. Verify
 # whether we still need to add this "no trailing newline" semantics for file writes in the real
 # sinks (likely by adjusting what ctx.iter_updated_lines() yields).
 # def _normalize_eof(text: str, ctx: ProcessingContext) -> str:
@@ -135,8 +170,9 @@ class WriteResult:
 
     Attributes:
         status: Final status reported by the sink.
-        bytes_written: Number of bytes written when the sink can report one;
-            zero for dry-run, skipped, failed, or unreported file writes.
+        bytes_written: Number of bytes written when reported by the sink. Stdout
+            reports emitted UTF-8 bytes; file sinks currently report zero after
+            successful writes.
     """
 
     status: WriteStatus
@@ -174,17 +210,18 @@ class StdoutSink:
             ``WRITTEN`` with the number of UTF-8 bytes printed when content is available;
             otherwise ``SKIPPED`` with zero bytes written.
         """
-        lines: list[str] | None = _updated_lines(ctx)
-        if lines is None:
+        if not _has_updated_lines(ctx):
             logger.debug(
                 "StdoutSink: ctx.views.updated not defined or ctx.views.updated.lines not defined: "
                 "nothing to do"
             )
             return WriteResult(status=WriteStatus.SKIPPED, bytes_written=0)
 
-        text: str = "".join(lines)
-        size: int = len(text.encode("utf-8"))
-        print(text, end="")  # noqa: T201 (intentional: pipeline handles stdout here)
+        try:
+            size: int = _write_stdout_lines(ctx)
+        except (OSError, UnicodeError) as e:
+            ctx.diagnostics.add_error(f"Stdout write failed: {e}")
+            return WriteResult(status=WriteStatus.FAILED, bytes_written=0)
         return WriteResult(status=WriteStatus.WRITTEN, bytes_written=size)
 
 
@@ -202,13 +239,14 @@ class InplaceFileSink(WriteSink):
     def write(self, *, ctx: ProcessingContext) -> WriteResult:
         """Write updated content directly into the original file (in-place).
 
-        Opens the file in binary write mode, truncates its contents, and writes
-        `ctx.views.updated.lines` directly. This operation preserves the inode identity
-        but may leave a truncated file if the process is interrupted mid-write.
+        Opens the file in binary write mode, truncates its contents, and streams
+        `ctx.iter_updated_lines()` to the target file. This operation preserves the
+        inode identity but may leave a truncated file if the process is interrupted
+        mid-write.
 
         Args:
-            ctx: The active processing context, expected to contain `ctx.views.updated.lines`
-                with UTF-8-encoded text to write.
+            ctx: The active processing context, expected to provide repeatable updated
+                content through `ctx.iter_updated_lines()`.
 
         Returns:
             Structured write result containing `WriteStatus.WRITTEN` on success,
@@ -224,9 +262,7 @@ class InplaceFileSink(WriteSink):
                 mode = None
 
             with path.open("wb") as f:
-                # Prefer streaming via the iterator (good for memory)
-                for line in ctx.iter_updated_lines():
-                    f.write(line.encode("utf-8"))
+                _write_encoded_lines(ctx=ctx, file=f)
                 f.flush()
                 os.fsync(f.fileno())
             if mode is not None:
@@ -260,14 +296,14 @@ class AtomicFileSink(WriteSink):
     def write(self, *, ctx: ProcessingContext) -> WriteResult:
         """Atomically replace the target file by writing to a temp file first.
 
-        Writes `ctx.views.updated.lines` to a temporary file in the same directory,
+        Streams `ctx.iter_updated_lines()` to a temporary file in the same directory,
         calls `os.fsync()` to ensure durability, and performs `os.replace()` to
         atomically swap it in place. The operation guarantees that readers will
         either see the old file or the complete new file, never a partial write.
 
         Args:
-            ctx: The active processing context, expected to
-                contain `ctx.views.updated.lines` with UTF-8-encoded text to write.
+            ctx: The active processing context, expected to provide repeatable updated
+                content through `ctx.iter_updated_lines()`.
 
         Returns:
             Structured write result with `WriteStatus.WRITTEN` on success, or
@@ -304,9 +340,7 @@ class AtomicFileSink(WriteSink):
                         # directly as a best-effort fallback.
                         with contextlib.suppress(OSError):
                             tmp.chmod(mode)
-                # Prefer streaming via the iterator (good for memory)
-                for line in ctx.iter_updated_lines():
-                    f.write(line.encode("utf-8"))
+                _write_encoded_lines(ctx=ctx, file=f)
                 f.flush()
                 os.fsync(f.fileno())
 

--- a/tests/pipeline/steps/test_writer.py
+++ b/tests/pipeline/steps/test_writer.py
@@ -26,7 +26,9 @@ from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import PlanStatus
 from topmark.pipeline.status import ResolveStatus
 from topmark.pipeline.status import WriteStatus
+from topmark.pipeline.views import UpdatedContent
 from topmark.pipeline.views import UpdatedView
+from topmark.pipeline.views import compose_updated_content
 from topmark.runtime.model import RunOptions
 
 if TYPE_CHECKING:
@@ -34,6 +36,7 @@ if TYPE_CHECKING:
 
     import pytest
     from _pytest.capture import CaptureResult
+    from _pytest.monkeypatch import MonkeyPatch
 
     from topmark.config.model import FrozenConfig
     from topmark.config.model import MutableConfig
@@ -43,7 +46,7 @@ if TYPE_CHECKING:
 def _make_writer_context(
     path: Path,
     *,
-    updated_lines: list[str] | None = None,
+    updated_lines: UpdatedContent | list[str] | None = None,
     apply_changes: bool = True,
     plan_status: PlanStatus = PlanStatus.REPLACED,
     output_target: OutputTarget = OutputTarget.FILE,
@@ -64,8 +67,24 @@ def _make_writer_context(
     ctx.status.plan = plan_status
     ctx.views.updated = None if updated_lines is None else UpdatedView(lines=updated_lines)
     ctx.newline_style = "\n"
-    ctx.ends_with_newline = bool(updated_lines and updated_lines[-1].endswith("\n"))
+    ctx.ends_with_newline = (
+        bool(updated_lines and updated_lines[-1].endswith("\n"))
+        if isinstance(updated_lines, list)
+        else True
+    )
     return ctx
+
+
+def _forbid_updated_materialization(monkeypatch: MonkeyPatch) -> None:
+    """Fail the test if WriterStep falls back to eager updated-line materialization."""
+
+    def fail_materialize(self: ProcessingContext) -> list[str]:
+        raise AssertionError("WriterStep must stream updated content")
+
+    monkeypatch.setattr(
+        "topmark.pipeline.context.model.ProcessingContext.materialize_updated_lines",
+        fail_materialize,
+    )
 
 
 def test_writer_dry_run_skips_filesystem_mutation(tmp_path: Path) -> None:
@@ -254,3 +273,109 @@ def test_writer_write_failure_sets_failed_status_and_preserves_original_file(
     assert ctx.status.write is WriteStatus.FAILED
     assert not path.exists()
     assert any("Atomic write failed:" in diagnostic.message for diagnostic in ctx.diagnostics)
+
+
+def test_writer_atomic_apply_streams_updated_content(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Atomic file writes should consume UpdatedContent without materializing it first."""
+    path: Path = tmp_path / "atomic_lazy.py"
+    path.write_text("original\n", encoding="utf-8")
+    _forbid_updated_materialization(monkeypatch)
+    content: UpdatedContent = compose_updated_content(["updated\n"], ["body\n"])
+    ctx: ProcessingContext = _make_writer_context(
+        path,
+        updated_lines=content,
+        apply_changes=True,
+        plan_status=PlanStatus.REPLACED,
+        file_write_strategy=FileWriteStrategy.ATOMIC,
+    )
+
+    ctx = run_writer(ctx)
+
+    assert ctx.status.write is WriteStatus.WRITTEN
+    assert path.read_text(encoding="utf-8") == "updated\nbody\n"
+
+
+def test_writer_inplace_apply_streams_updated_content(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """In-place file writes should consume UpdatedContent without materializing it first."""
+    path: Path = tmp_path / "inplace_lazy.py"
+    path.write_text("original\n", encoding="utf-8")
+    _forbid_updated_materialization(monkeypatch)
+    content: UpdatedContent = compose_updated_content(["updated\n"], ["body\n"])
+    ctx: ProcessingContext = _make_writer_context(
+        path,
+        updated_lines=content,
+        apply_changes=True,
+        plan_status=PlanStatus.REPLACED,
+        file_write_strategy=FileWriteStrategy.INPLACE,
+    )
+
+    ctx = run_writer(ctx)
+
+    assert ctx.status.write is WriteStatus.WRITTEN
+    assert path.read_text(encoding="utf-8") == "updated\nbody\n"
+
+
+def test_writer_stdout_preview_streams_updated_content(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """STDOUT writes should consume UpdatedContent without materializing it first."""
+    path: Path = tmp_path / "stdout_lazy.py"
+    path.write_text("original\n", encoding="utf-8")
+    _forbid_updated_materialization(monkeypatch)
+    content: UpdatedContent = compose_updated_content(["updated\n"], ["body\n"])
+    ctx: ProcessingContext = _make_writer_context(
+        path,
+        updated_lines=content,
+        apply_changes=False,
+        plan_status=PlanStatus.PREVIEWED,
+        output_target=OutputTarget.STDOUT,
+    )
+
+    ctx = run_writer(ctx)
+
+    captured: CaptureResult[str] = capsys.readouterr()
+    assert ctx.status.write is WriteStatus.WRITTEN
+    assert captured.out == "updated\nbody\n"
+    assert path.read_text(encoding="utf-8") == "original\n"
+
+
+def test_writer_stdout_preview_failure_sets_failed_status(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """STDOUT write failures should set FAILED and record a diagnostic."""
+    path: Path = tmp_path / "stdout_failure.py"
+    path.write_text("original\n", encoding="utf-8")
+    ctx: ProcessingContext = _make_writer_context(
+        path,
+        updated_lines=["updated\n"],
+        apply_changes=False,
+        plan_status=PlanStatus.PREVIEWED,
+        output_target=OutputTarget.STDOUT,
+    )
+
+    class FailingStdout:
+        """Minimal stdout replacement that fails on writes."""
+
+        def write(self, text: str) -> int:
+            """Raise an output failure for any attempted write."""
+            raise OSError("stdout unavailable")
+
+    monkeypatch.setattr("topmark.pipeline.steps.writer.sys.stdout", FailingStdout())
+
+    ctx = run_writer(ctx)
+
+    assert ctx.status.write is WriteStatus.FAILED
+    assert path.read_text(encoding="utf-8") == "original\n"
+    assert any(
+        "Stdout write failed: stdout unavailable" in diagnostic.message
+        for diagnostic in ctx.diagnostics
+    )


### PR DESCRIPTION
## Summary

- closes #137
- stream writer-owned updated-content consumption through `WriterStep` file and STDOUT sinks
- remove the remaining writer-local eager updated-line materialization
- preserve existing comparison, patch-generation, CLI/API, machine-readable output, and presentation behavior
- add regression coverage for atomic-file, in-place-file, and STDOUT writer streaming
- add STDOUT write-failure coverage
- document the #137 architecture and benchmark outcome in the developer performance-baseline and pipeline docs

## Breaking changes

None. This is an internal pipeline memory-ownership improvement with preserved user-facing behavior.