### PR TITLE
Package check and strip results from durable snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ ______________________________________________________________________
 
 ### Changed - Unreleased
 
+- Migrated public API `check()` and `strip()` result packaging to consume durable `ProcessingResult`
+  snapshots after context reduction, using reduced detail snapshots for public diff exposure while
+  preserving existing API DTO behavior.
 - Made human report-scope filtering result-compatible by introducing protocol-based filtering
   support for durable `ProcessingResult` snapshots while preserving existing context-based detail
   rendering contracts.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -69,9 +69,14 @@ field is `diff_text`, copied from the diff view by
 \[`ProcessingResult.from_context()`\][topmark.pipeline.result.ProcessingResult.from_context] without
 retaining the view object, original file image, or updated file image.
 
-Human and machine detail rendering still consume contexts today. Durable result serialization now
-includes the reduced detail snapshot, but the machine-output pipeline has not yet migrated to
-`ProcessingResult` and therefore continues to project data from live
+The public Python API `check()` and `strip()` result packaging now consumes durable
+`ProcessingResult` snapshots after the reduction boundary. This keeps API DTO assembly, report
+filtering, write counting, diagnostics aggregation, outcome bucketing, and public diff exposure on
+reduced result state rather than on live context views.
+
+Human rendering, probe rendering, and machine detail rendering still consume contexts today. Durable
+result serialization includes the reduced detail snapshot, but the machine-output pipeline has not
+yet migrated to `ProcessingResult` and therefore continues to project data from live
 \[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances. That is
 transitional rather than a target architecture: later result-boundary work can migrate detail
 renderers to the snapshot and then release volatile views immediately after result reduction.
@@ -229,14 +234,18 @@ By contrast, invalid command/option combinations and inappropriate STDIN modes a
 by the CLI layer as usage errors. They are not represented as synthetic contexts because no valid
 file-selection request exists yet.
 
-The public Python API mirrors this boundary for probe diagnostics.
-\[`topmark.api.probe()`\][topmark.api.commands.pipeline.probe] returns stable public DTOs
-(\[`ProbeRunResult`\][topmark.api.types.ProbeRunResult],
+The public Python API mirrors this boundary for probe diagnostics and content-processing results.
+\[`topmark.api.check()`\][topmark.api.commands.pipeline.check] and
+\[`topmark.api.strip()`\][topmark.api.commands.pipeline.strip] reduce completed contexts to durable
+\[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] snapshots before assembling stable
+\[`RunResult`\][topmark.api.types.RunResult] DTOs. Probe output still depends on resolver-specific
+probe state stored on contexts. \[`topmark.api.probe()`\][topmark.api.commands.pipeline.probe]
+returns stable public DTOs (\[`ProbeRunResult`\][topmark.api.types.ProbeRunResult],
 \[`ProbeFileResult`\][topmark.api.types.ProbeFileResult], and
 \[`ProbeCandidateInfo`\][topmark.api.types.ProbeCandidateInfo]) rather than raw pipeline contexts or
-resolver objects. Internally, the API runtime still uses synthetic
+resolver objects. Internally, probe API runtime still uses synthetic
 \[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances so CLI output,
-machine-readable output, API summaries, and exit-code selection can share the same resolver-level
+machine-readable output, probe summaries, and exit-code selection can share the same resolver-level
 result model.
 
 - Unmatched glob patterns are soft discovery diagnostics for processing commands

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -485,8 +485,11 @@ GitHub issue 147 extended that audit to the end-to-end CLI, API, reporting, and 
 architecture. The current ownership map is:
 
 - command orchestration keeps the ordered `ProcessingContext` result list so exit-code precedence,
-  missing-input synthesis, report-scope filtering, summaries, and machine-readable output all use
+  missing-input synthesis, human rendering, probe rendering, and machine-readable output still share
   one consistent result set;
+- public API `check()` and `strip()` result packaging now consumes durable `ProcessingResult`
+  snapshots after reduction for report filtering, summaries, diagnostics, write counts, and public
+  diff exposure;
 - human TEXT and Markdown renderers build a filtered `view_results` list for per-file presentation
   and then render one complete output string from small presentation fragments;
 - JSON machine output builds a complete envelope and serializes it as one pretty-printed JSON

--- a/src/topmark/api/commands/pipeline.py
+++ b/src/topmark/api/commands/pipeline.py
@@ -34,8 +34,7 @@ from topmark.api.runtime import select_pipeline
 from topmark.api.view import finalize_probe_result
 from topmark.api.view import finalize_run_result
 from topmark.core.errors import InvalidReportScopeError
-from topmark.pipeline.context.policy import effective_would_add_or_update
-from topmark.pipeline.context.policy import effective_would_strip
+from topmark.pipeline.reduction import reduce_processing_contexts
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.status import PlanStatus
 from topmark.runtime.model import RunOptions
@@ -166,11 +165,10 @@ def check(
     report_scope: ReportScope = _resolve_public_report_scope(report)
 
     return finalize_run_result(
-        results=api_run.results,
+        results=reduce_processing_contexts(api_run.results).results,
         file_list=api_run.file_list,
         apply=apply,
         report_scope=report_scope,
-        would_change=effective_would_add_or_update,
         update_statuses=update_statuses,
         encountered_exit_code=api_run.exit_code,
     )
@@ -257,11 +255,10 @@ def strip(
     report_scope: ReportScope = _resolve_public_report_scope(report)
 
     return finalize_run_result(
-        results=api_run.results,
+        results=reduce_processing_contexts(api_run.results).results,
         file_list=api_run.file_list,
         apply=apply,
         report_scope=report_scope,
-        would_change=effective_would_strip,
         update_statuses=update_statuses,
         encountered_exit_code=api_run.exit_code,
     )

--- a/src/topmark/api/view.py
+++ b/src/topmark/api/view.py
@@ -10,17 +10,26 @@
 
 """View and packaging helpers for the public API.
 
-These helpers convert internal `ProcessingContext` objects into stable,
+These helpers convert internal processing results into stable,
 JSON-friendly public shapes, apply view-level filtering where appropriate, and
 assemble public run-result DTOs.
 
-Why this exists:
-- `check()` and `strip()` share post-run behavior: filtering, summaries, diagnostics, and counts.
-- `probe()` has a different result contract but shares diagnostics and DTO packaging conventions.
-- Keeping this logic in one place avoids drift between API functions and keeps the façade small.
+Current reduction boundary:
+- `check()` and `strip()` consume durable `ProcessingResult` snapshots.
+- `probe()` still consumes `ProcessingContext` instances because probe details
+  depend on `resolution_probe` state that has not yet been reduced into a
+  durable snapshot.
 
-This module performs no I/O and produces no formatted/ANSI output; presentation belongs to
-CLI/UI layers.
+Why this exists:
+- `check()` and `strip()` share post-run behavior: filtering, summaries,
+  diagnostics, and counts.
+- `probe()` has a different result contract but shares diagnostics and DTO
+  packaging conventions.
+- Keeping this logic in one place avoids drift between API functions and keeps
+  the façade small.
+
+This module performs no I/O and produces no formatted/ANSI output;
+presentation belongs to CLI/UI layers.
 """
 
 from __future__ import annotations
@@ -43,6 +52,7 @@ from topmark.pipeline.outcomes import map_bucket
 from topmark.pipeline.reporting import ReportFilterResult
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.reporting import filter_results_for_report
+from topmark.pipeline.reporting import would_change_result
 from topmark.pipeline.status import PlanStatus
 from topmark.pipeline.status import WriteStatus
 
@@ -53,37 +63,37 @@ if TYPE_CHECKING:
 
     from topmark.core.exit_codes import ExitCode
     from topmark.core.logging import TopmarkLogger
+    from topmark.diagnostic.model import MutableDiagnosticLog
     from topmark.pipeline.context.model import ProcessingContext
-    from topmark.pipeline.views import DiffView
+    from topmark.pipeline.result import ProcessingResult
     from topmark.resolution.probe import ResolutionProbeMatchSignals
     from topmark.resolution.probe import ResolutionProbeResult
 
 logger: TopmarkLogger = get_logger(__name__)
 
 
-def to_file_result(ctx: ProcessingContext, *, apply: bool) -> FileResult:
-    """Convert a content-processing context into a public `FileResult`.
+def to_file_result(result: ProcessingResult, *, apply: bool) -> FileResult:
+    """Convert a durable processing result into a public `FileResult`.
 
     Args:
-        ctx: The source processing context.
+        result: The source durable processing result.
         apply: Whether the run is in apply mode (affects outcome mapping).
 
     Returns:
         Public, JSON-friendly per-file result.
     """
-    # Prefer a unified diff when available; otherwise None (human views may omit diffs).
-    diff_view: DiffView | None = ctx.views.diff
-    diff: str | None = diff_view.text if diff_view else None
+    # Prefer a reduced unified diff when available; otherwise None.
+    diff: str | None = result.detail.diff_text
 
     # Bucket: stable key plus display-oriented label. The key is stable; the
     # label may change between versions.
-    bucket: ResultBucket = map_bucket(ctx, apply=apply)
+    bucket: ResultBucket = map_bucket(result, apply=apply)
     key: str = bucket.outcome.value
     label: str = bucket.reason or NO_REASON_PROVIDED
 
     return FileResult(
-        path=Path(str(ctx.path)),
-        outcome=classify_outcome(ctx, apply=apply),
+        path=Path(str(result.path)),
+        outcome=classify_outcome(result, apply=apply),
         diff=diff,
         bucket_key=key,
         bucket_label=label,
@@ -209,7 +219,7 @@ def summarize_probe_file_results(files: Sequence[ProbeFileResult]) -> Mapping[st
 
 
 def count_writes(
-    results: Sequence[ProcessingContext],
+    results: Sequence[ProcessingResult],
     *,
     apply: bool,
     eligible: set[PlanStatus],
@@ -217,7 +227,7 @@ def count_writes(
     """Return `(written, failed)` counts for the given results.
 
     Args:
-        results: Pipeline results.
+        results: Durable pipeline results.
         apply: Whether the run was in apply mode (counts are zero when False).
         eligible: Which `WriteStatus` values count as "written".
 
@@ -234,7 +244,7 @@ def count_writes(
 
 
 def collect_diagnostics(
-    results: list[ProcessingContext],
+    results: Sequence[ProcessingResult],
 ) -> dict[str, list[DiagnosticEntry]]:
     """Collect per-file diagnostics as `{path: [diagnostic, ...]}`.
 
@@ -242,7 +252,7 @@ def collect_diagnostics(
     expose internal classes or enums.
 
     Args:
-        results: Pipeline results (typically the filtered view).
+        results: Durable pipeline results (typically the filtered view).
 
     Returns:
         Mapping from file path to diagnostic entries.
@@ -260,11 +270,11 @@ def collect_diagnostics(
     return diags
 
 
-def collect_diagnostic_totals(results: list[ProcessingContext]) -> DiagnosticTotals:
+def collect_diagnostic_totals(results: Sequence[ProcessingResult]) -> DiagnosticTotals:
     """Return aggregate counts of diagnostics across the given results.
 
     Args:
-        results: Pipeline results (typically the filtered view).
+        results: Durable pipeline results (typically the filtered view).
 
     Returns:
         Aggregate counts (info/warning/error/total).
@@ -292,13 +302,78 @@ def collect_diagnostic_totals(results: list[ProcessingContext]) -> DiagnosticTot
     )
 
 
+# ---- Context-based diagnostic helpers for probe pipeline ----
+
+
+def collect_context_diagnostics(
+    results: Sequence[ProcessingContext],
+) -> dict[str, list[DiagnosticEntry]]:
+    """Collect per-file diagnostics from context-based probe results.
+
+    Probe result assembly intentionally still consumes `ProcessingContext`
+    instances because probe details depend on `resolution_probe` state that is
+    not yet part of the durable result boundary.
+
+    Args:
+        results: Probe pipeline contexts.
+
+    Returns:
+        Mapping from file path to diagnostic entries.
+    """
+    diags: dict[str, list[DiagnosticEntry]] = {}
+    for ctx in results:
+        diagnostics: MutableDiagnosticLog = ctx.diagnostics
+        if diagnostics:
+            diags[str(ctx.path)] = [
+                DiagnosticEntry(
+                    level=d.level.value,
+                    message=d.message,
+                )
+                for d in diagnostics
+            ]
+    return diags
+
+
+def collect_context_diagnostic_totals(results: Sequence[ProcessingContext]) -> DiagnosticTotals:
+    """Return aggregate diagnostic counts from context-based probe results.
+
+    Args:
+        results: Probe pipeline contexts.
+
+    Returns:
+        Aggregate counts (info/warning/error/total).
+    """
+    total_info: int = 0
+    total_warn: int = 0
+    total_error: int = 0
+    for ctx in results:
+        diagnostics: MutableDiagnosticLog = ctx.diagnostics
+        if not diagnostics:
+            continue
+        for d in diagnostics:
+            match d.level.value:
+                case "info":
+                    total_info += 1
+                case "warning":
+                    total_warn += 1
+                case "error":
+                    total_error += 1
+    total: int = total_info + total_warn + total_error
+    return DiagnosticTotals(
+        info=total_info,
+        warning=total_warn,
+        error=total_error,
+        total=total,
+    )
+
+
 def finalize_run_result(
     *,
-    results: list[ProcessingContext],
+    results: Sequence[ProcessingResult],
     file_list: list[Path],
     apply: bool,
     report_scope: ReportScope,
-    would_change: Callable[[ProcessingContext], bool],
+    would_change: Callable[[ProcessingResult], bool] = would_change_result,
     update_statuses: set[PlanStatus],
     encountered_exit_code: ExitCode | None,
 ) -> RunResult:
@@ -309,7 +384,7 @@ def finalize_run_result(
     and write/failed counts).
 
     Args:
-        results: Raw pipeline results (unfiltered).
+        results: Raw durable pipeline results (unfiltered).
         file_list: Resolved input files for the run.
         apply: Whether the run was in apply mode (affects counting).
         report_scope: Active report scope for the current view.
@@ -328,12 +403,12 @@ def finalize_run_result(
             had_errors=False,
         )
 
-    filtered: ReportFilterResult[ProcessingContext] = filter_results_for_report(
+    filtered: ReportFilterResult[ProcessingResult] = filter_results_for_report(
         results,
         report_scope=report_scope,
         would_change=would_change,
     )
-    view_results: list[ProcessingContext] = filtered.view_results
+    view_results: list[ProcessingResult] = filtered.view_results
     files: tuple[FileResult, ...] = tuple(
         to_file_result(
             r,
@@ -410,8 +485,8 @@ def finalize_probe_result(
     files: tuple[ProbeFileResult, ...] = tuple(to_probe_file_result(r) for r in results)
     summary: Mapping[str, int] = summarize_probe_file_results(files)
 
-    diagnostics: dict[str, list[DiagnosticEntry]] = collect_diagnostics(results)
-    diagnostic_totals: DiagnosticTotals = collect_diagnostic_totals(results)
+    diagnostics: dict[str, list[DiagnosticEntry]] = collect_context_diagnostics(results)
+    diagnostic_totals: DiagnosticTotals = collect_context_diagnostic_totals(results)
     had_errors: bool = (diagnostic_totals["error"] > 0) or (encountered_exit_code is not None)
 
     return ProbeRunResult(

--- a/tests/api/test_api_probe.py
+++ b/tests/api/test_api_probe.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from topmark import api
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from topmark.api.types import DiagnosticTotals
 
 
 def test_probe_empty_explicit_dir_is_reported_as_filtered(tmp_path: Path) -> None:
@@ -127,6 +131,69 @@ def test_probe_missing_explicit_path_reports_error(tmp_path: Path) -> None:
     assert file_result.selected_file_type is None
     assert file_result.selected_processor is None
     assert file_result.candidates == ()
+
+    assert result.diagnostics == {}
+    assert result.diagnostic_totals == {
+        "info": 0,
+        "warning": 0,
+        "error": 0,
+        "total": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    (
+        "filename",
+        "content",
+        "include_file_types",
+        "expected_status",
+        "expected_diagnostic_totals",
+    ),
+    [
+        (
+            "sample.py",
+            "print('hello')\n",
+            ("python",),
+            "resolved",
+            {"info": 0, "warning": 0, "error": 0, "total": 0},
+        ),
+        (
+            "notes.xyz",
+            "TopMark notes\n",
+            None,
+            "unsupported",
+            {"info": 1, "warning": 0, "error": 0, "total": 1},
+        ),
+    ],
+)
+def test_probe_diagnostic_totals_match_context_diagnostics(
+    tmp_path: Path,
+    filename: str,
+    content: str,
+    include_file_types: tuple[str, ...] | None,
+    expected_status: str,
+    expected_diagnostic_totals: DiagnosticTotals,
+) -> None:
+    """Probe diagnostic totals reflect context diagnostics when present."""
+    target: Path = tmp_path / filename
+    target.write_text(content, encoding="utf-8")
+
+    result: api.ProbeRunResult = api.probe(
+        [target],
+        include_file_types=include_file_types,
+    )
+
+    assert result.had_errors is False
+    assert len(result.files) == 1
+    assert result.files[0].status == expected_status
+    assert result.diagnostic_totals == expected_diagnostic_totals
+
+    if expected_diagnostic_totals["total"] == 0:
+        assert result.diagnostics == {}
+    else:
+        assert result.diagnostics is not None
+        assert str(target) in result.diagnostics
+        assert len(result.diagnostics[str(target)]) == expected_diagnostic_totals["total"]
 
 
 def test_probe_explicit_input_filtered_by_file_type_is_reported(tmp_path: Path) -> None:

--- a/tests/api/test_result_view.py
+++ b/tests/api/test_result_view.py
@@ -1,0 +1,58 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_result_view.py
+#   file_relpath : tests/api/test_result_view.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for public API view assembly from durable processing results."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.helpers.pipeline import run_insert_diff
+from topmark.api.view import finalize_run_result
+from topmark.pipeline.reduction import ProcessingReduction
+from topmark.pipeline.reduction import reduce_processing_contexts
+from topmark.pipeline.reporting import ReportScope
+from topmark.pipeline.status import PlanStatus
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.api.types import RunResult
+    from topmark.config.model import FrozenConfig
+    from topmark.pipeline.context.model import ProcessingContext
+
+
+def test_finalize_run_result_consumes_durable_processing_results(
+    tmp_path: Path,
+    default_frozen_config: FrozenConfig,
+) -> None:
+    """Public API check/strip DTO assembly should not require live context views."""
+    path: Path = tmp_path / "sample.py"
+    path.write_text("print('hello')\n", encoding="utf-8")
+    ctx: ProcessingContext = run_insert_diff(path=path, cfg=default_frozen_config)
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+    if ctx.views.diff is not None:
+        ctx.views.diff.release()
+
+    result: RunResult = finalize_run_result(
+        results=reduction.results,
+        file_list=[path],
+        apply=False,
+        report_scope=ReportScope.ALL,
+        update_statuses={PlanStatus.INSERTED, PlanStatus.REPLACED, PlanStatus.REMOVED},
+        encountered_exit_code=None,
+    )
+
+    assert len(result.files) == 1
+    assert result.files[0].path == path
+    assert result.files[0].diff == reduction.results[0].detail.diff_text
+    assert result.files[0].diff is not None
+    assert result.had_errors is False


### PR DESCRIPTION
## Summary

This PR advances issue #148 by moving the public API `check()` / `strip()` result-packaging path across the durable result boundary.

Changes include:

- reduce `ProcessingContext` instances to `ProcessingResult` snapshots before API DTO assembly for `check()` and `strip()`
- update `src/topmark/api/view.py` helpers to consume `ProcessingResult` for:
  - report filtering
  - per-file `FileResult` conversion
  - diagnostics
  - diagnostic totals
  - write/failure counts
  - public diff exposure via `ProcessingDetailSnapshot.diff_text`
- keep `probe()` intentionally context-based because `resolution_probe` has not yet been reduced into a durable snapshot
- add context-specific probe diagnostic helpers instead of weakening the durable result boundary
- add focused API tests for:
  - result DTO assembly from durable snapshots
  - public diff exposure after live context diff views are released
  - probe diagnostic totals under the current context-based probe contract
- update architecture/performance documentation and the changelog

## Scope notes

This PR does not migrate:

- `probe()` to `ProcessingResult`
- CLI rendering or `cmd_common.py`
- machine-output rendering
- human TEXT/Markdown rendering
- runner ownership or context-release behavior

Those remain deferred follow-up work. In particular, probe migration should use a dedicated durable probe snapshot rather than storing `resolution_probe` directly on `ProcessingResult`.

## Breaking changes

None expected. Public API DTO shapes and behavior are preserved.