### PR TITLE
Refactor outcome classification to support durable ProcessingResult snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ ______________________________________________________________________
 - Clarified CI workflow maintainability by adding explicit job-level permissions for selected
   third-party-action jobs, bounded link-check jobs with explicit timeouts, and summarized
   path-filter decisions in the GitHub Actions step summary.
+- Made pipeline outcome bucketing compatible with durable `ProcessingResult` snapshots by
+  introducing typed outcome and pre-insert advisory snapshots, while preserving existing
+  `ProcessingContext` consumers and machine-output shapes.
 
 ### Breaking Changes - Unreleased
 
@@ -338,6 +341,8 @@ ______________________________________________________________________
 - Added immutable `StatusSnapshot` and `ProcessingResult` result-reduction primitives as the first
   stage of separating volatile pipeline execution state from durable processing outcomes (GitHub
   issue #148).
+- Added typed outcome-classification and pre-insert advisory snapshots so policy-derived bucketing
+  state can be reduced from mutable pipeline contexts without retaining volatile execution objects.
 
 ### Notes - Unreleased
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -34,6 +34,10 @@ The following architectural contracts are part of the stable 1.x design:
 - Machine-readable output remains independent from human-facing TEXT and Markdown output.
 - Mutable pipeline execution state can be reduced to durable result snapshots without changing
   runner, CLI, API, or presentation behavior.
+- Outcome bucketing is based on a narrow status + outcome-flag contract so live
+  \[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances and durable
+  \[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] snapshots can be classified
+  through the same presentation-free logic.
 
 ______________________________________________________________________
 

--- a/src/topmark/pipeline/context/model.py
+++ b/src/topmark/pipeline/context/model.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from topmark.config.policy import PolicyRegistry
     from topmark.core.logging import TopmarkLogger
     from topmark.filetypes.model import FileType
+    from topmark.pipeline.outcome_snapshot import OutcomeSnapshot
     from topmark.pipeline.protocols import Step
     from topmark.processors.base import HeaderProcessor
     from topmark.resolution.probe import ResolutionProbeResult
@@ -356,6 +357,22 @@ class ProcessingContext:
         if isinstance(lines, UpdatedContent):
             return list(lines.iter_lines())
         return list(lines)
+
+    @property
+    def outcome(self) -> OutcomeSnapshot:
+        """Return the current outcome-facing decision snapshot.
+
+        This property provides the durable outcome vocabulary for callers that
+        need to classify either a live context or a reduced result through the
+        same narrow protocol. The snapshot is computed from the current mutable
+        context state and is not cached.
+
+        Returns:
+            Outcome-facing flags derived from the current context state.
+        """
+        from topmark.pipeline.outcome_snapshot import OutcomeSnapshot
+
+        return OutcomeSnapshot.from_context(self)
 
     def to_dict(self) -> dict[str, object]:
         """Return a machine-readable representation of this processing result.

--- a/src/topmark/pipeline/context/policy.py
+++ b/src/topmark/pipeline/context/policy.py
@@ -21,7 +21,6 @@ empty files or tolerating mixed newlines) are permitted.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Protocol
 
 from topmark.config.policy import EmptyInsertMode
 from topmark.config.policy import HeaderMutationMode
@@ -35,56 +34,16 @@ from topmark.pipeline.status import StripStatus
 if TYPE_CHECKING:
     from topmark.config.policy import FrozenPolicy
     from topmark.core.logging import TopmarkLogger
-    from topmark.pipeline.context.status import ProcessingStatus
+    from topmark.pipeline.context.protocols import SupportsPolicyEvaluation
 
 
 logger: TopmarkLogger = get_logger(__name__)
 
 
-class PolicyContext(Protocol):
-    """Minimum context surface required by policy helpers."""
-
-    @property
-    def status(self) -> ProcessingStatus:
-        """Current aggregated pipeline status for this file."""
-        ...
-
-    def get_effective_policy(self) -> FrozenPolicy:
-        """Return the effective policy for this processing context."""
-        ...
-
-    @property
-    def is_effectively_empty(self) -> bool:
-        """Whether the file image is effectively empty.
-
-        Returns whether the decoded, BOM-stripped text image contains **no
-        non-whitespace characters**. Newlines and other whitespace are allowed.
-        This is the broad notion of "empty" used for most policy decisions.
-        """
-        ...
-
-    @property
-    def is_logically_empty(self) -> bool:
-        """Whether the file is "logically empty".
-
-        Returns whether the file is "logically empty": after BOM stripping,
-        it contains optional horizontal whitespace and **at most one** trailing
-        newline sequence (LF/CRLF/CR), and nothing else. This is a stricter subset
-        of `is_effectively_empty` and is useful to preserve stable round-trips for
-        files that are effectively placeholders.
-        """
-        ...
-
-    @property
-    def is_empty_like(self) -> bool:
-        """Whether a file image is "empty-like"."""
-        ...
-
-
 # ---- Classification helpers ----
 
 
-def is_empty_for_insert(ctx: PolicyContext) -> bool:
+def is_empty_for_insert(ctx: SupportsPolicyEvaluation) -> bool:
     """Return whether this file should be treated as "empty" for *insertion* decisions.
 
     This helper interprets the effective per-type policy setting
@@ -125,7 +84,7 @@ def is_empty_for_insert(ctx: PolicyContext) -> bool:
     return ctx.is_effectively_empty or ctx.status.fs == FsStatus.EMPTY
 
 
-def is_empty_for_insert_unchanged_by_default(ctx: PolicyContext) -> bool:
+def is_empty_for_insert_unchanged_by_default(ctx: SupportsPolicyEvaluation) -> bool:
     """Return True when an insertion-empty file should default to `UNCHANGED`.
 
     This helper is for *bucketing/reporting*, not mutation.
@@ -175,7 +134,7 @@ def is_empty_for_insert_unchanged_by_default(ctx: PolicyContext) -> bool:
 # ---- Policy permission helpers ----
 
 
-def allow_insert_into_empty_like(ctx: PolicyContext) -> bool:
+def allow_insert_into_empty_like(ctx: SupportsPolicyEvaluation) -> bool:
     """Return True if policy permits inserting a header into an empty-like file.
 
     This is the primary policy gate used by planner/updater when a file has no
@@ -210,7 +169,7 @@ def allow_insert_into_empty_like(ctx: PolicyContext) -> bool:
     return is_empty_for_insert(ctx) and bool(policy.allow_header_in_empty_files)
 
 
-def allow_empty_header(ctx: PolicyContext) -> bool:
+def allow_empty_header(ctx: SupportsPolicyEvaluation) -> bool:
     """Return True if the effective policy allows empty header insertion.
 
     This helper inspects the effective per-type policy (global configuration
@@ -229,7 +188,7 @@ def allow_empty_header(ctx: PolicyContext) -> bool:
     return policy.render_empty_header_when_no_fields
 
 
-def allow_content_reflow(ctx: PolicyContext) -> bool:
+def allow_content_reflow(ctx: SupportsPolicyEvaluation) -> bool:
     """Return True if the effective policy allows content reflow.
 
     This covers transformations that may adjust layout or whitespace around
@@ -247,7 +206,7 @@ def allow_content_reflow(ctx: PolicyContext) -> bool:
     return policy.allow_reflow
 
 
-def allow_mixed_line_endings(ctx: PolicyContext) -> bool:
+def allow_mixed_line_endings(ctx: SupportsPolicyEvaluation) -> bool:
     """Return True if policy allows proceeding despite mixed line endings.
 
     This helper is used by early pipeline steps (e.g., ReaderStep) when the
@@ -286,7 +245,7 @@ def allow_mixed_line_endings(ctx: PolicyContext) -> bool:
     return False
 
 
-def allow_bom_before_shebang(ctx: PolicyContext) -> bool:
+def allow_bom_before_shebang(ctx: SupportsPolicyEvaluation) -> bool:
     """Return True if policy allows proceeding despite a BOM before the shebang.
 
     This helper is used by early pipeline steps (e.g., ReaderStep) when the
@@ -328,7 +287,7 @@ def allow_bom_before_shebang(ctx: PolicyContext) -> bool:
 # ---- Mutation intent / feasibility / pipeline decision logic ----
 
 
-def check_permitted_by_policy(ctx: PolicyContext) -> bool | None:
+def check_permitted_by_policy(ctx: SupportsPolicyEvaluation) -> bool | None:
     """Whether the active check policy allows the intended header mutation.
 
     Args:
@@ -428,7 +387,7 @@ def check_permitted_by_policy(ctx: PolicyContext) -> bool | None:
     return True
 
 
-def would_change(ctx: PolicyContext) -> bool | None:
+def would_change(ctx: SupportsPolicyEvaluation) -> bool | None:
     """Return whether a change *would* occur (tri-state).
 
     Args:
@@ -458,7 +417,7 @@ def would_change(ctx: PolicyContext) -> bool | None:
     return None
 
 
-def can_change(ctx: PolicyContext) -> bool:
+def can_change(ctx: SupportsPolicyEvaluation) -> bool:
     """Return whether a mutation can be applied safely for this file.
 
     This helper answers a narrow question:
@@ -533,7 +492,7 @@ def can_change(ctx: PolicyContext) -> bool:
     return False
 
 
-def would_add_or_update(ctx: PolicyContext) -> bool:
+def would_add_or_update(ctx: SupportsPolicyEvaluation) -> bool:
     """Intent for check/apply: True if we'd insert or replace a header.
 
     Args:
@@ -549,7 +508,7 @@ def would_add_or_update(ctx: PolicyContext) -> bool:
     )
 
 
-def effective_would_add_or_update(ctx: PolicyContext) -> bool:
+def effective_would_add_or_update(ctx: SupportsPolicyEvaluation) -> bool:
     """True iff add/update is intended, feasible, and allowed by policy.
 
     Args:
@@ -566,7 +525,7 @@ def effective_would_add_or_update(ctx: PolicyContext) -> bool:
     )
 
 
-def would_strip(ctx: PolicyContext) -> bool:
+def would_strip(ctx: SupportsPolicyEvaluation) -> bool:
     """Intent for strip: True if a removal would occur.
 
     Args:
@@ -579,7 +538,7 @@ def would_strip(ctx: PolicyContext) -> bool:
     return ctx.status.strip == StripStatus.READY
 
 
-def effective_would_strip(ctx: PolicyContext) -> bool:
+def effective_would_strip(ctx: SupportsPolicyEvaluation) -> bool:
     """True iff a strip is intended and feasible.
 
     Args:

--- a/src/topmark/pipeline/context/protocols.py
+++ b/src/topmark/pipeline/context/protocols.py
@@ -1,0 +1,73 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : protocols.py
+#   file_relpath : src/topmark/pipeline/context/protocols.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Structural protocols for context-like pipeline objects.
+
+This module defines narrow contracts for code that needs to evaluate policy or
+policy-derived outcome flags without depending on the concrete mutable
+[`ProcessingContext`][topmark.pipeline.context.model.ProcessingContext] class.
+Keeping these contracts in a context-owned module avoids import cycles between
+context models, durable result snapshots, and policy helpers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Protocol
+
+if TYPE_CHECKING:
+    from topmark.config.policy import FrozenPolicy
+    from topmark.pipeline.context.status import ProcessingStatus
+
+
+class SupportsPolicyEvaluation(Protocol):
+    """Minimum context-like surface required by policy evaluation helpers.
+
+    The protocol is intentionally status- and policy-focused. It should contain
+    only fields used by `context.policy` helpers and by durable outcome snapshot
+    creation. Step-specific advisory state should stay out of this protocol
+    unless policy helpers start using it directly.
+    """
+
+    @property
+    def status(self) -> ProcessingStatus:
+        """Current per-axis processing status."""
+        ...
+
+    @property
+    def is_empty_like(self) -> bool:
+        """Whether the file is empty-like for policy purposes."""
+        ...
+
+    @property
+    def is_effectively_empty(self) -> bool:
+        """Whether the file image is effectively empty.
+
+        Returns whether the decoded, BOM-stripped text image contains **no
+        non-whitespace characters**. Newlines and other whitespace are allowed.
+        This is the broad notion of "empty" used for most policy decisions.
+        """
+        ...
+
+    @property
+    def is_logically_empty(self) -> bool:
+        """Whether the file is "logically empty".
+
+        Returns whether the file is "logically empty": after BOM stripping,
+        it contains optional horizontal whitespace and **at most one** trailing
+        newline sequence (LF/CRLF/CR), and nothing else. This is a stricter subset
+        of `is_effectively_empty` and is useful to preserve stable round-trips for
+        files that are effectively placeholders.
+        """
+        ...
+
+    def get_effective_policy(self) -> FrozenPolicy:
+        """Return the effective policy for the current file and file type."""
+        ...

--- a/src/topmark/pipeline/outcome_snapshot.py
+++ b/src/topmark/pipeline/outcome_snapshot.py
@@ -1,0 +1,118 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : outcome_snapshot.py
+#   file_relpath : src/topmark/pipeline/outcome_snapshot.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Durable outcome snapshot values for reduced pipeline results.
+
+The mutable [`ProcessingContext`][topmark.pipeline.context.model.ProcessingContext]
+remains the execution object used by pipeline steps. This module provides the
+immutable outcome-facing value object used when reducing that context into a
+[ProcessingResult][topmark.pipeline.result.ProcessingResult].
+
+`OutcomeSnapshot` deliberately stores computed flags rather than retaining the
+source context. That keeps result objects independent from volatile execution
+state and lets reporting code classify either a live context or a reduced result
+through the same outcome-classification protocol.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from topmark.pipeline.context.policy import can_change
+from topmark.pipeline.context.policy import check_permitted_by_policy
+from topmark.pipeline.context.policy import effective_would_add_or_update
+from topmark.pipeline.context.policy import effective_would_strip
+from topmark.pipeline.context.policy import is_empty_for_insert_unchanged_by_default
+from topmark.pipeline.context.policy import would_add_or_update
+from topmark.pipeline.context.policy import would_change
+from topmark.pipeline.context.policy import would_strip
+
+if TYPE_CHECKING:
+    from topmark.pipeline.context.protocols import SupportsPolicyEvaluation
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class OutcomeSnapshot:
+    """Durable outcome-facing flags captured from a processing context.
+
+    These flags mirror the current high-level outcome payload produced by
+    `ProcessingContext.to_dict()` without retaining the mutable context itself.
+    They also provide the stable policy-aware inputs consumed by outcome
+    bucketing once a context has been reduced to a result.
+
+    Attributes:
+        would_change: Whether the context represents any pending or completed change,
+            or `None` when the current status is not sufficient to decide.
+        can_change: Whether the context can change according to current feasibility checks.
+        permitted_by_policy: Whether policy permits the effective change, or `None`
+            when there is no clear mutation intent yet.
+        would_add_or_update: Whether check/update processing would add or update a header.
+        effective_would_add_or_update: Policy-aware add/update result.
+        would_strip: Whether strip processing would remove a header.
+        effective_would_strip: Policy-aware strip result.
+        empty_for_insert_unchanged_by_default: Whether empty-for-insert files should
+            default to unchanged under current policy.
+    """
+
+    would_change: bool | None
+    can_change: bool
+    permitted_by_policy: bool | None
+    would_add_or_update: bool
+    effective_would_add_or_update: bool
+    would_strip: bool
+    effective_would_strip: bool
+    empty_for_insert_unchanged_by_default: bool
+
+    @classmethod
+    def from_context(cls, ctx: SupportsPolicyEvaluation) -> OutcomeSnapshot:
+        """Create an outcome snapshot from a mutable processing context.
+
+        Args:
+            ctx: Source object exposing the policy-evaluation protocol. In normal
+                pipeline execution this is a `ProcessingContext`, but the snapshot
+                constructor depends only on the structural protocol to avoid a
+                concrete context import cycle.
+
+        Returns:
+            Durable outcome-facing flag snapshot.
+        """
+        return cls(
+            would_change=would_change(ctx),
+            can_change=can_change(ctx),
+            permitted_by_policy=check_permitted_by_policy(ctx),
+            would_add_or_update=would_add_or_update(ctx),
+            effective_would_add_or_update=effective_would_add_or_update(ctx),
+            would_strip=would_strip(ctx),
+            effective_would_strip=effective_would_strip(ctx),
+            empty_for_insert_unchanged_by_default=(is_empty_for_insert_unchanged_by_default(ctx)),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly outcome payload.
+
+        Returns:
+            Mapping matching the existing high-level outcome payload shape. The
+            helper intentionally omits internal-only classification fields that
+            are not part of the current serialized outcome payload.
+        """
+        return {
+            "would_change": self.would_change,
+            "can_change": self.can_change,
+            "permitted_by_policy": self.permitted_by_policy,
+            "check": {
+                "would_add_or_update": self.would_add_or_update,
+                "effective_would_add_or_update": self.effective_would_add_or_update,
+            },
+            "strip": {
+                "would_strip": self.would_strip,
+                "effective_would_strip": self.effective_would_strip,
+            },
+        }

--- a/src/topmark/pipeline/outcomes.py
+++ b/src/topmark/pipeline/outcomes.py
@@ -39,16 +39,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
+from typing import Protocol
 
 from topmark.core.logging import get_logger
 from topmark.core.outcomes import NO_REASON_PROVIDED
 from topmark.core.outcomes import OUTCOME_ORDER
 from topmark.core.outcomes import Outcome
-from topmark.pipeline.context.model import ProcessingContext
-from topmark.pipeline.context.policy import check_permitted_by_policy
-from topmark.pipeline.context.policy import effective_would_add_or_update
-from topmark.pipeline.context.policy import effective_would_strip
-from topmark.pipeline.context.policy import is_empty_for_insert_unchanged_by_default
 from topmark.pipeline.status import ComparisonStatus  # temporary
 from topmark.pipeline.status import ContentStatus  # temporary
 from topmark.pipeline.status import FsStatus  # temporary
@@ -60,11 +56,120 @@ from topmark.pipeline.status import StripStatus  # temporary
 from topmark.pipeline.status import WriteStatus  # temporary
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from topmark.core.logging import TopmarkLogger
     from topmark.pipeline.context.model import ProcessingContext
 
 
 logger: TopmarkLogger = get_logger(__name__)
+
+
+class SupportsOutcomeStatus(Protocol):
+    """Minimum status surface required for outcome classification."""
+
+    @property
+    def resolve(self) -> ResolveStatus:
+        """Resolution status used by the classifier."""
+        ...
+
+    @property
+    def fs(self) -> FsStatus:
+        """Filesystem status used by the classifier."""
+        ...
+
+    @property
+    def content(self) -> ContentStatus:
+        """Content status used by the classifier."""
+        ...
+
+    @property
+    def header(self) -> HeaderStatus:
+        """Header status used by the classifier."""
+        ...
+
+    @property
+    def generation(self) -> GenerationStatus:
+        """Generation status used by the classifier."""
+        ...
+
+    @property
+    def strip(self) -> StripStatus:
+        """Strip status used by the classifier."""
+        ...
+
+    @property
+    def comparison(self) -> ComparisonStatus:
+        """Comparison status used by the classifier."""
+        ...
+
+    @property
+    def plan(self) -> PlanStatus:
+        """Plan status used by the classifier."""
+        ...
+
+    @property
+    def write(self) -> WriteStatus:
+        """Write status used by the classifier."""
+        ...
+
+
+class SupportsOutcomeFlags(Protocol):
+    """Minimum precomputed outcome-flag surface required for bucketing."""
+
+    @property
+    def would_change(self) -> bool | None:
+        """Whether the context/result represents a pending or completed change."""
+        ...
+
+    @property
+    def can_change(self) -> bool:
+        """Whether the context/result can change according to feasibility checks."""
+        ...
+
+    @property
+    def permitted_by_policy(self) -> bool | None:
+        """Whether policy permits the effective change, when inferable."""
+        ...
+
+    @property
+    def would_add_or_update(self) -> bool:
+        """Whether check/update processing would add or update a header."""
+        ...
+
+    @property
+    def effective_would_add_or_update(self) -> bool:
+        """Policy-aware add/update result used by dry-run bucketing."""
+        ...
+
+    @property
+    def would_strip(self) -> bool:
+        """Whether strip processing would remove a header."""
+        ...
+
+    @property
+    def effective_would_strip(self) -> bool:
+        """Policy-aware strip result used by dry-run bucketing."""
+        ...
+
+    @property
+    def empty_for_insert_unchanged_by_default(self) -> bool:
+        """Whether empty-for-insert files default to unchanged under policy."""
+        ...
+
+
+class SupportsOutcomeClassification(Protocol):
+    """Minimum durable surface required by outcome classification helpers."""
+
+    @property
+    def status(self) -> SupportsOutcomeStatus:
+        """Per-axis status values used by the classifier."""
+        ...
+
+    @property
+    def outcome(self) -> SupportsOutcomeFlags:
+        """Precomputed policy-aware outcome flags used by the classifier."""
+        ...
 
 
 class Intent(Enum):
@@ -84,7 +189,7 @@ class Intent(Enum):
     NONE = "none"  # insufficient information to infer a concrete action
 
 
-def determine_intent(ctx: ProcessingContext) -> Intent:
+def determine_intent(ctx: SupportsOutcomeClassification) -> Intent:
     """Infer the high-level action intent from the current context.
 
     The inferred intent is used only for public bucketing. It is intentionally
@@ -152,7 +257,11 @@ class OutcomeReasonCount:
     count: int
 
 
-def map_bucket(ctx: ProcessingContext, *, apply: bool) -> ResultBucket:
+def map_bucket(
+    ctx: SupportsOutcomeClassification,
+    *,
+    apply: bool,
+) -> ResultBucket:
     """Map a processing context to a public bucket (`Outcome` + reason).
 
     This logic is precedence-ordered: the first matching rule wins. The ordering matters because
@@ -276,7 +385,7 @@ def map_bucket(ctx: ProcessingContext, *, apply: bool) -> ResultBucket:
     # This covers true empty files as well as empty-like placeholders such as
     # BOM-only, newline-only, or other images covered by the configured
     # `EmptyInsertMode`.
-    if is_empty_for_insert_unchanged_by_default(ctx):
+    if ctx.outcome.empty_for_insert_unchanged_by_default:
         return ret(
             debug_tag="unchanged:empty-for-insert",
             outcome=Outcome.UNCHANGED,
@@ -314,7 +423,7 @@ def map_bucket(ctx: ProcessingContext, *, apply: bool) -> ResultBucket:
 
     # 6) Policy veto (add-only / update-only)
     # Policy veto is tri-state: False means forbidden; True/None both mean "not vetoed".
-    permitted_by_policy: bool | None = check_permitted_by_policy(ctx)
+    permitted_by_policy: bool | None = ctx.outcome.permitted_by_policy
     if permitted_by_policy is False:
         return ret(
             debug_tag="skip:policy",
@@ -402,7 +511,7 @@ def map_bucket(ctx: ProcessingContext, *, apply: bool) -> ResultBucket:
     # steps (planner/writer) may not have run.
     if not apply:
         if intent in (Intent.INSERT, Intent.UPDATE):
-            if effective_would_add_or_update(ctx):
+            if ctx.outcome.effective_would_add_or_update:
                 return ret(
                     debug_tag="would-change:header",
                     outcome=outcome_if_changed,
@@ -414,7 +523,7 @@ def map_bucket(ctx: ProcessingContext, *, apply: bool) -> ResultBucket:
                 reason=header_lbl,
             )
         if intent == Intent.STRIP:
-            if effective_would_strip(ctx):
+            if ctx.outcome.effective_would_strip:
                 # Prefer the strip axis label for summaries.
                 return ret(
                     debug_tag="would-strip",
@@ -462,7 +571,11 @@ def map_bucket(ctx: ProcessingContext, *, apply: bool) -> ResultBucket:
     )
 
 
-def classify_outcome(ctx: ProcessingContext, *, apply: bool) -> Outcome:
+def classify_outcome(
+    ctx: SupportsOutcomeClassification,
+    *,
+    apply: bool,
+) -> Outcome:
     """Return the public `Outcome` classification for a processing context.
 
     This is a thin convenience wrapper around `map_bucket()` when only the
@@ -478,8 +591,10 @@ def classify_outcome(ctx: ProcessingContext, *, apply: bool) -> Outcome:
     return map_bucket(ctx, apply=apply).outcome
 
 
-def collect_outcome_reason_counts(
-    results: list[ProcessingContext],
+def collect_outcome_reason_counts_for_apply(
+    results: Iterable[SupportsOutcomeClassification],
+    *,
+    apply: bool,
 ) -> list[OutcomeReasonCount]:
     """Collect summary counts grouped by `(outcome, reason)`.
 
@@ -490,6 +605,41 @@ def collect_outcome_reason_counts(
     Ordering is deterministic and stable:
     1. Fixed public `OUTCOME_ORDER`
     2. Alphabetical `reason` within each outcome
+
+    Args:
+        results: Processing contexts or durable results to bucket and count.
+        apply: Whether to classify the supplied results as apply-mode output.
+
+    Returns:
+        Sorted list of `OutcomeReasonCount` rows.
+    """
+    counts: dict[tuple[Outcome, str], int] = {}
+    for r in results:
+        bucket: ResultBucket = map_bucket(r, apply=apply)
+        outcome: Outcome = bucket.outcome
+        reason: str = bucket.reason or NO_REASON_PROVIDED
+        key: tuple[Outcome, str] = (outcome, reason)
+        counts[key] = counts.get(key, 0) + 1
+
+    order_index: dict[Outcome, int] = {outcome: idx for idx, outcome in enumerate(OUTCOME_ORDER)}
+
+    rows: list[OutcomeReasonCount] = [
+        OutcomeReasonCount(outcome=outcome, reason=reason, count=count)
+        for (outcome, reason), count in counts.items()
+    ]
+    rows.sort(key=lambda row: (order_index.get(row.outcome, 10_000), row.reason))
+    return rows
+
+
+def collect_outcome_reason_counts(
+    results: list[ProcessingContext],
+) -> list[OutcomeReasonCount]:
+    """Collect summary counts grouped by `(outcome, reason)`.
+
+    This compatibility wrapper preserves existing context-based behavior by
+    deriving apply mode from each context's runtime options. New result-oriented
+    callers that no longer retain runtime options should use
+    `collect_outcome_reason_counts_for_apply()`.
 
     Args:
         results: Processing contexts to bucket and count.

--- a/src/topmark/pipeline/pre_insert_advisory.py
+++ b/src/topmark/pipeline/pre_insert_advisory.py
@@ -1,0 +1,91 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : pre_insert_advisory.py
+#   file_relpath : src/topmark/pipeline/pre_insert_advisory.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Durable pre-insert advisory values for reduced pipeline results.
+
+Pre-insert capability is execution-time advisory state produced by reader and
+planner steps. It is not part of policy evaluation itself, but it is useful
+durable result metadata because it explains why some files are not safe
+pre-insert candidates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from typing import Protocol
+
+if TYPE_CHECKING:
+    from topmark.filetypes.model import InsertCapability
+
+
+class SupportsPreInsertAdvisory(Protocol):
+    """Minimum context-like surface required to snapshot pre-insert advice."""
+
+    @property
+    def pre_insert_capability(self) -> InsertCapability:
+        """Current pre-insert capability advisory."""
+        ...
+
+    @property
+    def pre_insert_reason(self) -> str | None:
+        """Optional human-readable reason for the current advisory."""
+        ...
+
+    @property
+    def pre_insert_origin(self) -> str | None:
+        """Optional producer of the current advisory."""
+        ...
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PreInsertAdvisorySnapshot:
+    """Durable snapshot of pre-insert capability advisory state.
+
+    Attributes:
+        capability: Current pre-insert capability advisory.
+        reason: Optional human-readable reason for the advisory.
+        origin: Optional producer of the advisory.
+    """
+
+    capability: InsertCapability
+    reason: str | None
+    origin: str | None
+
+    @classmethod
+    def from_context(
+        cls,
+        ctx: SupportsPreInsertAdvisory,
+    ) -> PreInsertAdvisorySnapshot:
+        """Create a pre-insert advisory snapshot from a context-like object.
+
+        Args:
+            ctx: Source object exposing pre-insert advisory state.
+
+        Returns:
+            Durable pre-insert advisory snapshot.
+        """
+        return cls(
+            capability=ctx.pre_insert_capability,
+            reason=ctx.pre_insert_reason,
+            origin=ctx.pre_insert_origin,
+        )
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Return a JSON-friendly pre-insert advisory payload.
+
+        Returns:
+            Mapping matching the existing serialized advisory payload shape.
+        """
+        return {
+            "capability": self.capability.name,
+            "reason": self.reason,
+            "origin": self.origin,
+        }

--- a/src/topmark/pipeline/result.py
+++ b/src/topmark/pipeline/result.py
@@ -30,14 +30,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from topmark.pipeline.context.policy import can_change
-from topmark.pipeline.context.policy import check_permitted_by_policy
-from topmark.pipeline.context.policy import effective_would_add_or_update
-from topmark.pipeline.context.policy import effective_would_strip
-from topmark.pipeline.context.policy import would_add_or_update
-from topmark.pipeline.context.policy import would_change
-from topmark.pipeline.context.policy import would_strip
 from topmark.pipeline.context.status import StatusSnapshot
+from topmark.pipeline.outcome_snapshot import OutcomeSnapshot
+from topmark.pipeline.pre_insert_advisory import PreInsertAdvisorySnapshot
 from topmark.utils.path import format_machine_path
 
 if TYPE_CHECKING:
@@ -45,7 +40,6 @@ if TYPE_CHECKING:
 
     from topmark.diagnostic.model import FrozenDiagnosticLog
     from topmark.filetypes.model import FileType
-    from topmark.filetypes.model import InsertCapability
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.hints import Hint
 
@@ -103,101 +97,6 @@ class StepAxesSnapshot:
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
-class PreInsertCheckSnapshot:
-    """Durable pre-insert advisory state captured from a context.
-
-    Attributes:
-        capability: Advisory insert capability value.
-        reason: Optional human-readable reason for the advisory.
-        origin: Optional producer of the advisory.
-    """
-
-    capability: InsertCapability
-    reason: str | None
-    origin: str | None
-
-    def to_dict(self) -> dict[str, str | None]:
-        """Return a JSON-friendly pre-insert advisory payload.
-
-        Returns:
-            Mapping with capability name, reason, and origin.
-        """
-        return {
-            "capability": self.capability.name,
-            "reason": self.reason,
-            "origin": self.origin,
-        }
-
-
-@dataclass(frozen=True, kw_only=True, slots=True)
-class OutcomeSnapshot:
-    """Durable outcome-facing flags captured from a processing context.
-
-    These flags mirror the current high-level outcome payload produced by
-    `ProcessingContext.to_dict()` without retaining the mutable context itself.
-
-    Attributes:
-        would_change: Whether the context represents any pending or completed change,
-            or `None` when the current status is not sufficient to decide.
-        can_change: Whether the context can change according to current feasibility checks.
-        permitted_by_policy: Whether policy permits the effective change, or `None`
-            when there is no clear mutation intent yet.
-        would_add_or_update: Whether check/update processing would add or update a header.
-        effective_would_add_or_update: Policy-aware add/update result.
-        would_strip: Whether strip processing would remove a header.
-        effective_would_strip: Policy-aware strip result.
-    """
-
-    would_change: bool | None
-    can_change: bool
-    permitted_by_policy: bool | None
-    would_add_or_update: bool
-    effective_would_add_or_update: bool
-    would_strip: bool
-    effective_would_strip: bool
-
-    @classmethod
-    def from_context(cls, ctx: ProcessingContext) -> OutcomeSnapshot:
-        """Create an outcome snapshot from a mutable processing context.
-
-        Args:
-            ctx: Source context to evaluate.
-
-        Returns:
-            Durable outcome-facing flag snapshot.
-        """
-        return cls(
-            would_change=would_change(ctx),
-            can_change=can_change(ctx),
-            permitted_by_policy=check_permitted_by_policy(ctx),
-            would_add_or_update=would_add_or_update(ctx),
-            effective_would_add_or_update=effective_would_add_or_update(ctx),
-            would_strip=would_strip(ctx),
-            effective_would_strip=effective_would_strip(ctx),
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        """Return a JSON-friendly outcome payload.
-
-        Returns:
-            Mapping matching the existing high-level outcome payload shape.
-        """
-        return {
-            "would_change": self.would_change,
-            "can_change": self.can_change,
-            "permitted_by_policy": self.permitted_by_policy,
-            "check": {
-                "would_add_or_update": self.would_add_or_update,
-                "effective_would_add_or_update": self.effective_would_add_or_update,
-            },
-            "strip": {
-                "would_strip": self.would_strip,
-                "effective_would_strip": self.effective_would_strip,
-            },
-        }
-
-
-@dataclass(frozen=True, kw_only=True, slots=True)
 class ProcessingResult:
     """Durable reduced outcome for one processed file.
 
@@ -228,7 +127,7 @@ class ProcessingResult:
     diagnostics: FrozenDiagnosticLog
     diagnostic_counts: Mapping[str, int]
     hints: tuple[Hint, ...]
-    pre_insert_check: PreInsertCheckSnapshot
+    pre_insert_check: PreInsertAdvisorySnapshot
     outcome: OutcomeSnapshot
 
     @classmethod
@@ -261,11 +160,7 @@ class ProcessingResult:
             diagnostics=diagnostics,
             diagnostic_counts=diagnostics.to_dict(),
             hints=tuple(ctx.diagnostic_hints),
-            pre_insert_check=PreInsertCheckSnapshot(
-                capability=ctx.pre_insert_capability,
-                reason=ctx.pre_insert_reason,
-                origin=ctx.pre_insert_origin,
-            ),
+            pre_insert_check=PreInsertAdvisorySnapshot.from_context(ctx),
             outcome=OutcomeSnapshot.from_context(ctx),
         )
 

--- a/tests/pipeline/test_outcomes.py
+++ b/tests/pipeline/test_outcomes.py
@@ -26,8 +26,10 @@ from topmark.pipeline.outcomes import OutcomeReasonCount
 from topmark.pipeline.outcomes import ResultBucket
 from topmark.pipeline.outcomes import classify_outcome
 from topmark.pipeline.outcomes import collect_outcome_reason_counts
+from topmark.pipeline.outcomes import collect_outcome_reason_counts_for_apply
 from topmark.pipeline.outcomes import determine_intent
 from topmark.pipeline.outcomes import map_bucket
+from topmark.pipeline.result import ProcessingResult
 from topmark.pipeline.status import ComparisonStatus
 from topmark.pipeline.status import ContentStatus
 from topmark.pipeline.status import FsStatus
@@ -366,6 +368,136 @@ def test_map_bucket_falls_back_to_pending(tmp_path: Path) -> None:
 
     assert bucket.outcome is Outcome.PENDING
     assert bucket.reason == NO_REASON_PROVIDED
+
+
+def test_map_bucket_supports_processing_result_snapshot(tmp_path: Path) -> None:
+    """ProcessingResult should classify like the source ProcessingContext."""
+    ctx: ProcessingContext = _make_context(tmp_path)
+    ctx.status.header = HeaderStatus.MISSING
+    ctx.status.comparison = ComparisonStatus.CHANGED
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    context_bucket: ResultBucket = map_bucket(ctx, apply=False)
+    result_bucket: ResultBucket = map_bucket(result, apply=False)
+
+    assert result_bucket == context_bucket
+
+
+def test_map_bucket_supports_processing_result_empty_policy_snapshot(
+    tmp_path: Path,
+) -> None:
+    """ProcessingResult should preserve empty-for-insert policy classification."""
+    ctx: ProcessingContext = _make_context(tmp_path)
+    ctx.status.fs = FsStatus.EMPTY
+    ctx.status.header = HeaderStatus.MISSING
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    context_bucket: ResultBucket = map_bucket(ctx, apply=False)
+    result_bucket: ResultBucket = map_bucket(result, apply=False)
+
+    assert result_bucket == context_bucket
+
+
+def test_map_bucket_supports_processing_result_policy_veto_snapshot(
+    tmp_path: Path,
+) -> None:
+    """ProcessingResult should preserve policy-veto classification."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path,
+        mutation_mode=HeaderMutationMode.ADD_ONLY,
+    )
+    ctx.status.header = HeaderStatus.DETECTED
+    ctx.status.comparison = ComparisonStatus.CHANGED
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    context_bucket: ResultBucket = map_bucket(ctx, apply=False)
+    result_bucket: ResultBucket = map_bucket(result, apply=False)
+
+    assert result_bucket == context_bucket
+    assert result_bucket.outcome is Outcome.SKIPPED
+    assert result_bucket.reason == "skipped by policy"
+
+
+def test_map_bucket_supports_processing_result_write_failure_snapshot(
+    tmp_path: Path,
+) -> None:
+    """ProcessingResult should preserve apply-mode write failure classification."""
+    ctx: ProcessingContext = _make_context(tmp_path, apply_changes=True)
+    ctx.status.header = HeaderStatus.MISSING
+    ctx.status.comparison = ComparisonStatus.CHANGED
+    ctx.status.write = WriteStatus.FAILED
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    context_bucket: ResultBucket = map_bucket(ctx, apply=True)
+    result_bucket: ResultBucket = map_bucket(result, apply=True)
+
+    assert result_bucket == context_bucket
+    assert result_bucket.outcome is Outcome.ERROR
+    assert result_bucket.reason == WriteStatus.FAILED.value
+
+
+def test_collect_outcome_reason_counts_for_apply_supports_processing_results(
+    tmp_path: Path,
+) -> None:
+    """Apply-explicit summaries should work without runtime options."""
+    ctx: ProcessingContext = _make_context(tmp_path, apply_changes=True)
+    ctx.status.header = HeaderStatus.MISSING
+    ctx.status.comparison = ComparisonStatus.CHANGED
+    ctx.status.write = WriteStatus.WRITTEN
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    rows: list[OutcomeReasonCount] = collect_outcome_reason_counts_for_apply(
+        [result],
+        apply=True,
+    )
+
+    assert [(row.outcome, row.reason, row.count) for row in rows] == [
+        (
+            Outcome.INSERTED,
+            f"{HeaderStatus.MISSING.value}, {ComparisonStatus.CHANGED.value}",
+            1,
+        )
+    ]
+
+
+def test_collect_outcome_reason_counts_for_apply_groups_processing_results(
+    tmp_path: Path,
+) -> None:
+    """Apply-explicit summaries should group multiple reduced results by bucket."""
+    first_insert: ProcessingContext = _make_context(tmp_path, apply_changes=True)
+    first_insert.status.header = HeaderStatus.MISSING
+    first_insert.status.comparison = ComparisonStatus.CHANGED
+    first_insert.status.write = WriteStatus.WRITTEN
+
+    second_insert: ProcessingContext = _make_context(tmp_path, apply_changes=True)
+    second_insert.status.header = HeaderStatus.MISSING
+    second_insert.status.comparison = ComparisonStatus.CHANGED
+    second_insert.status.write = WriteStatus.WRITTEN
+
+    policy_veto: ProcessingContext = _make_context(
+        tmp_path,
+        mutation_mode=HeaderMutationMode.ADD_ONLY,
+    )
+    policy_veto.status.header = HeaderStatus.DETECTED
+    policy_veto.status.comparison = ComparisonStatus.CHANGED
+
+    rows: list[OutcomeReasonCount] = collect_outcome_reason_counts_for_apply(
+        [
+            ProcessingResult.from_context(first_insert),
+            ProcessingResult.from_context(second_insert),
+            ProcessingResult.from_context(policy_veto),
+        ],
+        apply=True,
+    )
+
+    assert [(row.outcome, row.reason, row.count) for row in rows] == [
+        (Outcome.SKIPPED, "skipped by policy", 1),
+        (
+            Outcome.INSERTED,
+            f"{HeaderStatus.MISSING.value}, {ComparisonStatus.CHANGED.value}",
+            2,
+        ),
+    ]
 
 
 def test_classify_outcome_returns_bucket_outcome(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR implements the second staged step of GitHub issue #148:

- Separate volatile ProcessingContext from durable ProcessingResult

It builds directly on PR #150, which introduced:

- StatusSnapshot
- ProcessingResult
- ProcessingResult.from_context(...)
- reduce_processing_context(...)

The goal of this PR is to remove the architectural requirement that
pipeline outcome classification operate exclusively on mutable
ProcessingContext instances.

Outcome bucketing can now operate on durable reduced results while
preserving all existing runtime behavior.

## Changes

### Outcome-classification abstraction

Introduced a protocol-based outcome-classification surface so that
outcome bucketing no longer fundamentally depends on ProcessingContext.

Key additions:

- SupportsPolicyEvaluation
- OutcomeSnapshot
- PreInsertAdvisorySnapshot

### Durable snapshot extraction

Policy-derived and advisory state is now captured through immutable
snapshot objects:

- OutcomeSnapshot
- PreInsertAdvisorySnapshot

This allows ProcessingResult instances to participate in outcome
classification without retaining references to mutable execution state.

### ProcessingResult integration

ProcessingResult now:

- stores typed outcome snapshots
- stores typed pre-insert advisory snapshots
- participates in outcome bucketing
- preserves existing machine-output payload shapes

### Tests

Added parity coverage ensuring that:

- ProcessingContext and ProcessingResult classify identically
- policy-aware outcome bucketing behaves consistently
- reduced results participate in summary generation

### Documentation

Updated:

- docs/dev/architecture.md
- CHANGELOG.md

to describe the new durable outcome-classification architecture.

## Compatibility

This PR intentionally does NOT change:

- CLI behavior
- API behavior
- runner behavior
- reporting behavior
- machine-readable output contracts
- processing semantics

The change is internal and architectural.

## Issue Tracking

Implements the next stage of:

- #148 Separate volatile ProcessingContext from durable ProcessingResult

Follows:

- PR #150

No breaking changes.