### PR TITLE
Refactor pipeline result snapshots to preserve execution mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,8 +110,8 @@ ______________________________________________________________________
   third-party-action jobs, bounded link-check jobs with explicit timeouts, and summarized
   path-filter decisions in the GitHub Actions step summary.
 - Made pipeline outcome bucketing compatible with durable `ProcessingResult` snapshots by
-  introducing typed outcome and pre-insert advisory snapshots, while preserving existing
-  `ProcessingContext` consumers and machine-output shapes.
+  introducing typed outcome, pre-insert advisory, and execution-mode snapshots, while preserving
+  existing `ProcessingContext` consumers, CLI/API behavior, and machine-output shapes.
 
 ### Breaking Changes - Unreleased
 
@@ -275,6 +275,8 @@ ______________________________________________________________________
 - Documented GitHub issue 147, including output ownership findings, streaming-output architecture
   alternatives, benchmark relevance, and the rationale for closing Track B without further
   implementation.
+- Clarified the architecture boundary between mutable `ProcessingContext` execution state and
+  durable `ProcessingResult` snapshots for outcome classification.
 
 ### Internal - Unreleased
 
@@ -341,8 +343,9 @@ ______________________________________________________________________
 - Added immutable `StatusSnapshot` and `ProcessingResult` result-reduction primitives as the first
   stage of separating volatile pipeline execution state from durable processing outcomes (GitHub
   issue #148).
-- Added typed outcome-classification and pre-insert advisory snapshots so policy-derived bucketing
-  state can be reduced from mutable pipeline contexts without retaining volatile execution objects.
+- Added typed outcome-classification, pre-insert advisory, and execution-mode snapshots so
+  policy-derived bucketing state and invocation intent can be reduced from mutable pipeline contexts
+  without retaining volatile execution objects.
 
 ### Notes - Unreleased
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -34,10 +34,12 @@ The following architectural contracts are part of the stable 1.x design:
 - Machine-readable output remains independent from human-facing TEXT and Markdown output.
 - Mutable pipeline execution state can be reduced to durable result snapshots without changing
   runner, CLI, API, or presentation behavior.
-- Outcome bucketing is based on a narrow status + outcome-flag contract so live
-  \[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances and durable
-  \[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] snapshots can be classified
-  through the same presentation-free logic.
+- Outcome bucketing is based on a narrow status + outcome-flag contract. Durable
+  \[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] snapshots preserve that
+  classification state, together with reduced execution-mode metadata, so result-oriented consumers
+  can classify outcomes without retaining the full mutable
+  \[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext]. Existing live-context
+  consumers remain supported while result-facing consumers migrate across the reduction boundary.
 
 ______________________________________________________________________
 

--- a/src/topmark/api/commands/pipeline.py
+++ b/src/topmark/api/commands/pipeline.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from topmark.api.types import PublicReportScopeLiteral
     from topmark.api.types import RunResult
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.protocols import Step
 
 __all__ = (
@@ -126,9 +127,10 @@ def check(
         Reporting/view filtering is handled by the public view layer. It does not
         change which files are eligible to be written when `apply=True`.
     """
+    PIPELINE_KIND: PipelineKindLiteral = "check"
     # Choose the concrete content-processing pipeline variant.
     pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
-        "check",
+        PIPELINE_KIND,
         apply=apply,
         diff=diff,
     )
@@ -137,6 +139,7 @@ def check(
     # file-list resolution, per-path config, and pipeline execution.
 
     run_options: RunOptions = RunOptions(
+        pipeline_kind=PIPELINE_KIND,
         apply_changes=apply,
         prune_views=prune_views,
         keep_diff_view=diff,
@@ -217,9 +220,10 @@ def strip(
         Reporting/view filtering is handled by the public view layer and does not
         modify pipeline write decisions.
     """
+    PIPELINE_KIND: PipelineKindLiteral = "strip"
     # Choose the concrete content-processing pipeline variant.
     pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
-        "strip",
+        PIPELINE_KIND,
         apply=apply,
         diff=diff,
     )
@@ -228,6 +232,7 @@ def strip(
     # file-list resolution, per-path config, and pipeline execution.
 
     run_options: RunOptions = RunOptions(
+        pipeline_kind=PIPELINE_KIND,
         apply_changes=apply,
         prune_views=prune_views,
         keep_diff_view=diff,
@@ -304,9 +309,10 @@ def probe(
         `probe()` is always read-only. It has no `apply` or `diff` mode because it
         explains resolution rather than planning or applying header mutations.
     """
+    PIPELINE_KIND: PipelineKindLiteral = "probe"
     # Probe has a single read-only diagnostic pipeline.
     pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
-        "probe",
+        PIPELINE_KIND,
         apply=False,
         diff=False,
     )
@@ -314,6 +320,7 @@ def probe(
     # missing literals and explicit inputs filtered before probing.
 
     run_options: RunOptions = RunOptions(
+        pipeline_kind=PIPELINE_KIND,
         apply_changes=False,
         prune_views=prune_views,
     )

--- a/src/topmark/api/runtime.py
+++ b/src/topmark/api/runtime.py
@@ -67,13 +67,13 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
 
-    from topmark.api.types import PipelineKindLiteral
     from topmark.api.types import PublicPolicy
     from topmark.config.resolution.bridge import ResolvedConfigDraft
     from topmark.config.resolution.layers import ConfigLayer
     from topmark.core.exit_codes import ExitCode
     from topmark.core.logging import TopmarkLogger
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.protocols import Step
     from topmark.resolution.discovery import FileSelectionProbeResult
     from topmark.resolution.files import FileListResolution

--- a/src/topmark/api/types.py
+++ b/src/topmark/api/types.py
@@ -64,19 +64,12 @@ Values are typed as `object` intentionally so the public boundary does not leak
 layer.
 """
 
-DiagnosticLevelLiteral = Literal[
+DiagnosticLevelLiteral: TypeAlias = Literal[
     "info",
     "warning",
     "error",
 ]
 """Allowed public diagnostic severity tokens."""
-
-PipelineKindLiteral = Literal[
-    "probe",
-    "check",
-    "strip",
-]
-"""Allowed public pipeline-family tokens."""
 
 
 # ---- Public diagnostics and run-result shapes ----
@@ -467,7 +460,7 @@ class BindingInfo(TypedDict, total=True):
 # ---- Public policy / reporting tokens ----
 
 
-PublicEmptyInsertModeLiteral = Literal[
+PublicEmptyInsertModeLiteral: TypeAlias = Literal[
     "bytes_empty",
     "logical_empty",
     "whitespace_empty",
@@ -478,7 +471,7 @@ These values intentionally mirror the internal `EmptyInsertMode.value` strings
 without exposing the internal enum class as part of the public API.
 """
 
-PublicHeaderMutationModeLiteral = Literal[
+PublicHeaderMutationModeLiteral: TypeAlias = Literal[
     "all",
     "add_only",
     "update_only",
@@ -489,7 +482,7 @@ These values intentionally mirror the internal `HeaderMutationMode.value`
 strings without exposing the internal enum class as part of the public API.
 """
 
-PublicReportScopeLiteral = Literal[
+PublicReportScopeLiteral: TypeAlias = Literal[
     "actionable",
     "noncompliant",
     "all",

--- a/src/topmark/cli/cmd_common.py
+++ b/src/topmark/cli/cmd_common.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
     from topmark.core.errors import ConfigValidationError
     from topmark.core.machine.schemas import MetaPayload
     from topmark.diagnostic.model import FrozenDiagnosticLog
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.toml.resolution import ResolvedTopmarkTomlSources
 
 
@@ -182,6 +183,7 @@ def build_file_resolution(
 
 def build_run_options(
     *,
+    pipeline_kind: PipelineKindLiteral | None,
     apply_changes: bool,
     write_mode: str | None,
     stdin_mode: bool,
@@ -192,6 +194,7 @@ def build_run_options(
     """Build invocation-wide runtime options for a CLI command.
 
     Args:
+        pipeline_kind: The pipeline kind (`check`, `strip`, `probe`).
         apply_changes: Whether the command should write changes.
         write_mode: Effective CLI write mode (`stdout`, `atomic`, or `inplace`).
         stdin_mode: Whether the command is operating in content-on-STDIN mode.
@@ -221,6 +224,7 @@ def build_run_options(
         file_write_strategy = FileWriteStrategy.INPLACE
 
     run_options = RunOptions(
+        pipeline_kind=pipeline_kind,
         apply_changes=apply_changes,
         output_target=output_target,
         file_write_strategy=file_write_strategy,

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -124,7 +124,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from topmark.api.types import PipelineKindLiteral
     from topmark.cli.cmd_common import PreparedCliConfig
     from topmark.cli.console.color import ColorMode
     from topmark.cli.console.protocols import ConsoleProtocol
@@ -135,6 +134,7 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import MetaPayload
     from topmark.diagnostic.model import FrozenDiagnosticLog
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.protocols import Step
     from topmark.resolution.files import FileListResolution
     from topmark.runtime.model import RunOptions
@@ -300,6 +300,7 @@ def check_command(
         PIPELINE_ERROR (70): An internal processing step failed.
         UNEXPECTED_ERROR (255): An unhandled error occurred.
     """
+    PIPELINE_KIND: PipelineKindLiteral = "check"
     ctx: click.Context = click.get_current_context()
     ctx.args = list(paths)
     state: TopmarkCliState = bootstrap_cli_state(ctx)
@@ -386,6 +387,7 @@ def check_command(
     )
 
     run_options: RunOptions = build_run_options(
+        pipeline_kind=PIPELINE_KIND,
         apply_changes=apply_changes,
         write_mode=write_mode,
         stdin_mode=plan.stdin_mode,
@@ -473,9 +475,8 @@ def check_command(
         return
 
     # Choose and run the concrete pipeline variant.
-    pipeline_kind: PipelineKindLiteral = "check"
     pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
-        pipeline_kind,
+        PIPELINE_KIND,
         apply=apply_changes,
         diff=diff,
     )
@@ -528,8 +529,7 @@ def check_command(
         )
     else:
         report = PipelineCommandHumanReport(
-            cmd=CliCmd.CHECK,
-            pipeline_kind=pipeline_kind,
+            pipeline_kind=PIPELINE_KIND,
             file_list_total=len(results),
             view_results=human_results,
             report_scope=report_scope,

--- a/src/topmark/cli/commands/config_dump.py
+++ b/src/topmark/cli/commands/config_dump.py
@@ -267,8 +267,9 @@ def config_dump_command(
     )
 
     run_options: RunOptions = build_run_options(
-        apply_changes=False,  # Not relevant for `config dump``
-        write_mode=None,  # Not relevant for `config dump``
+        pipeline_kind=None,  # Not relevant for `config dump`
+        apply_changes=False,  # Not relevant for `config dump`
+        write_mode=None,  # Not relevant for `config dump`
         stdin_mode=plan.stdin_mode,
         stdin_filename=plan.stdin_filename,
     )

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -114,6 +114,7 @@ if TYPE_CHECKING:
     from topmark.diagnostic.model import FrozenDiagnosticLog
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.engine import PipelineExecution
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.protocols import Step
     from topmark.resolution.discovery import FileSelectionProbeResult
     from topmark.resolution.files import FileListResolution
@@ -231,6 +232,7 @@ def probe_command(
         PIPELINE_ERROR (70): An internal processing step failed.
         UNEXPECTED_ERROR (255): An unhandled error occurred.
     """
+    PIPELINE_KIND: PipelineKindLiteral = "probe"
     ctx: click.Context = click.get_current_context()
     ctx.args = list(paths)
     state: TopmarkCliState = bootstrap_cli_state(ctx)
@@ -303,6 +305,7 @@ def probe_command(
     )
 
     run_options: RunOptions = build_run_options(
+        pipeline_kind=PIPELINE_KIND,
         apply_changes=False,  # Not relevant for `topmark probe`
         write_mode=None,  # Not relevant for `topmark probe`
         stdin_mode=plan.stdin_mode,
@@ -447,7 +450,7 @@ def probe_command(
         )
     else:
         report = ProbeCommandHumanReport(
-            cmd=CliCmd.PROBE,
+            pipeline_kind=PIPELINE_KIND,
             file_list_total=len(results),
             view_results=results,
             verbosity_level=verbosity_level,

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -116,7 +116,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from topmark.api.types import PipelineKindLiteral
     from topmark.cli.cmd_common import PreparedCliConfig
     from topmark.cli.console.color import ColorMode
     from topmark.cli.console.protocols import ConsoleProtocol
@@ -126,6 +125,7 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import MetaPayload
     from topmark.diagnostic.model import FrozenDiagnosticLog
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.protocols import Step
     from topmark.resolution.files import FileListResolution
     from topmark.runtime.model import RunOptions
@@ -264,6 +264,7 @@ def strip_command(
         PIPELINE_ERROR (70): An internal processing step failed.
         UNEXPECTED_ERROR (255): An unhandled error occurred.
     """
+    PIPELINE_KIND: PipelineKindLiteral = "strip"
     ctx: click.Context = click.get_current_context()
     ctx.args = list(paths)
     state: TopmarkCliState = bootstrap_cli_state(ctx)
@@ -345,6 +346,7 @@ def strip_command(
     )
 
     run_options: RunOptions = build_run_options(
+        pipeline_kind=PIPELINE_KIND,
         apply_changes=apply_changes,
         write_mode=write_mode,
         stdin_mode=plan.stdin_mode,
@@ -432,9 +434,8 @@ def strip_command(
         return
 
     # Choose and run the concrete pipeline variant.
-    pipeline_kind: PipelineKindLiteral = "strip"
     pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
-        pipeline_kind,
+        PIPELINE_KIND,
         apply=apply_changes,
         diff=diff,
     )
@@ -487,8 +488,7 @@ def strip_command(
         )
     else:
         report = PipelineCommandHumanReport(
-            cmd=CliCmd.STRIP,
-            pipeline_kind=pipeline_kind,
+            pipeline_kind=PIPELINE_KIND,
             file_list_total=len(results),
             view_results=human_results,
             report_scope=report_scope,

--- a/src/topmark/pipeline/kinds.py
+++ b/src/topmark/pipeline/kinds.py
@@ -1,0 +1,44 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : kinds.py
+#   file_relpath : src/topmark/pipeline/kinds.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Pipeline-family identifiers shared across runtime layers.
+
+This module defines lightweight pipeline-kind aliases that are consumed by
+pipeline execution, runtime configuration, CLI commands, and API entry points.
+
+The aliases live in a dedicated low-level module so they can be imported by
+both runtime and public-facing layers without creating dependency cycles.
+In particular, pipeline-kind definitions are intentionally separated from
+`topmark.api.types` because pipeline execution and result-reduction code
+must not depend on API-specific modules.
+
+Pipeline kinds describe the high-level intent of a pipeline invocation
+(`probe`, `check`, or `strip`). They do not describe a specific pipeline
+implementation or step sequence.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from typing import TypeAlias
+
+__all__ = ("PipelineKindLiteral",)
+
+
+PipelineKindLiteral: TypeAlias = Literal[
+    "probe",
+    "check",
+    "strip",
+]
+"""Allowed pipeline-family identifiers.
+
+These values describe the high-level processing intent selected by the user
+and are propagated through runtime execution and durable result snapshots.
+"""

--- a/src/topmark/pipeline/machine/payloads.py
+++ b/src/topmark/pipeline/machine/payloads.py
@@ -43,13 +43,16 @@ from typing import TYPE_CHECKING
 from topmark.pipeline.context.model import ProcessingContext
 from topmark.pipeline.outcomes import OutcomeReasonCount
 from topmark.pipeline.outcomes import collect_outcome_reason_counts
+from topmark.pipeline.outcomes import collect_outcome_reason_counts_for_apply
 from topmark.utils.path import format_machine_path
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from collections.abc import Iterator
 
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.machine.schemas import OutcomeSummaryRow
+    from topmark.pipeline.outcomes import SupportsOutcomeClassification
     from topmark.resolution.probe import ResolutionProbeCandidate
     from topmark.resolution.probe import ResolutionProbeMatchSignals
     from topmark.resolution.probe import ResolutionProbeResult
@@ -201,6 +204,48 @@ def iter_processing_results_payload_items(
         yield r.to_dict()
 
 
+def _summary_rows_from_counts(
+    counts: list[OutcomeReasonCount],
+) -> list[OutcomeSummaryRow]:
+    """Build JSON-friendly summary rows from grouped outcome counts.
+
+    Args:
+        counts: Ordered outcome/reason/count rows.
+
+    Returns:
+        List of [`OutcomeSummaryRow`][topmark.pipeline.machine.schemas.OutcomeSummaryRow] objects.
+    """
+    return [
+        {"outcome": row.outcome.value, "reason": row.reason, "count": row.count} for row in counts
+    ]
+
+
+def build_processing_results_summary_rows_payload_for_apply(
+    results: Iterable[SupportsOutcomeClassification],
+    *,
+    apply: bool,
+) -> list[OutcomeSummaryRow]:
+    """Build a JSON-friendly summary payload for an explicit execution mode.
+
+    This result-compatible helper accepts either mutable processing contexts or
+    durable processing results. The execution mode is supplied explicitly so
+    callers do not need to retain runtime options only for outcome summary
+    classification.
+
+    Args:
+        results: Ordered list of processing contexts or durable results.
+        apply: Whether to classify the supplied results as apply-mode output.
+
+    Returns:
+        List of [`OutcomeSummaryRow`][topmark.pipeline.machine.schemas.OutcomeSummaryRow] objects.
+    """
+    counts: list[OutcomeReasonCount] = collect_outcome_reason_counts_for_apply(
+        results,
+        apply=apply,
+    )
+    return _summary_rows_from_counts(counts)
+
+
 def build_processing_results_summary_rows_payload(
     results: list[ProcessingContext],
 ) -> list[OutcomeSummaryRow]:
@@ -230,10 +275,32 @@ def build_processing_results_summary_rows_payload(
         List of [`OutcomeSummaryRow`][topmark.pipeline.machine.schemas.OutcomeSummaryRow] objects.
     """
     counts: list[OutcomeReasonCount] = collect_outcome_reason_counts(results)
-    summary_rows: list[OutcomeSummaryRow] = [
-        {"outcome": row.outcome.value, "reason": row.reason, "count": row.count} for row in counts
-    ]
-    return summary_rows
+    return _summary_rows_from_counts(counts)
+
+
+def iter_processing_results_summary_entries_for_apply(
+    results: Iterable[SupportsOutcomeClassification],
+    *,
+    apply: bool,
+) -> Iterator[OutcomeSummaryRow]:
+    """Yield NDJSON-friendly summary rows for an explicit execution mode.
+
+    This result-compatible helper accepts either mutable processing contexts or
+    durable processing results. Each yielded object preserves the full
+    `(outcome, reason, count)` tuple so NDJSON summary mode does not collapse
+    sub-buckets inside the same outcome.
+
+    Args:
+        results: Ordered list of processing contexts or durable results.
+        apply: Whether to classify the supplied results as apply-mode output.
+
+    Yields:
+        One summary row object per `(outcome, reason)` bucket.
+    """
+    yield from build_processing_results_summary_rows_payload_for_apply(
+        results,
+        apply=apply,
+    )
 
 
 def iter_processing_results_summary_entries(
@@ -255,10 +322,4 @@ def iter_processing_results_summary_entries(
     """
     counts: list[OutcomeReasonCount] = collect_outcome_reason_counts(results)
 
-    for row in counts:
-        summary_row: OutcomeSummaryRow = {
-            "outcome": row.outcome.value,
-            "reason": row.reason,
-            "count": row.count,
-        }
-        yield summary_row
+    yield from _summary_rows_from_counts(counts)

--- a/src/topmark/pipeline/outcome_snapshot.py
+++ b/src/topmark/pipeline/outcome_snapshot.py
@@ -17,8 +17,8 @@ immutable outcome-facing value object used when reducing that context into a
 
 `OutcomeSnapshot` deliberately stores computed flags rather than retaining the
 source context. That keeps result objects independent from volatile execution
-state and lets reporting code classify either a live context or a reduced result
-through the same outcome-classification protocol.
+state and provides the policy-aware fields needed by result-oriented classification
+without retaining the mutable context.
 """
 
 from __future__ import annotations

--- a/src/topmark/pipeline/outcomes.py
+++ b/src/topmark/pipeline/outcomes.py
@@ -591,6 +591,48 @@ def classify_outcome(
     return map_bucket(ctx, apply=apply).outcome
 
 
+# Helper functions for bucketing and sorting outcome reasons/counts.
+def _count_buckets(
+    buckets: Iterable[ResultBucket],
+) -> dict[tuple[Outcome, str], int]:
+    """Count result buckets by `(outcome, reason)`.
+
+    Args:
+        buckets: Buckets to count.
+
+    Returns:
+        Mapping from `(outcome, reason)` to occurrence count.
+    """
+    counts: dict[tuple[Outcome, str], int] = {}
+    for bucket in buckets:
+        outcome: Outcome = bucket.outcome
+        reason: str = bucket.reason or NO_REASON_PROVIDED
+        key: tuple[Outcome, str] = (outcome, reason)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _sorted_outcome_reason_rows(
+    counts: dict[tuple[Outcome, str], int],
+) -> list[OutcomeReasonCount]:
+    """Return sorted outcome summary rows for counted buckets.
+
+    Args:
+        counts: Mapping from `(outcome, reason)` to occurrence count.
+
+    Returns:
+        Sorted list of `OutcomeReasonCount` rows.
+    """
+    order_index: dict[Outcome, int] = {outcome: idx for idx, outcome in enumerate(OUTCOME_ORDER)}
+
+    rows: list[OutcomeReasonCount] = [
+        OutcomeReasonCount(outcome=outcome, reason=reason, count=count)
+        for (outcome, reason), count in counts.items()
+    ]
+    rows.sort(key=lambda row: (order_index.get(row.outcome, 10_000), row.reason))
+    return rows
+
+
 def collect_outcome_reason_counts_for_apply(
     results: Iterable[SupportsOutcomeClassification],
     *,
@@ -613,22 +655,8 @@ def collect_outcome_reason_counts_for_apply(
     Returns:
         Sorted list of `OutcomeReasonCount` rows.
     """
-    counts: dict[tuple[Outcome, str], int] = {}
-    for r in results:
-        bucket: ResultBucket = map_bucket(r, apply=apply)
-        outcome: Outcome = bucket.outcome
-        reason: str = bucket.reason or NO_REASON_PROVIDED
-        key: tuple[Outcome, str] = (outcome, reason)
-        counts[key] = counts.get(key, 0) + 1
-
-    order_index: dict[Outcome, int] = {outcome: idx for idx, outcome in enumerate(OUTCOME_ORDER)}
-
-    rows: list[OutcomeReasonCount] = [
-        OutcomeReasonCount(outcome=outcome, reason=reason, count=count)
-        for (outcome, reason), count in counts.items()
-    ]
-    rows.sort(key=lambda row: (order_index.get(row.outcome, 10_000), row.reason))
-    return rows
+    buckets: Iterable[ResultBucket] = (map_bucket(r, apply=apply) for r in results)
+    return _sorted_outcome_reason_rows(_count_buckets(buckets))
 
 
 def collect_outcome_reason_counts(
@@ -647,20 +675,7 @@ def collect_outcome_reason_counts(
     Returns:
         Sorted list of `OutcomeReasonCount` rows.
     """
-    counts: dict[tuple[Outcome, str], int] = {}
-    for r in results:
-        apply: bool = r.run_options.apply_changes is True
-        bucket: ResultBucket = map_bucket(r, apply=apply)
-        outcome: Outcome = bucket.outcome
-        reason: str = bucket.reason or NO_REASON_PROVIDED
-        key: tuple[Outcome, str] = (outcome, reason)
-        counts[key] = counts.get(key, 0) + 1
-
-    order_index: dict[Outcome, int] = {outcome: idx for idx, outcome in enumerate(OUTCOME_ORDER)}
-
-    rows: list[OutcomeReasonCount] = [
-        OutcomeReasonCount(outcome=outcome, reason=reason, count=count)
-        for (outcome, reason), count in counts.items()
-    ]
-    rows.sort(key=lambda row: (order_index.get(row.outcome, 10_000), row.reason))
-    return rows
+    buckets: Iterable[ResultBucket] = (
+        map_bucket(r, apply=r.run_options.apply_changes is True) for r in results
+    )
+    return _sorted_outcome_reason_rows(_count_buckets(buckets))

--- a/src/topmark/pipeline/result.py
+++ b/src/topmark/pipeline/result.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from typing_extensions import Self
+
 from topmark.pipeline.context.status import StatusSnapshot
 from topmark.pipeline.outcome_snapshot import OutcomeSnapshot
 from topmark.pipeline.pre_insert_advisory import PreInsertAdvisorySnapshot
@@ -42,6 +44,8 @@ if TYPE_CHECKING:
     from topmark.filetypes.model import FileType
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.hints import Hint
+    from topmark.pipeline.kinds import PipelineKindLiteral
+    from topmark.runtime.model import RunOptions
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -57,7 +61,10 @@ class FileTypeSnapshot:
     description: str
 
     @classmethod
-    def from_file_type(cls, file_type: FileType) -> FileTypeSnapshot:
+    def from_file_type(
+        cls,
+        file_type: FileType,
+    ) -> Self:
         """Create a file-type snapshot from a resolved file type.
 
         Args:
@@ -97,6 +104,57 @@ class StepAxesSnapshot:
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
+class ExecutionModeSnapshot:
+    """Durable invocation-mode facts captured from runtime options.
+
+    `ExecutionModeSnapshot` intentionally stores only the execution facts that
+    remain meaningful after reducing a mutable processing context. It does not
+    retain the full `RunOptions` object because that object also carries
+    runtime-only presentation, STDIN, and output-target configuration.
+
+    Attributes:
+        pipeline_kind: Pipeline family selected for the run (`check`, `strip`,
+            or `probe`). `None` is reserved for non-pipeline helper contexts.
+        apply_changes: Whether this run applied file mutations instead of
+            previewing them.
+    """
+
+    pipeline_kind: PipelineKindLiteral | None
+    apply_changes: bool
+
+    @classmethod
+    def from_run_options(
+        cls,
+        run_options: RunOptions,
+    ) -> Self:
+        """Create an execution-mode snapshot from runtime options.
+
+        Args:
+            run_options: Runtime options for one TopMark invocation.
+
+        Returns:
+            Reduced execution-mode metadata suitable for storing in a durable
+            processing result.
+        """
+        return cls(
+            pipeline_kind=run_options.pipeline_kind,
+            apply_changes=bool(run_options.apply_changes),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a machine-readable execution-mode payload.
+
+        Returns:
+            JSON-serializable mapping containing the reduced pipeline kind and
+            apply-mode flag.
+        """
+        return {
+            "apply_changes": self.apply_changes,
+            "pipeline_kind": self.pipeline_kind,
+        }
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ProcessingResult:
     """Durable reduced outcome for one processed file.
 
@@ -109,6 +167,7 @@ class ProcessingResult:
     Attributes:
         path: Processing path for the file.
         file_type: Durable resolved file-type identity, if any.
+        execution_mode: The execution-mode snapshot for this context.
         steps: Names of executed steps in execution order.
         step_axes: Axes declared by each executed step.
         status: Immutable per-axis status snapshot.
@@ -121,6 +180,7 @@ class ProcessingResult:
 
     path: Path
     file_type: FileTypeSnapshot | None
+    execution_mode: ExecutionModeSnapshot
     steps: tuple[str, ...]
     step_axes: tuple[StepAxesSnapshot, ...]
     status: StatusSnapshot
@@ -131,7 +191,10 @@ class ProcessingResult:
     outcome: OutcomeSnapshot
 
     @classmethod
-    def from_context(cls, ctx: ProcessingContext) -> ProcessingResult:
+    def from_context(
+        cls,
+        ctx: ProcessingContext,
+    ) -> Self:
         """Reduce a mutable processing context to a durable result snapshot.
 
         Args:
@@ -148,6 +211,7 @@ class ProcessingResult:
                 if ctx.file_type is not None
                 else None
             ),
+            execution_mode=ExecutionModeSnapshot.from_run_options(ctx.run_options),
             steps=tuple(step.name for step in ctx.steps),
             step_axes=tuple(
                 StepAxesSnapshot(
@@ -185,6 +249,7 @@ class ProcessingResult:
         return {
             "path": format_machine_path(self.path),
             "file_type": self.file_type.to_dict() if self.file_type is not None else None,
+            "execution_mode": self.execution_mode.to_dict(),
             "steps": list(self.steps),
             "step_axes": self.step_axes_dict,
             "status": self.status.to_dict(),
@@ -209,15 +274,3 @@ class ProcessingResult:
             "pre_insert_check": self.pre_insert_check.to_dict(),
             "outcome": self.outcome.to_dict(),
         }
-
-
-def reduce_processing_context(ctx: ProcessingContext) -> ProcessingResult:
-    """Reduce a mutable processing context to a durable result snapshot.
-
-    Args:
-        ctx: Source mutable context.
-
-    Returns:
-        Detached durable result snapshot.
-    """
-    return ProcessingResult.from_context(ctx)

--- a/src/topmark/presentation/markdown/pipeline.py
+++ b/src/topmark/presentation/markdown/pipeline.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from topmark.diagnostic.model import DiagnosticStats
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.hints import Hint
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.outcomes import OutcomeReasonCount
     from topmark.pipeline.views import DiffView
 
@@ -106,13 +107,13 @@ def _render_hint_markdown(
 
 def _render_pipeline_banner_markdown(
     *,
-    cmd: str,
+    pipeline_kind: PipelineKindLiteral,
     n_files: int,
 ) -> str:
     """Render the Markdown banner for a pipeline command.
 
     Args:
-        cmd: Command name.
+        pipeline_kind: Pipeline kind (`check`, `strip`, `probe`).
         n_files: Number of pipeline result entries before view filtering.
 
     Returns:
@@ -120,7 +121,7 @@ def _render_pipeline_banner_markdown(
     """
     return "\n".join(
         [
-            f"# TopMark {cmd} Results",
+            f"# TopMark {pipeline_kind} Results",
             "",
             f"Processing **{n_files}** file(s).",
         ]
@@ -157,13 +158,11 @@ def _render_apply_command_markdown(
 
 def _render_check_guidance_message_markdown(
     ctx: ProcessingContext,
-    apply_changes: bool,
 ) -> str | None:
     """Render per-file guidance for `topmark check` results.
 
     Args:
         ctx: Processing context for the file.
-        apply_changes: Whether the command runs in apply mode.
 
     Returns:
         Guidance message for this file, or `None` when no check action is relevant.
@@ -174,6 +173,8 @@ def _render_check_guidance_message_markdown(
     """
     if not effective_would_add_or_update(ctx):
         return None
+
+    apply_changes: bool | None = ctx.run_options.apply_changes
 
     path_label: str = render_path_display_markdown(ctx)
     intent: Intent = determine_intent(ctx)
@@ -208,13 +209,11 @@ def _render_check_guidance_message_markdown(
 
 def _render_strip_guidance_message_markdown(
     ctx: ProcessingContext,
-    apply_changes: bool,
 ) -> str | None:
     """Render per-file guidance for `topmark strip` results.
 
     Args:
         ctx: Processing context for the file.
-        apply_changes: Whether the command runs in apply mode.
 
     Returns:
         Guidance message for this file, or `None` when no strip action is relevant.
@@ -225,6 +224,8 @@ def _render_strip_guidance_message_markdown(
     """
     if not effective_would_strip(ctx):
         return None
+
+    apply_changes: bool | None = ctx.run_options.apply_changes
 
     path_label: str = render_path_display_markdown(ctx)
     intent: Intent = determine_intent(ctx)
@@ -303,8 +304,7 @@ def _render_file_summary_line_markdown(
 def _render_per_file_guidance_markdown(
     *,
     view_results: list[ProcessingContext],
-    make_message: Callable[[ProcessingContext, bool], str | None],
-    apply_changes: bool,
+    make_message: Callable[[ProcessingContext], str | None],
     show_diffs: bool,
 ) -> str:
     """Render per-file Markdown sections.
@@ -321,7 +321,6 @@ def _render_per_file_guidance_markdown(
     Args:
         view_results: Processing contexts to render.
         make_message: Per-file guidance message builder.
-        apply_changes: Whether the command runs in apply mode.
         show_diffs: Whether to include unified diffs.
 
     Returns:
@@ -341,7 +340,7 @@ def _render_per_file_guidance_markdown(
         )
 
         # 2. guidance message for actionable check/strip outcomes.
-        msg: str | None = make_message(ctx, apply_changes)
+        msg: str | None = make_message(ctx)
         if msg:
             blocks.append(f"  - {msg}")
 
@@ -520,10 +519,10 @@ def render_pipeline_output_markdown(
     Raises:
         RuntimeError: If an invalid pipeline kind was selected.
     """
-    make_message: Callable[[ProcessingContext, bool], str | None] | None = None
-    if report.pipeline_kind == CliCmd.CHECK:
+    make_message: Callable[[ProcessingContext], str | None] | None = None
+    if report.pipeline_kind == "check":
         make_message = _render_check_guidance_message_markdown
-    elif report.pipeline_kind == CliCmd.STRIP:
+    elif report.pipeline_kind == "strip":
         make_message = _render_strip_guidance_message_markdown
     else:
         # Defensive guard.
@@ -534,7 +533,7 @@ def render_pipeline_output_markdown(
     # Markdown always starts with a document banner.
     parts.append(
         _render_pipeline_banner_markdown(
-            cmd=report.cmd,
+            pipeline_kind=report.pipeline_kind,
             n_files=report.file_list_total,
         )
     )
@@ -560,7 +559,6 @@ def render_pipeline_output_markdown(
             _render_per_file_guidance_markdown(
                 view_results=report.view_results,
                 make_message=make_message,
-                apply_changes=report.apply_changes,
                 show_diffs=report.show_diffs,
             ),
         )

--- a/src/topmark/presentation/shared/outcomes.py
+++ b/src/topmark/presentation/shared/outcomes.py
@@ -25,10 +25,14 @@ from topmark.core.outcomes import Outcome
 from topmark.core.presentation import StyleRole
 from topmark.pipeline.outcomes import OutcomeReasonCount
 from topmark.pipeline.outcomes import collect_outcome_reason_counts
+from topmark.pipeline.outcomes import collect_outcome_reason_counts_for_apply
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from topmark.cli.presentation import TextStyler
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.outcomes import SupportsOutcomeClassification
 
 
 _OUTCOME_STYLE_ROLE: dict[Outcome, StyleRole] = {
@@ -73,10 +77,41 @@ def get_outcome_styler(outcome: Outcome) -> TextStyler:
     return style_for_role(role)
 
 
+def collect_outcome_counts_styled_for_apply(
+    results: Iterable[SupportsOutcomeClassification],
+    *,
+    apply: bool,
+) -> list[tuple[OutcomeReasonCount, TextStyler]]:
+    """Return styled summary rows for an explicit execution mode.
+
+    This result-compatible helper accepts either mutable processing contexts or
+    durable processing results. The execution mode is supplied explicitly so
+    callers do not need to retain runtime options only for outcome summary
+    classification.
+
+    Args:
+        results: Processing contexts or durable results to classify and count.
+        apply: Whether to classify the supplied results as apply-mode output.
+
+    Returns:
+        Stable summary rows paired with the CLI text styler for their semantic outcome role.
+    """
+    counts: list[OutcomeReasonCount] = collect_outcome_reason_counts_for_apply(
+        results,
+        apply=apply,
+    )
+    return [(row, get_outcome_styler(row.outcome)) for row in counts]
+
+
 def collect_outcome_counts_styled(
     results: list[ProcessingContext],
 ) -> list[tuple[OutcomeReasonCount, TextStyler]]:
     """Return styled summary rows grouped by `(outcome, reason)`.
+
+    This compatibility wrapper preserves existing context-based behavior by
+    deriving apply mode from each context's runtime options. New result-oriented
+    callers that no longer retain runtime options should use
+    `collect_outcome_counts_styled_for_apply()`.
 
     Args:
         results: Processing contexts to classify and count.

--- a/src/topmark/presentation/shared/pipeline.py
+++ b/src/topmark/presentation/shared/pipeline.py
@@ -33,8 +33,8 @@ from typing import TYPE_CHECKING
 from topmark.pipeline.status import FsStatus
 
 if TYPE_CHECKING:
-    from topmark.api.types import PipelineKindLiteral
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.reporting import ReportScope
 
 
@@ -49,14 +49,14 @@ class ProbeCommandHumanReport:
     Attributes:
         verbosity_level: Effective TEXT verbosity; Markdown renderers ignore it.
         styled: Whether TEXT renderers should apply styling; Markdown renderers ignore it.
-        cmd: Command name, usually `probe`.
+        pipeline_kind: Pipeline kind used to select command-specific guidance.
         file_list_total: Total number of candidate files before view filtering.
         view_results: Processing contexts selected for the current human-output view.
     """
 
     verbosity_level: int
     styled: bool
-    cmd: str
+    pipeline_kind: PipelineKindLiteral
     file_list_total: int
     view_results: list[ProcessingContext]
 
@@ -72,7 +72,6 @@ class PipelineCommandHumanReport:
     Attributes:
         verbosity_level: Effective TEXT verbosity; Markdown renderers ignore it.
         styled: Whether TEXT renderers should apply styling; Markdown renderers ignore it.
-        cmd: Command name, such as `check` or `strip`.
         pipeline_kind: Pipeline kind used to select command-specific guidance.
         file_list_total: Total number of user-requested results before view filtering,
             including selected pipeline files and synthetic resolver-level outcomes.
@@ -86,7 +85,6 @@ class PipelineCommandHumanReport:
 
     verbosity_level: int
     styled: bool
-    cmd: str
     pipeline_kind: PipelineKindLiteral
     file_list_total: int
     view_results: list[ProcessingContext]

--- a/src/topmark/presentation/text/pipeline.py
+++ b/src/topmark/presentation/text/pipeline.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from topmark.diagnostic.model import DiagnosticStats
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.hints import Hint
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.outcomes import OutcomeReasonCount
     from topmark.pipeline.views import DiffView
 
@@ -167,14 +168,14 @@ def _render_hint_text(
 
 def _render_pipeline_banner_text(
     *,
-    cmd: str,
+    pipeline_kind: PipelineKindLiteral,
     n_files: int,
     styled: bool,
 ) -> str:
     """Render the TEXT banner for a pipeline command.
 
     Args:
-        cmd: Command name.
+        pipeline_kind: The pipeline kind (`check`, `strip`, `probe`).
         n_files: Number of pipeline result entries before view filtering.
         styled: Whether ANSI-capable styling is enabled.
 
@@ -187,7 +188,7 @@ def _render_pipeline_banner_text(
 
     return "\n".join(
         [
-            heading_styler(f"📋 TopMark {cmd} Results"),
+            heading_styler(f"📋 TopMark {pipeline_kind} Results"),
             "",
             info_styler(f"\n🔍 Processing {n_files} file(s):"),
         ]
@@ -223,13 +224,11 @@ def _render_apply_command_text(
 
 def _render_check_guidance_message_text(
     ctx: ProcessingContext,
-    apply_changes: bool,
 ) -> str | None:
     """Render per-file guidance for `topmark check` results.
 
     Args:
         ctx: Processing context for the file.
-        apply_changes: Whether the command runs in apply mode.
 
     Returns:
         Guidance message for this file, or `None` when no check action is relevant.
@@ -240,6 +239,8 @@ def _render_check_guidance_message_text(
     """
     if not effective_would_add_or_update(ctx):
         return None
+
+    apply_changes: bool | None = ctx.run_options.apply_changes
 
     path_label: str = render_path_display_text(ctx)
     intent: Intent = determine_intent(ctx)
@@ -273,13 +274,11 @@ def _render_check_guidance_message_text(
 
 def _render_strip_guidance_message_text(
     ctx: ProcessingContext,
-    apply_changes: bool,
 ) -> str | None:
     """Render per-file guidance for `topmark strip` results.
 
     Args:
         ctx: Processing context for the file.
-        apply_changes: Whether the command runs in apply mode.
 
     Returns:
         Guidance message for this file, or `None` when no strip action is relevant.
@@ -290,6 +289,8 @@ def _render_strip_guidance_message_text(
     """
     if not effective_would_strip(ctx):
         return None
+
+    apply_changes: bool | None = ctx.run_options.apply_changes
 
     path_label: str = render_path_display_text(ctx)
     intent: Intent = determine_intent(ctx)
@@ -413,8 +414,7 @@ def _render_file_summary_line_text(
 def _render_per_file_guidance_text(
     *,
     view_results: list[ProcessingContext],
-    make_message: Callable[[ProcessingContext, bool], str | None],
-    apply_changes: bool,
+    make_message: Callable[[ProcessingContext], str | None],
     show_diffs: bool,
     verbosity_level: int,
     styled: bool,
@@ -431,7 +431,6 @@ def _render_per_file_guidance_text(
     Args:
         view_results: Processing contexts to render.
         make_message: Per-file guidance message builder.
-        apply_changes: Whether the command runs in apply mode.
         show_diffs: Whether to include unified diffs.
         verbosity_level: Effective TEXT verbosity level.
         styled: Whether ANSI-capable styling is enabled.
@@ -462,7 +461,7 @@ def _render_per_file_guidance_text(
         )
 
         # 2. guidance message for actionable check/strip outcomes.
-        msg: str | None = make_message(ctx, apply_changes)
+        msg: str | None = make_message(ctx)
         if msg:
             parts.append(
                 emphasis_styler(
@@ -714,10 +713,10 @@ def render_pipeline_output_text(
     Raises:
         RuntimeError: If an invalid pipeline kind was selected.
     """
-    make_message: Callable[[ProcessingContext, bool], str | None] | None = None
-    if report.pipeline_kind == CliCmd.CHECK:
+    make_message: Callable[[ProcessingContext], str | None] | None = None
+    if report.pipeline_kind == "check":
         make_message = _render_check_guidance_message_text
-    elif report.pipeline_kind == CliCmd.STRIP:
+    elif report.pipeline_kind == "strip":
         make_message = _render_strip_guidance_message_text
     else:
         # Defensive guard.
@@ -732,7 +731,7 @@ def render_pipeline_output_text(
     if report.verbosity_level > 0:
         parts.append(
             _render_pipeline_banner_text(
-                cmd=report.cmd,
+                pipeline_kind=report.pipeline_kind,
                 n_files=report.file_list_total,
                 styled=report.styled,
             )
@@ -760,7 +759,6 @@ def render_pipeline_output_text(
             _render_per_file_guidance_text(
                 view_results=report.view_results,
                 make_message=make_message,
-                apply_changes=report.apply_changes,
                 show_diffs=report.show_diffs,
                 verbosity_level=report.verbosity_level,
                 styled=report.styled,

--- a/src/topmark/runtime/model.py
+++ b/src/topmark/runtime/model.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
     from topmark.config.types import FileWriteStrategy
     from topmark.config.types import OutputTarget
+    from topmark.pipeline.kinds import PipelineKindLiteral
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -42,6 +43,7 @@ class RunOptions:
     config discovery or per-path effective config resolution.
 
     Attributes:
+        pipeline_kind: the pipeline kind (`check`, `strip`, `probe`).
         apply_changes: Whether the run should write changes (`True`) or preview
             only (`False`).
         output_target: Where output should be emitted for this run.
@@ -56,6 +58,7 @@ class RunOptions:
         started_at: Timestamp captured once for the whole run.
     """
 
+    pipeline_kind: PipelineKindLiteral | None = None
     apply_changes: bool | None = None
     output_target: OutputTarget | None = None
     file_write_strategy: FileWriteStrategy | None = None

--- a/tests/helpers/api.py
+++ b/tests/helpers/api.py
@@ -45,13 +45,13 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from topmark.api.types import PipelineKindLiteral
     from topmark.api.types import PublicPolicy
     from topmark.api.types import PublicReportScopeLiteral
     from topmark.config.model import FrozenConfig
     from topmark.config.model import MutableConfig
     from topmark.config.resolution.bridge import ResolvedConfigDraft
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.protocols import Step
     from topmark.toml.types import TomlValue
 

--- a/tests/helpers/pipeline.py
+++ b/tests/helpers/pipeline.py
@@ -163,16 +163,22 @@ def run_writer(ctx: ProcessingContext) -> ProcessingContext:
 # ---- Context/bootstrap helpers ----
 
 
-def make_pipeline_context(path: Path, cfg: FrozenConfig) -> ProcessingContext:
+def make_pipeline_context(
+    path: Path,
+    cfg: FrozenConfig,
+) -> ProcessingContext:
     """Return a ProcessingContext seeded with policy and runtime defaults.
 
     Test helpers that bootstrap contexts directly should provide both the
     effective layered config and invocation-wide runtime options. Most unit
     tests do not care about custom runtime behavior, so this helper supplies
-    a default dry-run `RunOptions` instance.
+    default dry-run check-mode `RunOptions`.
     """
     policy_registry: PolicyRegistry = make_policy_registry(cfg)
-    run_options: RunOptions = RunOptions(apply_changes=False)
+    run_options: RunOptions = RunOptions(
+        pipeline_kind="check",
+        apply_changes=False,
+    )
     return ProcessingContext.bootstrap(
         path=path,
         config=cfg,

--- a/tests/pipeline/test_machine_payloads.py
+++ b/tests/pipeline/test_machine_payloads.py
@@ -1,0 +1,87 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_machine_payloads.py
+#   file_relpath : tests/pipeline/test_machine_payloads.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Unit tests for pipeline machine payload builders."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.helpers.pipeline import make_pipeline_context
+from topmark.config.io.deserializers import mutable_config_from_defaults
+from topmark.pipeline.machine.payloads import build_processing_results_summary_rows_payload
+from topmark.pipeline.machine.payloads import (
+    build_processing_results_summary_rows_payload_for_apply,
+)
+from topmark.pipeline.machine.payloads import iter_processing_results_summary_entries
+from topmark.pipeline.machine.payloads import iter_processing_results_summary_entries_for_apply
+from topmark.pipeline.result import ProcessingResult
+from topmark.pipeline.status import ComparisonStatus
+from topmark.pipeline.status import ContentStatus
+from topmark.pipeline.status import FsStatus
+from topmark.pipeline.status import HeaderStatus
+from topmark.pipeline.status import ResolveStatus
+from topmark.pipeline.status import WriteStatus
+from topmark.runtime.model import RunOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.config.model import MutableConfig
+    from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.machine.schemas import OutcomeSummaryRow
+
+
+def _make_inserted_context(tmp_path: Path) -> ProcessingContext:
+    """Create a context classified as an inserted file in apply mode."""
+    mutable: MutableConfig = mutable_config_from_defaults()
+    ctx: ProcessingContext = make_pipeline_context(tmp_path / "case.py", mutable.freeze())
+    ctx.run_options = RunOptions(apply_changes=True)
+    ctx.status.resolve = ResolveStatus.RESOLVED
+    ctx.status.fs = FsStatus.OK
+    ctx.status.content = ContentStatus.OK
+    ctx.status.header = HeaderStatus.MISSING
+    ctx.status.comparison = ComparisonStatus.CHANGED
+    ctx.status.write = WriteStatus.WRITTEN
+    return ctx
+
+
+def test_processing_summary_rows_payload_for_apply_supports_processing_results(
+    tmp_path: Path,
+) -> None:
+    """Apply-explicit JSON summary payloads should support durable results."""
+    ctx: ProcessingContext = _make_inserted_context(tmp_path)
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    context_rows: list[OutcomeSummaryRow] = build_processing_results_summary_rows_payload([ctx])
+    result_rows: list[OutcomeSummaryRow] = build_processing_results_summary_rows_payload_for_apply(
+        [result],
+        apply=True,
+    )
+
+    assert result_rows == context_rows
+
+
+def test_processing_summary_entries_for_apply_supports_processing_results(
+    tmp_path: Path,
+) -> None:
+    """Apply-explicit NDJSON summary entries should support durable results."""
+    ctx: ProcessingContext = _make_inserted_context(tmp_path)
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    context_rows: list[OutcomeSummaryRow] = list(iter_processing_results_summary_entries([ctx]))
+    result_rows: list[OutcomeSummaryRow] = list(
+        iter_processing_results_summary_entries_for_apply(
+            [result],
+            apply=True,
+        ),
+    )
+
+    assert result_rows == context_rows

--- a/tests/pipeline/test_outcomes.py
+++ b/tests/pipeline/test_outcomes.py
@@ -21,6 +21,7 @@ from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.config.policy import HeaderMutationMode
 from topmark.core.outcomes import NO_REASON_PROVIDED
 from topmark.core.outcomes import Outcome
+from topmark.pipeline.context.model import ProcessingContext
 from topmark.pipeline.outcomes import Intent
 from topmark.pipeline.outcomes import OutcomeReasonCount
 from topmark.pipeline.outcomes import ResultBucket
@@ -46,12 +47,14 @@ if TYPE_CHECKING:
 
     from topmark.config.model import MutableConfig
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
 
 
 def _make_context(
     tmp_path: Path,
     *,
     apply_changes: bool = False,
+    pipeline_kind: PipelineKindLiteral = "check",
     mutation_mode: HeaderMutationMode | None = None,
 ) -> ProcessingContext:
     """Create a baseline context past resolve/fs/content feasibility checks."""
@@ -60,7 +63,10 @@ def _make_context(
         mutable.policy.header_mutation_mode = mutation_mode
 
     ctx: ProcessingContext = make_pipeline_context(tmp_path / "case.py", mutable.freeze())
-    ctx.run_options = RunOptions(apply_changes=apply_changes)
+    ctx.run_options = RunOptions(
+        pipeline_kind=pipeline_kind,
+        apply_changes=apply_changes,
+    )
     ctx.status.resolve = ResolveStatus.RESOLVED
     ctx.status.fs = FsStatus.OK
     ctx.status.content = ContentStatus.OK
@@ -88,7 +94,7 @@ def test_determine_intent_from_status_axes(
     expected: Intent,
 ) -> None:
     """Intent inference should depend on status axes, not pipeline names."""
-    ctx = _make_context(tmp_path)
+    ctx: ProcessingContext = _make_context(tmp_path)
     ctx.status.header = header
     ctx.status.strip = strip
 
@@ -220,7 +226,10 @@ def test_map_bucket_maps_strip_axis_in_dry_run(
     expected: Outcome,
 ) -> None:
     """Strip-axis states should not depend on comparison status."""
-    ctx: ProcessingContext = _make_context(tmp_path)
+    ctx: ProcessingContext = _make_context(
+        tmp_path,
+        pipeline_kind="strip",
+    )
     ctx.status.strip = strip_status
 
     bucket: ResultBucket = map_bucket(ctx, apply=False)
@@ -231,7 +240,11 @@ def test_map_bucket_maps_strip_axis_in_dry_run(
 
 def test_map_bucket_maps_strip_ready_to_stripped_in_apply_mode(tmp_path: Path) -> None:
     """Apply-mode strip-ready state should classify as stripped."""
-    ctx: ProcessingContext = _make_context(tmp_path, apply_changes=True)
+    ctx: ProcessingContext = _make_context(
+        tmp_path,
+        apply_changes=True,
+        pipeline_kind="strip",
+    )
     ctx.status.strip = StripStatus.READY
 
     bucket: ResultBucket = map_bucket(ctx, apply=True)
@@ -436,8 +449,17 @@ def test_map_bucket_supports_processing_result_write_failure_snapshot(
     assert result_bucket.reason == WriteStatus.FAILED.value
 
 
+@pytest.mark.parametrize(
+    ("apply", "expected_outcome"),
+    [
+        (False, Outcome.WOULD_INSERT),
+        (True, Outcome.INSERTED),
+    ],
+)
 def test_collect_outcome_reason_counts_for_apply_supports_processing_results(
     tmp_path: Path,
+    apply: bool,
+    expected_outcome: Outcome,
 ) -> None:
     """Apply-explicit summaries should work without runtime options."""
     ctx: ProcessingContext = _make_context(tmp_path, apply_changes=True)
@@ -448,12 +470,12 @@ def test_collect_outcome_reason_counts_for_apply_supports_processing_results(
 
     rows: list[OutcomeReasonCount] = collect_outcome_reason_counts_for_apply(
         [result],
-        apply=True,
+        apply=apply,
     )
 
     assert [(row.outcome, row.reason, row.count) for row in rows] == [
         (
-            Outcome.INSERTED,
+            expected_outcome,
             f"{HeaderStatus.MISSING.value}, {ComparisonStatus.CHANGED.value}",
             1,
         )
@@ -507,6 +529,63 @@ def test_classify_outcome_returns_bucket_outcome(tmp_path: Path) -> None:
     ctx.status.comparison = ComparisonStatus.CHANGED
 
     assert classify_outcome(ctx, apply=False) is Outcome.WOULD_INSERT
+
+
+def test_collect_outcome_reason_counts_matches_processing_result_summary(
+    tmp_path: Path,
+) -> None:
+    """Context and reduced-result summaries should classify equivalent rows."""
+    first_insert: ProcessingContext = _make_context(tmp_path)
+    first_insert.status.header = HeaderStatus.MISSING
+    first_insert.status.comparison = ComparisonStatus.CHANGED
+
+    second_insert: ProcessingContext = _make_context(tmp_path)
+    second_insert.status.header = HeaderStatus.MISSING
+    second_insert.status.comparison = ComparisonStatus.CHANGED
+
+    unchanged: ProcessingContext = _make_context(tmp_path)
+    unchanged.status.header = HeaderStatus.DETECTED
+    unchanged.status.comparison = ComparisonStatus.UNCHANGED
+
+    contexts: list[ProcessingContext] = [first_insert, second_insert, unchanged]
+
+    context_rows: list[OutcomeReasonCount] = collect_outcome_reason_counts(contexts)
+    result_rows: list[OutcomeReasonCount] = collect_outcome_reason_counts_for_apply(
+        [ProcessingResult.from_context(ctx) for ctx in contexts],
+        apply=False,
+    )
+
+    assert result_rows == context_rows
+
+
+@pytest.mark.parametrize(
+    ("generation", "plan", "apply", "expected_outcome"),
+    [
+        (GenerationStatus.NO_FIELDS, PlanStatus.PENDING, False, Outcome.UNCHANGED),
+        (GenerationStatus.PENDING, PlanStatus.PREVIEWED, False, Outcome.WOULD_CHANGE),
+        (GenerationStatus.PENDING, PlanStatus.SKIPPED, False, Outcome.SKIPPED),
+        (GenerationStatus.PENDING, PlanStatus.FAILED, False, Outcome.SKIPPED),
+    ],
+)
+def test_map_bucket_matches_processing_result_for_fallback_branches(
+    tmp_path: Path,
+    generation: GenerationStatus,
+    plan: PlanStatus,
+    apply: bool,
+    expected_outcome: Outcome,
+) -> None:
+    """Ensure map_bucket matches processing result for fall-back branches."""
+    ctx: ProcessingContext = _make_context(tmp_path)
+    ctx.status.header = HeaderStatus.PENDING
+    ctx.status.comparison = ComparisonStatus.PENDING
+    ctx.status.generation = generation
+    ctx.status.plan = plan
+
+    context_bucket: ResultBucket = map_bucket(ctx, apply=apply)
+    result_bucket: ResultBucket = map_bucket(ProcessingResult.from_context(ctx), apply=apply)
+
+    assert result_bucket == context_bucket
+    assert result_bucket.outcome is expected_outcome
 
 
 def test_collect_outcome_reason_counts_groups_and_sorts(tmp_path: Path) -> None:

--- a/tests/pipeline/test_result.py
+++ b/tests/pipeline/test_result.py
@@ -17,14 +17,13 @@ from typing import TYPE_CHECKING
 from tests.helpers.pipeline import make_context_from_text
 from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.core.typing_guards import is_mapping
-from topmark.pipeline.context.model import ProcessingContext
 from topmark.pipeline.hints import Axis
 from topmark.pipeline.hints import KnownCode
 from topmark.pipeline.result import ProcessingResult
-from topmark.pipeline.result import reduce_processing_context
 from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import ResolveStatus
 from topmark.pipeline.status import WriteStatus
+from topmark.runtime.model import RunOptions
 from topmark.utils.path import format_machine_path
 
 if TYPE_CHECKING:
@@ -32,16 +31,27 @@ if TYPE_CHECKING:
 
     from topmark.config.model import FrozenConfig
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
 
 
-def _make_result_context(tmp_path: Path) -> ProcessingContext:
+def _make_result_context(
+    tmp_path: Path,
+    *,
+    pipeline_kind: PipelineKindLiteral = "check",
+    apply_changes: bool = False,
+) -> ProcessingContext:
     """Create a small post-reader context suitable for result-reduction tests."""
     cfg: FrozenConfig = mutable_config_from_defaults().freeze()
-    return make_context_from_text(
+    ctx: ProcessingContext = make_context_from_text(
         "print('hello')\n",
         cfg=cfg,
         path=tmp_path / "sample.py",
     )
+    ctx.run_options = RunOptions(
+        pipeline_kind=pipeline_kind,
+        apply_changes=apply_changes,
+    )
+    return ctx
 
 
 def test_processing_result_reduces_context_identity(
@@ -77,7 +87,7 @@ def test_processing_result_snapshots_status(
     ctx.status.header = HeaderStatus.MISSING
     ctx.status.write = WriteStatus.WRITTEN
 
-    result: ProcessingResult = reduce_processing_context(ctx)
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
 
     ctx.status.header = HeaderStatus.PENDING
     ctx.status.write = WriteStatus.PENDING
@@ -128,4 +138,30 @@ def test_processing_result_to_dict_preserves_outcome_shape(
     assert set(outcome["strip"]) == {
         "would_strip",
         "effective_would_strip",
+    }
+
+
+def test_processing_result_to_dict_preserves_execution_mode(
+    tmp_path: Path,
+) -> None:
+    """ProcessingResult serialization should preserve durable execution mode."""
+    ctx: ProcessingContext = _make_result_context(
+        tmp_path,
+        apply_changes=True,
+    )
+
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+    payload: dict[str, object] = result.to_dict()
+    execution_mode: object = payload["execution_mode"]
+
+    assert result.execution_mode.pipeline_kind == "check"
+    assert result.execution_mode.apply_changes is True
+    assert result.execution_mode.to_dict() == {
+        "pipeline_kind": "check",
+        "apply_changes": True,
+    }
+    assert is_mapping(execution_mode)
+    assert execution_mode == {
+        "pipeline_kind": "check",
+        "apply_changes": True,
     }

--- a/tests/presentation/test_pipeline_rendering.py
+++ b/tests/presentation/test_pipeline_rendering.py
@@ -20,7 +20,6 @@ import pytest
 from tests.helpers.pipeline import make_pipeline_context
 from tests.helpers.registry import make_file_type
 from tests.presentation.conftest import find_table_row
-from topmark.cli.keys import CliCmd
 from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.diagnostic.model import Diagnostic
 from topmark.diagnostic.model import DiagnosticLevel
@@ -52,14 +51,15 @@ from topmark.runtime.model import RunOptions
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from topmark.api.types import PipelineKindLiteral
     from topmark.config.model import FrozenConfig
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
 
 
 def _make_context(
     path: Path,
     *,
+    pipeline_kind: PipelineKindLiteral = "check",
     apply_changes: bool = False,
     stdin_mode: bool = False,
     stdin_filename: str | None = None,
@@ -68,6 +68,7 @@ def _make_context(
     cfg: FrozenConfig = mutable_config_from_defaults().freeze()
     ctx: ProcessingContext = make_pipeline_context(path, cfg)
     ctx.run_options = RunOptions(
+        pipeline_kind=pipeline_kind,
         apply_changes=apply_changes,
         stdin_mode=stdin_mode,
         stdin_filename=stdin_filename,
@@ -88,8 +89,7 @@ def _make_context(
 
 def _make_report(
     *,
-    cmd: str = CliCmd.CHECK,
-    pipeline_kind: PipelineKindLiteral = CliCmd.CHECK,
+    pipeline_kind: PipelineKindLiteral = "check",
     view_results: list[ProcessingContext],
     file_list_total: int | None = None,
     verbosity_level: int = 0,
@@ -103,7 +103,6 @@ def _make_report(
     return PipelineCommandHumanReport(
         verbosity_level=verbosity_level,
         styled=False,
-        cmd=cmd,
         pipeline_kind=pipeline_kind,
         file_list_total=file_list_total if file_list_total is not None else len(view_results),
         view_results=view_results,
@@ -300,8 +299,7 @@ def test_render_pipeline_output_text_strip_guidance_uses_strip_command(
 
     output: str = render_pipeline_output_text(
         _make_report(
-            cmd=CliCmd.STRIP,
-            pipeline_kind=CliCmd.STRIP,
+            pipeline_kind="strip",
             view_results=[ctx],
         )
     )
@@ -436,7 +434,7 @@ def test_pipeline_renderers_reject_invalid_pipeline_kind(tmp_path: Path) -> None
     """Both renderers should reject invalid pipeline kinds defensively."""
     ctx: ProcessingContext = _make_context(tmp_path / "invalid.py")
     report: PipelineCommandHumanReport = _make_report(
-        pipeline_kind=cast("PipelineKindLiteral", "probe"),
+        pipeline_kind=cast("PipelineKindLiteral", "unknown"),
         view_results=[ctx],
     )
 

--- a/tests/presentation/test_shared_outcomes.py
+++ b/tests/presentation/test_shared_outcomes.py
@@ -1,0 +1,82 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_shared_outcomes.py
+#   file_relpath : tests/presentation/test_shared_outcomes.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Unit tests for shared presentation outcome helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.helpers.pipeline import make_pipeline_context
+from topmark.config.io.deserializers import mutable_config_from_defaults
+from topmark.pipeline.result import ProcessingResult
+from topmark.pipeline.status import ComparisonStatus
+from topmark.pipeline.status import ContentStatus
+from topmark.pipeline.status import FsStatus
+from topmark.pipeline.status import HeaderStatus
+from topmark.pipeline.status import ResolveStatus
+from topmark.pipeline.status import WriteStatus
+from topmark.presentation.shared.outcomes import collect_outcome_counts_styled
+from topmark.presentation.shared.outcomes import collect_outcome_counts_styled_for_apply
+from topmark.runtime.model import RunOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.cli.presentation import TextStyler
+    from topmark.config.model import MutableConfig
+    from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
+    from topmark.pipeline.outcomes import OutcomeReasonCount
+
+
+def _make_inserted_context(
+    tmp_path: Path,
+    *,
+    pipeline_kind: PipelineKindLiteral = "check",
+) -> ProcessingContext:
+    """Create a context classified as an inserted file in apply mode."""
+    mutable: MutableConfig = mutable_config_from_defaults()
+    ctx: ProcessingContext = make_pipeline_context(tmp_path / "case.py", mutable.freeze())
+    ctx.run_options = RunOptions(
+        pipeline_kind=pipeline_kind,
+        apply_changes=True,
+    )
+
+    ctx.status.resolve = ResolveStatus.RESOLVED
+    ctx.status.fs = FsStatus.OK
+    ctx.status.content = ContentStatus.OK
+    ctx.status.header = HeaderStatus.MISSING
+    ctx.status.comparison = ComparisonStatus.CHANGED
+    ctx.status.write = WriteStatus.WRITTEN
+    return ctx
+
+
+def test_collect_outcome_counts_styled_for_apply_supports_processing_results(
+    tmp_path: Path,
+) -> None:
+    """Apply-explicit styled summaries should support durable results."""
+    ctx: ProcessingContext = _make_inserted_context(
+        tmp_path,
+    )
+    result: ProcessingResult = ProcessingResult.from_context(ctx)
+
+    context_rows: list[tuple[OutcomeReasonCount, TextStyler]] = [
+        (row, styler) for row, styler in collect_outcome_counts_styled([ctx])
+    ]
+    result_rows: list[tuple[OutcomeReasonCount, TextStyler]] = [
+        (row, styler)
+        for row, styler in collect_outcome_counts_styled_for_apply([result], apply=True)
+    ]
+
+    assert [row for row, _styler in result_rows] == [row for row, _styler in context_rows]
+    assert [styler("x") for _row, styler in result_rows] == [
+        styler("x") for _row, styler in context_rows
+    ]


### PR DESCRIPTION
## Summary

This PR continues the staged work for #148 by extending the durable
`ProcessingResult` vocabulary without migrating API/CLI consumers away from
mutable `ProcessingContext`.

Changes include:

- introducing `topmark.pipeline.kinds.PipelineKindLiteral` as the
  dependency-safe source of pipeline-kind typing;
- propagating pipeline kind through CLI/API `RunOptions`;
- adding `ExecutionModeSnapshot` to `ProcessingResult`;
- serializing reduced execution-mode metadata from
  `ProcessingResult.to_dict()`;
- adding result-compatible outcome-summary support while preserving existing
  `ProcessingContext` consumers and output shapes;
- adding context/result parity tests for outcome classification and summary
  generation;
- documenting the architecture boundary between mutable
  `ProcessingContext` execution state and durable `ProcessingResult`
  snapshots.

## Scope

This PR intentionally does **not** migrate CLI/API return contracts,
presentation rendering, or runner execution to `ProcessingResult`.

Those migrations remain follow-up work after the reduction boundary is fully
established.

## Compatibility

No breaking changes are intended.

The following behavior remains unchanged:

- CLI output
- API behavior
- runner contracts
- machine-readable output formats
- outcome classification results

The new execution-mode snapshot is additive and exists solely to preserve
durable invocation metadata across the reduction boundary.

## Related

- Parent issue: #148
- Builds on:
  - PR #150 (`StatusSnapshot`, `ProcessingResult`)
  - PR #151 (`OutcomeSnapshot`, `PreInsertAdvisorySnapshot`)