### PR TITLE
Add durable processing result primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,9 @@ ______________________________________________________________________
   handling.
 - Added regression coverage for repeatable updated-content iteration and updated-view lifecycle
   behavior.
+- Added immutable `StatusSnapshot` and `ProcessingResult` result-reduction primitives as the first
+  stage of separating volatile pipeline execution state from durable processing outcomes (GitHub
+  issue #148).
 
 ### Notes - Unreleased
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -32,6 +32,8 @@ The following architectural contracts are part of the stable 1.x design:
 - Registry mutation is represented as explicit overlay state.
 - Pipeline execution remains independent from presentation rendering.
 - Machine-readable output remains independent from human-facing TEXT and Markdown output.
+- Mutable pipeline execution state can be reduced to durable result snapshots without changing
+  runner, CLI, API, or presentation behavior.
 
 ______________________________________________________________________
 

--- a/src/topmark/pipeline/context/status.py
+++ b/src/topmark/pipeline/context/status.py
@@ -50,6 +50,7 @@ status evaluation remains predictable, testable, and import-safe.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import fields
 from typing import TypedDict
 
 from topmark.pipeline.hints import Axis
@@ -80,6 +81,125 @@ class AxisStatusPayload(TypedDict):
     axis: str
     name: str
     label: str
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class StatusSnapshot:
+    """Immutable snapshot of per-axis pipeline status.
+
+    A `StatusSnapshot` captures the durable result-facing status values from a
+    mutable [`ProcessingStatus`][topmark.pipeline.context.status.ProcessingStatus]
+    instance without retaining the mutable source object. It is intended for
+    post-run result models that should remain stable after the pipeline context
+    continues to mutate or is released.
+
+    Attributes:
+        resolve: Snapshot of file-type resolution status.
+        fs: Snapshot of file system status.
+        content: Snapshot of content-level status.
+        header: Snapshot of header detection and parsing status.
+        generation: Snapshot of header generation status.
+        render: Snapshot of header rendering status.
+        strip: Snapshot of header stripping status.
+        comparison: Snapshot of comparison status.
+        plan: Snapshot of update-planning status.
+        patch: Snapshot of patch generation status.
+        write: Snapshot of write status.
+    """
+
+    resolve: ResolveStatus
+    fs: FsStatus
+    content: ContentStatus
+    header: HeaderStatus
+    generation: GenerationStatus
+    render: RenderStatus
+    strip: StripStatus
+    comparison: ComparisonStatus
+    plan: PlanStatus
+    patch: PatchStatus
+    write: WriteStatus
+
+    @classmethod
+    def from_status(cls, status: ProcessingStatus) -> StatusSnapshot:
+        """Create an immutable status snapshot from mutable pipeline status.
+
+        Args:
+            status: Mutable status object to snapshot.
+
+        Returns:
+            Detached immutable status snapshot containing the current per-axis values.
+        """
+        return cls(
+            resolve=status.resolve,
+            fs=status.fs,
+            content=status.content,
+            header=status.header,
+            generation=status.generation,
+            render=status.render,
+            strip=status.strip,
+            comparison=status.comparison,
+            plan=status.plan,
+            patch=status.patch,
+            write=status.write,
+        )
+
+    def get(self, axis: Axis) -> BaseStatus:
+        """Get the status for a given Axis.
+
+        Args:
+            axis: The Axis we want to get the status for.
+
+        Returns:
+            The status for the given Axis.
+        """
+        match axis:
+            case Axis.RESOLVE:
+                return self.resolve
+            case Axis.FS:
+                return self.fs
+            case Axis.CONTENT:
+                return self.content
+            case Axis.HEADER:
+                return self.header
+            case Axis.GENERATION:
+                return self.generation
+            case Axis.RENDER:
+                return self.render
+            case Axis.STRIP:
+                return self.strip
+            case Axis.COMPARISON:
+                return self.comparison
+            case Axis.PLAN:
+                return self.plan
+            case Axis.PATCH:
+                return self.patch
+            case Axis.WRITE:
+                return self.write
+
+    def to_dict(self) -> dict[str, AxisStatusPayload]:
+        """Return axis → {axis, name, label} payload for all axes.
+
+        Returns:
+            Mapping from axis name to its status payload.
+        """
+        data: dict[str, AxisStatusPayload] = {}
+        for item in fields(self):
+            axis_name: str = item.name
+            status: BaseStatus = getattr(self, axis_name)
+            data[axis_name] = {
+                "axis": axis_name,
+                "name": status.name,
+                "label": status.value,
+            }
+        return data
+
+    def has_write_outcome(self) -> bool:
+        """Return True if the write axis has reached a non-pending outcome.
+
+        Returns:
+            `True` when the write status is anything other than `PENDING`.
+        """
+        return self.write is not WriteStatus.PENDING
 
 
 @dataclass(kw_only=True, slots=True)

--- a/src/topmark/pipeline/hints.py
+++ b/src/topmark/pipeline/hints.py
@@ -235,19 +235,6 @@ class KnownCode(EnumIntrospectionMixin, str, Enum):
     PATCH_FAILED = "patch:failed"
 
 
-# Higher is more severe/important
-_CLUSTER_SCORE: dict[str, int] = {
-    Cluster.ERROR.value: 100,
-    Cluster.BLOCKED_POLICY.value: 90,
-    Cluster.SKIPPED.value: 80,
-    Cluster.UNSUPPORTED.value: 80,
-    Cluster.CHANGED.value: 70,
-    Cluster.WOULD_CHANGE.value: 60,
-    Cluster.UNCHANGED.value: 50,
-    Cluster.PENDING.value: 10,
-}
-
-
 @dataclass(frozen=True, kw_only=True, slots=True)
 class Hint:
     """Normalized hint payload attached to a `ProcessingContext`.

--- a/src/topmark/pipeline/result.py
+++ b/src/topmark/pipeline/result.py
@@ -1,0 +1,328 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : result.py
+#   file_relpath : src/topmark/pipeline/result.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Durable result snapshots for completed TopMark pipeline contexts.
+
+This module contains immutable value objects that capture the result-facing
+portion of a mutable
+[`ProcessingContext`][topmark.pipeline.context.model.ProcessingContext]. The
+objects defined here are deliberately reduced: they keep durable information
+such as path identity, statuses, diagnostics, hints, and outcome-facing flags,
+but they do not retain volatile runtime state such as file views, processors,
+configuration objects, policy registries, or flow-control objects.
+
+The initial reducer is intentionally conservative. Existing runners, CLI code,
+and public API adapters may continue to return and consume
+`ProcessingContext`; this module provides the vocabulary and conversion seam
+for staged migration toward durable post-run results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from topmark.pipeline.context.policy import can_change
+from topmark.pipeline.context.policy import check_permitted_by_policy
+from topmark.pipeline.context.policy import effective_would_add_or_update
+from topmark.pipeline.context.policy import effective_would_strip
+from topmark.pipeline.context.policy import would_add_or_update
+from topmark.pipeline.context.policy import would_change
+from topmark.pipeline.context.policy import would_strip
+from topmark.pipeline.context.status import StatusSnapshot
+from topmark.utils.path import format_machine_path
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from topmark.diagnostic.model import FrozenDiagnosticLog
+    from topmark.filetypes.model import FileType
+    from topmark.filetypes.model import InsertCapability
+    from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.hints import Hint
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class FileTypeSnapshot:
+    """Durable file-type identity captured from a processing context.
+
+    Attributes:
+        qualified_key: Canonical qualified file-type key.
+        description: Human-facing file-type description.
+    """
+
+    qualified_key: str
+    description: str
+
+    @classmethod
+    def from_file_type(cls, file_type: FileType) -> FileTypeSnapshot:
+        """Create a file-type snapshot from a resolved file type.
+
+        Args:
+            file_type: Resolved file type to snapshot.
+
+        Returns:
+            Durable file-type identity snapshot.
+        """
+        return cls(
+            qualified_key=file_type.qualified_key,
+            description=file_type.description,
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-friendly file-type payload.
+
+        Returns:
+            Mapping containing the qualified key and description.
+        """
+        return {
+            "qualified_key": self.qualified_key,
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class StepAxesSnapshot:
+    """Durable step-to-axes relationship captured from an executed step.
+
+    Attributes:
+        step: Executed step name.
+        axes: Tuple of axis names the step declared it may write.
+    """
+
+    step: str
+    axes: tuple[str, ...]
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PreInsertCheckSnapshot:
+    """Durable pre-insert advisory state captured from a context.
+
+    Attributes:
+        capability: Advisory insert capability value.
+        reason: Optional human-readable reason for the advisory.
+        origin: Optional producer of the advisory.
+    """
+
+    capability: InsertCapability
+    reason: str | None
+    origin: str | None
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Return a JSON-friendly pre-insert advisory payload.
+
+        Returns:
+            Mapping with capability name, reason, and origin.
+        """
+        return {
+            "capability": self.capability.name,
+            "reason": self.reason,
+            "origin": self.origin,
+        }
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class OutcomeSnapshot:
+    """Durable outcome-facing flags captured from a processing context.
+
+    These flags mirror the current high-level outcome payload produced by
+    `ProcessingContext.to_dict()` without retaining the mutable context itself.
+
+    Attributes:
+        would_change: Whether the context represents any pending or completed change,
+            or `None` when the current status is not sufficient to decide.
+        can_change: Whether the context can change according to current feasibility checks.
+        permitted_by_policy: Whether policy permits the effective change, or `None`
+            when there is no clear mutation intent yet.
+        would_add_or_update: Whether check/update processing would add or update a header.
+        effective_would_add_or_update: Policy-aware add/update result.
+        would_strip: Whether strip processing would remove a header.
+        effective_would_strip: Policy-aware strip result.
+    """
+
+    would_change: bool | None
+    can_change: bool
+    permitted_by_policy: bool | None
+    would_add_or_update: bool
+    effective_would_add_or_update: bool
+    would_strip: bool
+    effective_would_strip: bool
+
+    @classmethod
+    def from_context(cls, ctx: ProcessingContext) -> OutcomeSnapshot:
+        """Create an outcome snapshot from a mutable processing context.
+
+        Args:
+            ctx: Source context to evaluate.
+
+        Returns:
+            Durable outcome-facing flag snapshot.
+        """
+        return cls(
+            would_change=would_change(ctx),
+            can_change=can_change(ctx),
+            permitted_by_policy=check_permitted_by_policy(ctx),
+            would_add_or_update=would_add_or_update(ctx),
+            effective_would_add_or_update=effective_would_add_or_update(ctx),
+            would_strip=would_strip(ctx),
+            effective_would_strip=effective_would_strip(ctx),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly outcome payload.
+
+        Returns:
+            Mapping matching the existing high-level outcome payload shape.
+        """
+        return {
+            "would_change": self.would_change,
+            "can_change": self.can_change,
+            "permitted_by_policy": self.permitted_by_policy,
+            "check": {
+                "would_add_or_update": self.would_add_or_update,
+                "effective_would_add_or_update": self.effective_would_add_or_update,
+            },
+            "strip": {
+                "would_strip": self.would_strip,
+                "effective_would_strip": self.effective_would_strip,
+            },
+        }
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ProcessingResult:
+    """Durable reduced outcome for one processed file.
+
+    A `ProcessingResult` is an immutable snapshot of the result-facing state of
+    a completed or partially completed
+    [`ProcessingContext`][topmark.pipeline.context.model.ProcessingContext]. It
+    intentionally does not retain runtime-only fields such as configuration,
+    policy registries, processors, mutable views, or flow-control objects.
+
+    Attributes:
+        path: Processing path for the file.
+        file_type: Durable resolved file-type identity, if any.
+        steps: Names of executed steps in execution order.
+        step_axes: Axes declared by each executed step.
+        status: Immutable per-axis status snapshot.
+        diagnostics: Immutable diagnostic log snapshot.
+        diagnostic_counts: Diagnostic counts by severity.
+        hints: Hints captured in insertion order.
+        pre_insert_check: Durable pre-insert advisory snapshot.
+        outcome: Durable high-level outcome flag snapshot.
+    """
+
+    path: Path
+    file_type: FileTypeSnapshot | None
+    steps: tuple[str, ...]
+    step_axes: tuple[StepAxesSnapshot, ...]
+    status: StatusSnapshot
+    diagnostics: FrozenDiagnosticLog
+    diagnostic_counts: Mapping[str, int]
+    hints: tuple[Hint, ...]
+    pre_insert_check: PreInsertCheckSnapshot
+    outcome: OutcomeSnapshot
+
+    @classmethod
+    def from_context(cls, ctx: ProcessingContext) -> ProcessingResult:
+        """Reduce a mutable processing context to a durable result snapshot.
+
+        Args:
+            ctx: Source mutable context.
+
+        Returns:
+            Detached durable result snapshot.
+        """
+        diagnostics: FrozenDiagnosticLog = ctx.diagnostics.freeze()
+        return cls(
+            path=Path(ctx.path),
+            file_type=(
+                FileTypeSnapshot.from_file_type(ctx.file_type)
+                if ctx.file_type is not None
+                else None
+            ),
+            steps=tuple(step.name for step in ctx.steps),
+            step_axes=tuple(
+                StepAxesSnapshot(
+                    step=step.name,
+                    axes=tuple(axis.value for axis in step.axes_written),
+                )
+                for step in ctx.steps
+            ),
+            status=StatusSnapshot.from_status(ctx.status),
+            diagnostics=diagnostics,
+            diagnostic_counts=diagnostics.to_dict(),
+            hints=tuple(ctx.diagnostic_hints),
+            pre_insert_check=PreInsertCheckSnapshot(
+                capability=ctx.pre_insert_capability,
+                reason=ctx.pre_insert_reason,
+                origin=ctx.pre_insert_origin,
+            ),
+            outcome=OutcomeSnapshot.from_context(ctx),
+        )
+
+    @property
+    def step_axes_dict(self) -> dict[str, list[str]]:
+        """Return step axes in the current machine-output mapping shape.
+
+        Returns:
+            Mapping from step name to a list of axis names.
+        """
+        return {item.step: list(item.axes) for item in self.step_axes}
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a machine-readable representation of this durable result.
+
+        The shape intentionally mirrors the result-facing subset of
+        `ProcessingContext.to_dict()` while omitting volatile view details.
+
+        Returns:
+            JSON-serializable mapping describing the durable processing result.
+        """
+        return {
+            "path": format_machine_path(self.path),
+            "file_type": self.file_type.to_dict() if self.file_type is not None else None,
+            "steps": list(self.steps),
+            "step_axes": self.step_axes_dict,
+            "status": self.status.to_dict(),
+            "diagnostics": [
+                {"level": diagnostic.level.value, "message": diagnostic.message}
+                for diagnostic in self.diagnostics
+            ],
+            "diagnostic_counts": self.diagnostic_counts,
+            "hints": [
+                {
+                    "axis": hint.axis.value,
+                    "code": hint.code,
+                    "message": hint.message,
+                    "detail": hint.detail,
+                    "cluster": hint.cluster,
+                    "terminal": hint.terminal,
+                    "reason": hint.reason,
+                    "meta": hint.meta,
+                }
+                for hint in self.hints
+            ],
+            "pre_insert_check": self.pre_insert_check.to_dict(),
+            "outcome": self.outcome.to_dict(),
+        }
+
+
+def reduce_processing_context(ctx: ProcessingContext) -> ProcessingResult:
+    """Reduce a mutable processing context to a durable result snapshot.
+
+    Args:
+        ctx: Source mutable context.
+
+    Returns:
+        Detached durable result snapshot.
+    """
+    return ProcessingResult.from_context(ctx)

--- a/tests/pipeline/test_context_status.py
+++ b/tests/pipeline/test_context_status.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from topmark.pipeline.context.status import ProcessingStatus
+from topmark.pipeline.context.status import StatusSnapshot
 from topmark.pipeline.context.status import StepStatus
 from topmark.pipeline.hints import Axis
 from topmark.pipeline.status import ComparisonStatus
@@ -61,6 +62,34 @@ def test_processing_status_get_returns_axis_status(
     setattr(processing_status, axis.value, status)
 
     assert processing_status.get(axis) is status
+
+
+@pytest.mark.parametrize(
+    ("axis", "status"),
+    [
+        (Axis.RESOLVE, ResolveStatus.RESOLVED),
+        (Axis.FS, FsStatus.OK),
+        (Axis.CONTENT, ContentStatus.OK),
+        (Axis.HEADER, HeaderStatus.DETECTED),
+        (Axis.GENERATION, GenerationStatus.GENERATED),
+        (Axis.RENDER, RenderStatus.RENDERED),
+        (Axis.STRIP, StripStatus.READY),
+        (Axis.COMPARISON, ComparisonStatus.CHANGED),
+        (Axis.PLAN, PlanStatus.PREVIEWED),
+        (Axis.PATCH, PatchStatus.GENERATED),
+        (Axis.WRITE, WriteStatus.WRITTEN),
+    ],
+)
+def test_status_snapshot_get_returns_axis_status(
+    axis: Axis,
+    status: BaseStatus,
+) -> None:
+    """StatusSnapshot.get() should return the status for every pipeline axis."""
+    processing_status = ProcessingStatus()
+    setattr(processing_status, axis.value, status)
+    snapshot: StatusSnapshot = StatusSnapshot.from_status(processing_status)
+
+    assert snapshot.get(axis) is status
 
 
 def test_processing_status_reset_restores_all_axes_to_pending() -> None:
@@ -168,6 +197,82 @@ def test_processing_status_to_dict_serializes_every_axis() -> None:
         "name": "SKIPPED",
         "label": WriteStatus.SKIPPED.value,
     }
+
+
+def test_status_snapshot_copies_axis_values() -> None:
+    """StatusSnapshot should capture the current value of every status axis."""
+    status = ProcessingStatus(
+        resolve=ResolveStatus.RESOLVED,
+        fs=FsStatus.OK,
+        content=ContentStatus.OK,
+        header=HeaderStatus.DETECTED,
+        generation=GenerationStatus.GENERATED,
+        render=RenderStatus.RENDERED,
+        strip=StripStatus.READY,
+        comparison=ComparisonStatus.CHANGED,
+        plan=PlanStatus.PREVIEWED,
+        patch=PatchStatus.GENERATED,
+        write=WriteStatus.WRITTEN,
+    )
+
+    snapshot: StatusSnapshot = StatusSnapshot.from_status(status)
+
+    assert snapshot.resolve is ResolveStatus.RESOLVED
+    assert snapshot.fs is FsStatus.OK
+    assert snapshot.content is ContentStatus.OK
+    assert snapshot.header is HeaderStatus.DETECTED
+    assert snapshot.generation is GenerationStatus.GENERATED
+    assert snapshot.render is RenderStatus.RENDERED
+    assert snapshot.strip is StripStatus.READY
+    assert snapshot.comparison is ComparisonStatus.CHANGED
+    assert snapshot.plan is PlanStatus.PREVIEWED
+    assert snapshot.patch is PatchStatus.GENERATED
+    assert snapshot.write is WriteStatus.WRITTEN
+
+
+def test_status_snapshot_is_detached_from_source_status() -> None:
+    """StatusSnapshot should not change when the source ProcessingStatus mutates."""
+    status = ProcessingStatus(resolve=ResolveStatus.RESOLVED, write=WriteStatus.WRITTEN)
+
+    snapshot: StatusSnapshot = StatusSnapshot.from_status(status)
+
+    status.resolve = ResolveStatus.PENDING
+    status.write = WriteStatus.PENDING
+
+    assert snapshot.resolve is ResolveStatus.RESOLVED
+    assert snapshot.write is WriteStatus.WRITTEN
+
+
+def test_status_snapshot_to_dict_matches_processing_status() -> None:
+    """StatusSnapshot.to_dict() should preserve the ProcessingStatus payload shape."""
+    status = ProcessingStatus(
+        resolve=ResolveStatus.RESOLVED,
+        fs=FsStatus.OK,
+        content=ContentStatus.OK,
+        header=HeaderStatus.MISSING,
+        generation=GenerationStatus.NO_FIELDS,
+        render=RenderStatus.RENDERED,
+        strip=StripStatus.NOT_NEEDED,
+        comparison=ComparisonStatus.UNCHANGED,
+        plan=PlanStatus.SKIPPED,
+        patch=PatchStatus.SKIPPED,
+        write=WriteStatus.SKIPPED,
+    )
+
+    snapshot: StatusSnapshot = StatusSnapshot.from_status(status)
+
+    assert snapshot.to_dict() == status.to_dict()
+
+
+def test_status_snapshot_has_write_outcome_detects_non_pending_write() -> None:
+    """StatusSnapshot.has_write_outcome() should mirror ProcessingStatus behavior."""
+    pending: StatusSnapshot = StatusSnapshot.from_status(ProcessingStatus())
+    written: StatusSnapshot = StatusSnapshot.from_status(
+        ProcessingStatus(write=WriteStatus.WRITTEN)
+    )
+
+    assert pending.has_write_outcome() is False
+    assert written.has_write_outcome() is True
 
 
 def test_processing_status_has_write_outcome_detects_non_pending_write() -> None:

--- a/tests/pipeline/test_result.py
+++ b/tests/pipeline/test_result.py
@@ -1,0 +1,130 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_result.py
+#   file_relpath : tests/pipeline/test_result.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Unit tests for durable pipeline result reduction."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.helpers.pipeline import make_context_from_text
+from topmark.config.io.deserializers import mutable_config_from_defaults
+from topmark.core.typing_guards import is_mapping
+from topmark.pipeline.context.model import ProcessingContext
+from topmark.pipeline.hints import Axis
+from topmark.pipeline.hints import KnownCode
+from topmark.pipeline.result import ProcessingResult
+from topmark.pipeline.result import reduce_processing_context
+from topmark.pipeline.status import HeaderStatus
+from topmark.pipeline.status import ResolveStatus
+from topmark.pipeline.status import WriteStatus
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.config.model import FrozenConfig
+    from topmark.pipeline.context.model import ProcessingContext
+
+
+def _make_result_context(tmp_path: Path) -> ProcessingContext:
+    """Create a small post-reader context suitable for result-reduction tests."""
+    cfg: FrozenConfig = mutable_config_from_defaults().freeze()
+    return make_context_from_text(
+        "print('hello')\n",
+        cfg=cfg,
+        path=tmp_path / "sample.py",
+    )
+
+
+def test_processing_result_reduces_context_identity(
+    tmp_path: Path,
+) -> None:
+    """ProcessingResult should capture durable identity fields from a context."""
+    ctx: ProcessingContext = _make_result_context(tmp_path)
+    assert ctx.file_type is not None
+
+    ctx.status.header = HeaderStatus.MISSING
+    ctx.hint(
+        axis=Axis.HEADER,
+        code=KnownCode.HEADER_MISSING,
+        message="Header is missing",
+    )
+
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    assert result.path == ctx.path
+    assert result.file_type is not None
+    assert result.file_type.qualified_key == ctx.file_type.qualified_key
+    assert result.file_type.description == ctx.file_type.description
+    assert result.status.resolve is ResolveStatus.RESOLVED
+    assert result.status.header is HeaderStatus.MISSING
+    assert result.hints == tuple(ctx.diagnostic_hints)
+
+
+def test_processing_result_snapshots_status(
+    tmp_path: Path,
+) -> None:
+    """ProcessingResult should not retain mutable ProcessingStatus state."""
+    ctx: ProcessingContext = _make_result_context(tmp_path)
+    ctx.status.header = HeaderStatus.MISSING
+    ctx.status.write = WriteStatus.WRITTEN
+
+    result: ProcessingResult = reduce_processing_context(ctx)
+
+    ctx.status.header = HeaderStatus.PENDING
+    ctx.status.write = WriteStatus.PENDING
+
+    assert result.status.header is HeaderStatus.MISSING
+    assert result.status.write is WriteStatus.WRITTEN
+
+
+def test_processing_result_to_dict_excludes_runtime_views(
+    tmp_path: Path,
+) -> None:
+    """ProcessingResult serialization should omit volatile runtime view state."""
+    ctx: ProcessingContext = _make_result_context(tmp_path)
+
+    payload: dict[str, object] = ProcessingResult.from_context(ctx).to_dict()
+
+    assert "views" not in payload
+    assert payload["path"] == str(tmp_path / "sample.py")
+    assert "status" in payload
+    assert "diagnostics" in payload
+    assert "diagnostic_counts" in payload
+    assert "hints" in payload
+
+
+def test_processing_result_to_dict_preserves_outcome_shape(
+    tmp_path: Path,
+) -> None:
+    """ProcessingResult serialization should preserve the current outcome payload shape."""
+    ctx: ProcessingContext = _make_result_context(tmp_path)
+
+    payload: dict[str, object] = ProcessingResult.from_context(ctx).to_dict()
+    outcome: object = payload["outcome"]
+
+    assert is_mapping(outcome)
+    assert set(outcome) == {
+        "would_change",
+        "can_change",
+        "permitted_by_policy",
+        "check",
+        "strip",
+    }
+    assert is_mapping(outcome["check"])
+    assert set(outcome["check"]) == {
+        "would_add_or_update",
+        "effective_would_add_or_update",
+    }
+    assert is_mapping(outcome["strip"])
+    assert set(outcome["strip"]) == {
+        "would_strip",
+        "effective_would_strip",
+    }

--- a/tests/pipeline/test_result.py
+++ b/tests/pipeline/test_result.py
@@ -25,6 +25,7 @@ from topmark.pipeline.result import reduce_processing_context
 from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import ResolveStatus
 from topmark.pipeline.status import WriteStatus
+from topmark.utils.path import format_machine_path
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -94,7 +95,7 @@ def test_processing_result_to_dict_excludes_runtime_views(
     payload: dict[str, object] = ProcessingResult.from_context(ctx).to_dict()
 
     assert "views" not in payload
-    assert payload["path"] == str(tmp_path / "sample.py")
+    assert payload["path"] == format_machine_path(tmp_path / "sample.py")
     assert "status" in payload
     assert "diagnostics" in payload
     assert "diagnostic_counts" in payload


### PR DESCRIPTION
## Summary

- add immutable `StatusSnapshot` support for detached pipeline status capture
- add internal `ProcessingResult` reduction primitives for durable post-run outcome state
- preserve existing runner, CLI, API, and machine-readable output behavior
- add focused tests for status snapshots and context-to-result reduction
- document the architecture invariant and changelog entry for the staged #148 implementation

## Scope

This is PR 1 for #148. It introduces the internal vocabulary and reduction seam only.

It intentionally does not migrate CLI/API/reporting consumers from `ProcessingContext` to `ProcessingResult`; that remains follow-up work.

## Validation

- `pytest ...`
- `pyright`
- `ruff check ...`

Refs #148