### PR TITLE
Add batch processing-result reduction boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,9 @@ ______________________________________________________________________
   implementation.
 - Clarified the architecture boundary between mutable `ProcessingContext` execution state and
   durable `ProcessingResult` snapshots for outcome classification.
+- Added an internal batch reduction boundary from mutable processing contexts to durable processing
+  results, preparing reporting logic for future streaming consolidation without changing current
+  runner behavior.
 
 ### Internal - Unreleased
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -43,6 +43,28 @@ The following architectural contracts are part of the stable 1.x design:
 
 ______________________________________________________________________
 
+## Mutable-context to durable-result handover
+
+TopMark currently uses a batch handover boundary after the existing runner has produced its per-file
+\[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances.
+\[`reduce_processing_contexts()`\][topmark.pipeline.reduction.reduce_processing_contexts] preserves
+the source contexts and creates matching durable
+\[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] snapshots in the same order.
+
+This boundary is intentionally conservative:
+
+- it does **not** introduce per-file streaming consolidation;
+- it does **not** update summaries incrementally while files are processed;
+- it does **not** release \[`ProcessingContext.views`\][topmark.pipeline.views.Views] early;
+- it does make summary and exit-code logic testable against durable results without changing current
+  CLI, API, human-output, probe-output, or machine-detail contracts.
+
+Future streaming-oriented work can use this seam to evaluate whether reduction can move from an
+end-of-run batch step into the per-file processing loop, followed by incremental reporting updates
+and earlier release of memory-heavy context state.
+
+______________________________________________________________________
+
 ## High-level configuration architecture
 
 TopMark separates configuration concerns into three layers:

--- a/src/topmark/pipeline/engine.py
+++ b/src/topmark/pipeline/engine.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from typing import Protocol
 
 from topmark.config.policy import PolicyRegistry
 from topmark.config.policy import make_policy_registry
@@ -74,6 +75,34 @@ if TYPE_CHECKING:
     from topmark.runtime.model import RunOptions
 
 logger: TopmarkLogger = get_logger(__name__)
+
+
+class SupportsPipelineExitStatus(Protocol):
+    """Minimum result surface required for pipeline exit-code selection."""
+
+    @property
+    def fs(self) -> FsStatus:
+        """Filesystem status used by exit-code selection."""
+        ...
+
+    @property
+    def content(self) -> ContentStatus:
+        """Content status used by exit-code selection."""
+        ...
+
+    @property
+    def write(self) -> WriteStatus:
+        """Write status used by exit-code selection."""
+        ...
+
+
+class SupportsPipelineExitResult(Protocol):
+    """Minimum context/result surface required for pipeline exit-code selection."""
+
+    @property
+    def status(self) -> SupportsPipelineExitStatus:
+        """Per-axis status values used by exit-code selection."""
+        ...
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -174,7 +203,7 @@ class PipelineExecution:
 
 
 def exit_code_from_pipeline_results(
-    results: Sequence[ProcessingContext],
+    results: Sequence[SupportsPipelineExitResult],
 ) -> ExitCode | None:
     """Return the highest-priority non-success exit code implied by pipeline results.
 
@@ -196,7 +225,8 @@ def exit_code_from_pipeline_results(
     command-specific non-zero meaning.
 
     Args:
-        results: Pipeline contexts returned by `run_steps_for_files`.
+        results: Pipeline contexts or durable processing results returned by
+            `run_steps_for_files` or the batch reduction boundary.
 
     Returns:
         The highest-priority `ExitCode` implied by the results, or `None` when

--- a/src/topmark/pipeline/reduction.py
+++ b/src/topmark/pipeline/reduction.py
@@ -1,0 +1,76 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : reduction.py
+#   file_relpath : src/topmark/pipeline/reduction.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Batch handover helpers for durable pipeline result reduction.
+
+This module defines the explicit boundary between mutable pipeline execution
+state and durable result state. The current helper is intentionally a *batch*
+reducer: it consumes already-produced
+[`ProcessingContext`][topmark.pipeline.context.model.ProcessingContext]
+instances and returns matching
+[`ProcessingResult`][topmark.pipeline.result.ProcessingResult] snapshots.
+
+It does not introduce per-file streaming consolidation, incremental summary
+updates, or early release of context-owned views. Its purpose is to make the
+handover seam typed and testable so later work can decide whether this boundary
+can move earlier in the processing loop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from topmark.pipeline.result import ProcessingResult
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from topmark.pipeline.context.model import ProcessingContext
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ProcessingReduction:
+    """Batch reduction result for processed pipeline contexts.
+
+    Attributes:
+        contexts: Immutable tuple of the source mutable processing contexts.
+            These are retained intentionally for current CLI, API, human-output,
+            probe-output, and machine-detail consumers.
+        results: Immutable tuple of durable processing-result snapshots reduced
+            from `contexts` in the same order.
+    """
+
+    contexts: tuple[ProcessingContext, ...]
+    results: tuple[ProcessingResult, ...]
+
+
+def reduce_processing_contexts(
+    contexts: Iterable[ProcessingContext],
+) -> ProcessingReduction:
+    """Reduce completed processing contexts to durable results as a batch.
+
+    This helper marks the current post-run handover boundary. It preserves the
+    source contexts while creating detached durable result snapshots, which lets
+    existing context-based consumers keep working while summary and exit-code
+    logic gains a result-compatible seam.
+
+    Args:
+        contexts: Completed or partially completed processing contexts to reduce.
+
+    Returns:
+        Batch reduction containing the source contexts and corresponding
+        durable results in matching order.
+    """
+    source_contexts: tuple[ProcessingContext, ...] = tuple(contexts)
+    return ProcessingReduction(
+        contexts=source_contexts,
+        results=tuple(ProcessingResult.from_context(ctx) for ctx in source_contexts),
+    )

--- a/src/topmark/pipeline/result.py
+++ b/src/topmark/pipeline/result.py
@@ -21,7 +21,8 @@ configuration objects, policy registries, or flow-control objects.
 The initial reducer is intentionally conservative. Existing runners, CLI code,
 and public API adapters may continue to return and consume
 `ProcessingContext`; this module provides the vocabulary and conversion seam
-for staged migration toward durable post-run results.
+for staged migration toward durable post-run results. The batch handover helper
+lives in [`topmark.pipeline.reduction`][topmark.pipeline.reduction].
 """
 
 from __future__ import annotations

--- a/tests/pipeline/test_reduction.py
+++ b/tests/pipeline/test_reduction.py
@@ -1,0 +1,143 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_reduction.py
+#   file_relpath : tests/pipeline/test_reduction.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for the batch processing-context reduction boundary."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.helpers.pipeline import make_context_from_text
+from topmark.config.io.deserializers import mutable_config_from_defaults
+from topmark.core.exit_codes import ExitCode
+from topmark.pipeline.engine import exit_code_from_pipeline_results
+from topmark.pipeline.outcomes import OutcomeReasonCount
+from topmark.pipeline.outcomes import collect_outcome_reason_counts
+from topmark.pipeline.outcomes import collect_outcome_reason_counts_for_apply
+from topmark.pipeline.reduction import ProcessingReduction
+from topmark.pipeline.reduction import reduce_processing_contexts
+from topmark.pipeline.status import ComparisonStatus
+from topmark.pipeline.status import ContentStatus
+from topmark.pipeline.status import FsStatus
+from topmark.pipeline.status import HeaderStatus
+from topmark.pipeline.status import WriteStatus
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.config.model import FrozenConfig
+    from topmark.pipeline.context.model import ProcessingContext
+
+
+def _make_reduction_context(
+    tmp_path: Path,
+    filename: str,
+) -> ProcessingContext:
+    """Create a small processing context for reduction-boundary tests."""
+    cfg: FrozenConfig = mutable_config_from_defaults().freeze()
+    return make_context_from_text(
+        "print('hello')\n",
+        cfg=cfg,
+        path=tmp_path / filename,
+    )
+
+
+def test_reduce_processing_contexts_returns_batch_handover(
+    tmp_path: Path,
+) -> None:
+    """Batch reduction should preserve contexts and produce ordered results."""
+    first: ProcessingContext = _make_reduction_context(tmp_path, "first.py")
+    second: ProcessingContext = _make_reduction_context(tmp_path, "second.py")
+    first.status.header = HeaderStatus.MISSING
+    second.status.header = HeaderStatus.DETECTED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([first, second])
+
+    assert reduction.contexts == (first, second)
+    assert [result.path.name for result in reduction.results] == ["first.py", "second.py"]
+    assert reduction.results[0].status.header is HeaderStatus.MISSING
+    assert reduction.results[1].status.header is HeaderStatus.DETECTED
+
+
+def test_reduce_processing_contexts_snapshots_status_without_releasing_contexts(
+    tmp_path: Path,
+) -> None:
+    """Batch reduction should detach result state while retaining source contexts."""
+    ctx: ProcessingContext = _make_reduction_context(tmp_path, "sample.py")
+    ctx.status.header = HeaderStatus.MISSING
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+    ctx.status.header = HeaderStatus.DETECTED
+
+    assert reduction.contexts[0] is ctx
+    assert reduction.contexts[0].status.header is HeaderStatus.DETECTED
+    assert reduction.results[0].status.header is HeaderStatus.MISSING
+
+
+def test_reduced_results_match_context_summary_counts(
+    tmp_path: Path,
+) -> None:
+    """Reduced results should preserve context-based outcome summary rows."""
+    first_insert: ProcessingContext = _make_reduction_context(tmp_path, "first.py")
+    first_insert.status.header = HeaderStatus.MISSING
+    first_insert.status.comparison = ComparisonStatus.CHANGED
+
+    second_insert: ProcessingContext = _make_reduction_context(tmp_path, "second.py")
+    second_insert.status.header = HeaderStatus.MISSING
+    second_insert.status.comparison = ComparisonStatus.CHANGED
+
+    unchanged: ProcessingContext = _make_reduction_context(tmp_path, "unchanged.py")
+    unchanged.status.header = HeaderStatus.DETECTED
+    unchanged.status.comparison = ComparisonStatus.UNCHANGED
+
+    contexts: list[ProcessingContext] = [first_insert, second_insert, unchanged]
+    reduction: ProcessingReduction = reduce_processing_contexts(contexts)
+
+    context_rows: list[OutcomeReasonCount] = collect_outcome_reason_counts(contexts)
+    result_rows: list[OutcomeReasonCount] = collect_outcome_reason_counts_for_apply(
+        reduction.results,
+        apply=False,
+    )
+
+    assert result_rows == context_rows
+
+
+def test_exit_code_selection_accepts_reduced_results(
+    tmp_path: Path,
+) -> None:
+    """Exit-code selection should work across contexts and reduced results."""
+    not_found: ProcessingContext = _make_reduction_context(tmp_path, "missing.py")
+    not_found.status.fs = FsStatus.NOT_FOUND
+
+    write_failed: ProcessingContext = _make_reduction_context(tmp_path, "failed.py")
+    write_failed.status.write = WriteStatus.FAILED
+
+    contexts: list[ProcessingContext] = [write_failed, not_found]
+    reduction: ProcessingReduction = reduce_processing_contexts(contexts)
+
+    assert exit_code_from_pipeline_results(contexts) is ExitCode.FILE_NOT_FOUND
+    assert exit_code_from_pipeline_results(reduction.results) is ExitCode.FILE_NOT_FOUND
+
+
+def test_exit_code_selection_preserves_result_priority(
+    tmp_path: Path,
+) -> None:
+    """Result-based exit-code selection should preserve existing priority order."""
+    unreadable: ProcessingContext = _make_reduction_context(tmp_path, "unreadable.py")
+    unreadable.status.content = ContentStatus.UNREADABLE
+
+    no_write_permission: ProcessingContext = _make_reduction_context(tmp_path, "blocked.py")
+    no_write_permission.status.fs = FsStatus.NO_WRITE_PERMISSION
+
+    reduction: ProcessingReduction = reduce_processing_contexts(
+        [unreadable, no_write_permission],
+    )
+
+    assert exit_code_from_pipeline_results(reduction.results) is ExitCode.PERMISSION_DENIED


### PR DESCRIPTION
## Summary

Adds the fourth incremental PR for #148 by introducing a conservative batch
handover boundary from mutable `ProcessingContext` objects to durable
`ProcessingResult` snapshots.

This PR adds:

- `topmark.pipeline.reduction.ProcessingReduction`
- `topmark.pipeline.reduction.reduce_processing_contexts(...)`
- result-compatible exit-code selection via a small protocol surface
- parity tests for:
  - ordered context/result reduction
  - detached status snapshots
  - outcome-summary rows
  - exit-code priority
- architecture documentation describing the batch handover boundary
- an Unreleased changelog entry

## Scope clarification

This PR intentionally does **not** implement the full split between mutable
`ProcessingContext` execution state and stable `ProcessingResult` reporting
state.

The runner still retains `ProcessingContext` instances for the full run, and
existing CLI, API, human-output, probe-output, and machine-detail consumers can
continue using contexts unchanged.

This PR is therefore a prerequisite seam for future work, not the final
streaming architecture. It does not introduce:

- per-file streaming consolidation
- incremental summary updates
- early release of `ProcessingContext.views`
- machine-output schema changes
- runner contract changes

## Follow-up direction

A follow-up PR can build on this seam to evaluate which reporting consumers can
be moved from context-primary to result-primary inputs, and later whether the
boundary can move from end-of-run batch reduction to per-file reduction and
context/view release.

## Breaking changes

None.