### PR TITLE
Refine ProcessingContext/ProcessingResult ownership and release lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ ______________________________________________________________________
   preserving retained diff output.
 - Pruned consumed pipeline views incrementally between steps when view pruning is enabled, reducing
   transient retention before later patch/write phases while preserving requested diff output.
+- Clarified pipeline execution and reduction ownership by renaming execution collections to
+  `contexts`, keeping runner pruning limited to between-step consumed-view release, and moving final
+  volatile-view release to the durable `ProcessingResult` reduction boundary for check/strip paths.
 - Replaced string-based pipeline view-pruning decisions with typed `ViewSlot` consumer metadata
   declared by concrete pipeline steps.
 - Replaced eager replacement-image composition with a repeatable updated-content abstraction and
@@ -295,8 +298,9 @@ ______________________________________________________________________
   alternatives, benchmark relevance, and the rationale for closing Track B without further
   implementation.
 - Clarified the architecture boundary between mutable `ProcessingContext` execution state and
-  durable `ProcessingResult` snapshots, including outcome classification, report filtering, reduced
-  detail snapshots, check/strip machine output, and check/strip human rendering.
+  durable `ProcessingResult` snapshots, including execution-context ownership, reduction-driven
+  volatile-view release, outcome classification, report filtering, reduced detail snapshots,
+  check/strip machine output, and check/strip human rendering.
 - Added an internal batch reduction boundary from mutable processing contexts to durable processing
   results, including durable detail-state capture that prepares reporting logic for future streaming
   consolidation without changing current runner behavior.
@@ -363,6 +367,9 @@ ______________________________________________________________________
   handling.
 - Added regression coverage for repeatable updated-content iteration and updated-view lifecycle
   behavior.
+- Renamed internal pipeline execution collections from `results` to `contexts` where they still
+  carry mutable `ProcessingContext` instances, preserving a clearer distinction from durable
+  `ProcessingResult` snapshots.
 - Added immutable `StatusSnapshot` and `ProcessingResult` result-reduction primitives as the first
   stage of separating volatile pipeline execution state from durable processing outcomes (GitHub
   issue #148).

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -48,15 +48,25 @@ ______________________________________________________________________
 
 TopMark currently uses a batch handover boundary after the existing runner has produced its per-file
 \[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances.
-\[`reduce_processing_contexts()`\][topmark.pipeline.reduction.reduce_processing_contexts] preserves
-the source contexts and creates matching durable
-\[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] snapshots in the same order.
+\[`PipelineExecution`\][topmark.pipeline.engine.PipelineExecution] therefore names those mutable
+execution objects `contexts`, while
+\[`run_steps_for_files()`\][topmark.pipeline.engine.run_steps_for_files] remains the
+context-producing execution layer.
+\[`reduce_processing_contexts()`\][topmark.pipeline.reduction.reduce_processing_contexts] creates
+matching durable \[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] snapshots in the
+same order. Source-context retention is explicit: compatibility callers may keep contexts in the
+\[`ProcessingReduction`\][topmark.pipeline.reduction.ProcessingReduction] handover object, while
+check/strip callers that now consume durable results use a reduced-only handover and release
+context-owned view payloads after snapshotting.
 
 This boundary is intentionally conservative:
 
 - it does **not** introduce per-file streaming consolidation;
 - it does **not** update summaries incrementally while files are processed;
-- it does **not** release \[`ProcessingContext.views`\][topmark.pipeline.views.Views] early;
+- it keeps runner-owned pruning limited to between-step release of consumed volatile views, while
+  final view release happens only after
+  \[`ProcessingResult.from_context()`\][topmark.pipeline.result.ProcessingResult.from_context] has
+  copied durable detail fields such as `detail.diff_text`;
 - it does make summary, exit-code, report-scope filtering, public API DTO assembly, and check/strip
   machine-readable result serialization testable against durable results without changing runner
   ownership, human-output rendering, or probe-output contracts.

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -191,6 +191,13 @@ The benchmark tool records lightweight ownership indicators including:
 - retained views before pruning;
 - retained views after pruning.
 
+The `views_before_prune` measurement captures the final retained volatile views after pipeline
+execution. The `views_after_prune` measurement then explicitly releases all remaining volatile views
+from the benchmark context. This mirrors the durable-result lifecycle introduced during GitHub issue
+148: `ProcessingResult` owns durable snapshots such as rendered diff text after reduction, while
+`ProcessingContext` views remain volatile execution state and may be released once snapshotting has
+completed.
+
 ______________________________________________________________________
 
 ## Baseline scenarios
@@ -288,9 +295,11 @@ continues to use the historical unpruned mode names in its predefined suites. Ex
 mode variants were added for measuring lifecycle improvements without changing the original baseline
 reference points.
 
-The benchmark harness mirrors the production pruning lifecycle during step sampling whenever a
-pruned mode is used, so retained-view measurements reflect the views that remain available to
-downstream pipeline steps rather than only final cleanup behavior.
+The benchmark harness mirrors the production between-step pruning lifecycle during step sampling
+whenever a pruned mode is used, so retained-view measurements reflect the views that remain
+available to downstream pipeline steps. Final volatile-view release is measured separately after the
+run so it remains distinct from runner-owned between-step pruning and reduction-owned durable
+snapshotting.
 
 Representative issue 140 measurements collected using the explicit pruned benchmark modes were:
 

--- a/src/topmark/api/commands/pipeline.py
+++ b/src/topmark/api/commands/pipeline.py
@@ -117,7 +117,7 @@ def check(
         exclude_file_types: Optional blacklist of file type identifiers to exclude from discovery.
         report: Reporting scope for the returned API view (`actionable`,
             `noncompliant`, or `all`).
-        prune_views: If `True`, trim heavy views after the run (keeps summaries).
+        prune_views: If True, release consumed volatile views between pipeline steps.
 
     Returns:
         Filtered per-file outcomes, counts, diagnostics, and write stats.
@@ -165,7 +165,11 @@ def check(
     report_scope: ReportScope = _resolve_public_report_scope(report)
 
     return finalize_run_result(
-        results=reduce_processing_contexts(api_run.results).results,
+        results=reduce_processing_contexts(
+            api_run.contexts,
+            retain_contexts=False,
+            release_views=True,
+        ).results,
         file_list=api_run.file_list,
         apply=apply,
         report_scope=report_scope,
@@ -208,7 +212,7 @@ def strip(
         exclude_file_types: Optional blacklist of file type identifiers to exclude from discovery.
         report: Reporting scope for the returned API view (`actionable`,
             `noncompliant`, or `all`).
-        prune_views: If `True`, trim heavy internal views after the run (keeps summaries).
+        prune_views: If True, release consumed volatile views between pipeline steps.
 
     Returns:
         Resolved runtime config, selected file list, filtered results, and any
@@ -255,7 +259,11 @@ def strip(
     report_scope: ReportScope = _resolve_public_report_scope(report)
 
     return finalize_run_result(
-        results=reduce_processing_contexts(api_run.results).results,
+        results=reduce_processing_contexts(
+            api_run.contexts,
+            retain_contexts=False,
+            release_views=True,
+        ).results,
         file_list=api_run.file_list,
         apply=apply,
         report_scope=report_scope,
@@ -295,7 +303,7 @@ def probe(
         policy_by_type: Optional per-type policy overrides merged after discovery.
         include_file_types: Optional whitelist of file type identifiers to restrict discovery.
         exclude_file_types: Optional blacklist of file type identifiers to exclude from discovery.
-        prune_views: If `True`, trim heavy internal views after the run where applicable.
+        prune_views: If True, release consumed volatile views between pipeline steps.
             Probe results are built from resolution data, not presentation views.
 
     Returns:
@@ -336,7 +344,7 @@ def probe(
     # Probe has a dedicated public result shape; do not route it through the
     # check/strip finalizer.
     return finalize_probe_result(
-        results=api_run.results,
+        results=api_run.contexts,
         file_list=api_run.file_list,
         encountered_exit_code=api_run.exit_code,
     )

--- a/src/topmark/api/runtime.py
+++ b/src/topmark/api/runtime.py
@@ -689,7 +689,7 @@ def _execute_pipeline_for_file_list(
     """
     if not prepared.file_list:
         return PipelineExecution(
-            results=[],
+            contexts=[],
             exit_code=None,
         )
 
@@ -760,7 +760,7 @@ def run_pipeline(
         prepared=prepared,
         pipeline=pipeline,
     )
-    results: list[ProcessingContext] = execution.results
+    results: list[ProcessingContext] = execution.contexts
     encountered_exit_code: ExitCode | None = execution.exit_code
 
     logger.info("Processing %d file(s) with TopMark %s", len(prepared.file_list), TOPMARK_VERSION)
@@ -768,7 +768,7 @@ def run_pipeline(
     return ApiPipelineRun(
         effective_cfg=prepared.effective_cfg,
         file_list=prepared.file_list,
-        results=results,
+        contexts=results,
         exit_code=encountered_exit_code,
     )
 
@@ -841,7 +841,7 @@ def run_probe_pipeline(
         prepared=prepared,
         pipeline=pipeline,
     )
-    results: list[ProcessingContext] = execution.results
+    results: list[ProcessingContext] = execution.contexts
     encountered_exit_code: ExitCode | None = execution.exit_code
 
     # Missing explicit literals are hard resolver-level failures. Add them
@@ -872,6 +872,6 @@ def run_probe_pipeline(
     return ApiPipelineRun(
         effective_cfg=prepared.effective_cfg,
         file_list=prepared.file_list,
-        results=results,
+        contexts=results,
         exit_code=encountered_exit_code,
     )

--- a/src/topmark/api/types.py
+++ b/src/topmark/api/types.py
@@ -292,7 +292,7 @@ class ApiPipelineRun:
             overlays, and execution-scoped adjustments.
         file_list: Files selected for pipeline execution after discovery and
             filtering.
-        results: Processing contexts produced by pipeline execution. For probe
+        contexts: Processing contexts produced by pipeline execution. For probe
             runs, this may also include synthetic contexts representing missing
             or filtered explicit inputs.
         exit_code: Fatal pipeline-level exit code, if one was encountered.
@@ -307,7 +307,7 @@ class ApiPipelineRun:
 
     effective_cfg: FrozenConfig
     file_list: list[Path]
-    results: list[ProcessingContext]
+    contexts: list[ProcessingContext]
     exit_code: ExitCode | None
 
 

--- a/src/topmark/cli/cmd_common.py
+++ b/src/topmark/cli/cmd_common.py
@@ -199,8 +199,10 @@ def build_run_options(
         write_mode: Effective CLI write mode (`stdout`, `atomic`, or `inplace`).
         stdin_mode: Whether the command is operating in content-on-STDIN mode.
         stdin_filename: Synthetic file name associated with STDIN content, if any.
-        prune_views: If `True`, trim heavy views after the run (keeps summaries). Default: `True`.
-        keep_diff_view: Whether to preserve the diff view.
+        prune_views: If True, release consumed volatile views between pipeline steps.
+        keep_diff_view: Whether to preserve the diff view during between-step pruning;
+            must be true for pipelines containing `PatcherStep` until reduction
+            snapshots `ProcessingDetailSnapshot.diff_text`.
 
     Returns:
         The execution-only runtime options for the current CLI invocation.

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -101,7 +101,6 @@ from topmark.core.formats import OutputFormat
 from topmark.core.logging import get_logger
 from topmark.core.machine.payloads import build_meta_payload
 from topmark.pipeline.context.model import ProcessingContext
-from topmark.pipeline.context.policy import effective_would_add_or_update
 from topmark.pipeline.engine import PipelineExecution
 from topmark.pipeline.engine import exit_code_from_pipeline_results
 from topmark.pipeline.engine import run_steps_for_files
@@ -492,7 +491,7 @@ def check_command(
         pipeline=pipeline,
         file_list=file_list,
     )
-    results: list[ProcessingContext] = pipeline_run.results
+    context_results: list[ProcessingContext] = pipeline_run.contexts
     encountered_exit_code: ExitCode | None = pipeline_run.exit_code
 
     # Add resolver-level hard failures before deriving the process exit code so
@@ -502,9 +501,9 @@ def check_command(
         config=config,
         run_options=run_options,
     )
-    results.extend(missing_results)
+    context_results.extend(missing_results)
 
-    pipeline_error_code: ExitCode | None = exit_code_from_pipeline_results(results)
+    pipeline_error_code: ExitCode | None = exit_code_from_pipeline_results(context_results)
     encountered_exit_code = encountered_exit_code or pipeline_error_code
 
     # Report scope is a human per-file listing policy only.
@@ -513,17 +512,20 @@ def check_command(
     # - Human summary mode must also use the full raw result set so aggregated
     #   counts are not distorted by per-file report filtering.
     # - Human non-summary output uses the filtered per-file view.
-    reduction: ProcessingReduction = reduce_processing_contexts(results)
+    reduction: ProcessingReduction = reduce_processing_contexts(
+        context_results,
+        retain_contexts=False,
+        release_views=True,
+    )
+    results: Sequence[ProcessingResult] = reduction.results
 
     filtered: ReportFilterResult[ProcessingResult] = filter_results_for_report(
-        reduction.results,
+        results,
         report_scope=report_scope,
         would_change=would_change_result,
     )
 
-    human_results: Sequence[ProcessingResult] = (
-        reduction.results if summary_mode else filtered.view_results
-    )
+    human_results: Sequence[ProcessingResult] = results if summary_mode else filtered.view_results
 
     if fmt in (OutputFormat.JSON, OutputFormat.NDJSON):
         emit_processing_results_machine(
@@ -531,7 +533,7 @@ def check_command(
             meta=meta,
             config=config,
             resolved_toml=prepared_cli_config.resolved_toml,
-            results=reduction.results,
+            results=results,
             fmt=fmt,
             summary_mode=summary_mode,
         )
@@ -564,9 +566,11 @@ def check_command(
             safe_unlink(temp_path)
             return
         else:
-            # Count outcomes after writer statuses have been finalized.
-            written: int = sum(1 for r in results if r.status.write == WriteStatus.WRITTEN)
-            failed: int = sum(1 for r in results if r.status.write == WriteStatus.FAILED)
+            # Count outcomes from durable results after writer statuses have been finalized.
+            written: int = sum(
+                1 for result in results if result.status.write == WriteStatus.WRITTEN
+            )
+            failed: int = sum(1 for result in results if result.status.write == WriteStatus.FAILED)
 
             # Emit apply summary. TEXT honors --quiet; Markdown remains document-oriented.
             if fmt == OutputFormat.TEXT and not state.quiet:
@@ -610,7 +614,9 @@ def check_command(
         temp_path=temp_path,
     )
 
-    if not apply_changes and any(effective_would_add_or_update(r) for r in results):
+    if not apply_changes and any(
+        result.outcome.effective_would_add_or_update for result in results
+    ):
         ctx.exit(ExitCode.WOULD_CHANGE)
 
     # Cleanup temp file if any (shouldn't be needed except on errors)

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -411,7 +411,7 @@ def probe_command(
         pipeline=pipeline,
         file_list=file_list,
     )
-    results: list[ProcessingContext] = pipeline_run.results
+    context_results: list[ProcessingContext] = pipeline_run.contexts
     encountered_exit_code: ExitCode | None = pipeline_run.exit_code
 
     # Add resolver-level hard failures before deriving the process exit code.
@@ -422,16 +422,16 @@ def probe_command(
         config=config,
         run_options=run_options,
     )
-    results.extend(missing_results)
+    context_results.extend(missing_results)
 
     # Compute hard-error precedence before adding synthetic filtered contexts;
     # filtered explicit inputs remain probe-semantic outcomes and map to 69.
-    pipeline_error_code: ExitCode | None = exit_code_from_pipeline_results(results)
+    pipeline_error_code: ExitCode | None = exit_code_from_pipeline_results(context_results)
     encountered_exit_code = encountered_exit_code or pipeline_error_code
 
     # Add synthetic probe results for explicit inputs that were filtered before
     # the probe pipeline could run.
-    results.extend(
+    context_results.extend(
         build_filtered_probe_contexts(
             selection_results=filtered_selection_results,
             config=config,
@@ -445,14 +445,14 @@ def probe_command(
             meta=meta,
             config=config,
             resolved_toml=prepared_cli_config.resolved_toml,
-            results=results,
+            results=context_results,
             fmt=fmt,
         )
     else:
         report = ProbeCommandHumanReport(
             pipeline_kind=PIPELINE_KIND,
-            file_list_total=len(results),
-            view_results=results,
+            file_list_total=len(context_results),
+            view_results=context_results,
             verbosity_level=verbosity_level,
             styled=enable_color,
         )
@@ -473,13 +473,13 @@ def probe_command(
 
     # Probe-specific semantic exit status. Filtered explicit inputs are reported
     # as probe results and therefore map to UNSUPPORTED_FILE_TYPE.
-    if any(result.resolution_probe is None for result in results):
+    if any(result.resolution_probe is None for result in context_results):
         ctx.exit(ExitCode.PIPELINE_ERROR)
 
     if any(
         result.resolution_probe is not None
         and result.resolution_probe.status != ResolutionProbeStatus.RESOLVED
-        for result in results
+        for result in context_results
     ):
         ctx.exit(ExitCode.UNSUPPORTED_FILE_TYPE)
 

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -93,7 +93,6 @@ from topmark.core.exit_codes import ExitCode
 from topmark.core.formats import OutputFormat
 from topmark.core.logging import get_logger
 from topmark.core.machine.payloads import build_meta_payload
-from topmark.pipeline.context.policy import effective_would_strip
 from topmark.pipeline.engine import PipelineExecution
 from topmark.pipeline.engine import exit_code_from_pipeline_results
 from topmark.pipeline.engine import run_steps_for_files
@@ -451,7 +450,7 @@ def strip_command(
         pipeline=pipeline,
         file_list=file_list,
     )
-    results: list[ProcessingContext] = pipeline_run.results
+    context_results: list[ProcessingContext] = pipeline_run.contexts
     encountered_exit_code: ExitCode | None = pipeline_run.exit_code
 
     # Add resolver-level hard failures before deriving the process exit code so
@@ -461,9 +460,9 @@ def strip_command(
         config=config,
         run_options=run_options,
     )
-    results.extend(missing_results)
+    context_results.extend(missing_results)
 
-    pipeline_error_code: ExitCode | None = exit_code_from_pipeline_results(results)
+    pipeline_error_code: ExitCode | None = exit_code_from_pipeline_results(context_results)
     encountered_exit_code = encountered_exit_code or pipeline_error_code
 
     # Report scope is a human per-file listing policy only.
@@ -472,17 +471,20 @@ def strip_command(
     # - Human summary mode must also use the full raw result set so aggregated
     #   counts are not distorted by per-file report filtering.
     # - Human non-summary output uses the filtered per-file view.
-    reduction: ProcessingReduction = reduce_processing_contexts(results)
+    reduction: ProcessingReduction = reduce_processing_contexts(
+        context_results,
+        retain_contexts=False,
+        release_views=True,
+    )
+    results: Sequence[ProcessingResult] = reduction.results
 
     filtered: ReportFilterResult[ProcessingResult] = filter_results_for_report(
-        reduction.results,
+        results,
         report_scope=report_scope,
         would_change=would_change_result,
     )
 
-    human_results: Sequence[ProcessingResult] = (
-        reduction.results if summary_mode else filtered.view_results
-    )
+    human_results: Sequence[ProcessingResult] = results if summary_mode else filtered.view_results
 
     if fmt in (OutputFormat.JSON, OutputFormat.NDJSON):
         emit_processing_results_machine(
@@ -490,7 +492,7 @@ def strip_command(
             meta=meta,
             config=config,
             resolved_toml=prepared_cli_config.resolved_toml,
-            results=reduction.results,
+            results=results,
             fmt=fmt,
             summary_mode=summary_mode,
         )
@@ -523,9 +525,11 @@ def strip_command(
             safe_unlink(temp_path)
             return
         else:
-            # Count outcomes after writer statuses have been finalized.
-            written: int = sum(1 for r in results if r.status.write == WriteStatus.WRITTEN)
-            failed: int = sum(1 for r in results if r.status.write == WriteStatus.FAILED)
+            # Count outcomes from durable results after writer statuses have been finalized.
+            written: int = sum(
+                1 for result in results if result.status.write == WriteStatus.WRITTEN
+            )
+            failed: int = sum(1 for result in results if result.status.write == WriteStatus.FAILED)
 
             # Emit apply summary. TEXT honors --quiet; Markdown remains document-oriented.
             if fmt == OutputFormat.TEXT and not state.quiet:
@@ -569,7 +573,7 @@ def strip_command(
         temp_path=temp_path,
     )
 
-    if not apply_changes and any(effective_would_strip(r) for r in results):
+    if not apply_changes and any(result.outcome.effective_would_strip for result in results):
         ctx.exit(ExitCode.WOULD_CHANGE)
 
     # Cleanup temp file if any (shouldn't be needed except on errors)

--- a/src/topmark/pipeline/engine.py
+++ b/src/topmark/pipeline/engine.py
@@ -191,14 +191,14 @@ class PipelineExecution:
     """Result of running pipeline steps over a selected file list.
 
     Attributes:
-        results: Ordered per-file processing contexts produced by the pipeline,
+        contexts: Ordered per-file processing contexts produced by pipeline execution,
             one for each path in the input file list that did not raise a fatal
             engine-level error.
         exit_code: First non-success engine-level exit code encountered while
             iterating files, or `None` when no such error occurred.
     """
 
-    results: list[ProcessingContext]
+    contexts: list[ProcessingContext]
     exit_code: ExitCode | None
 
 
@@ -366,4 +366,4 @@ def run_steps_for_files(
             encountered_exit_code = encountered_exit_code or ExitCode.PIPELINE_ERROR
             continue
 
-    return PipelineExecution(results=results, exit_code=encountered_exit_code)
+    return PipelineExecution(contexts=results, exit_code=encountered_exit_code)

--- a/src/topmark/pipeline/reduction.py
+++ b/src/topmark/pipeline/reduction.py
@@ -17,10 +17,10 @@ reducer: it consumes already-produced
 instances and returns matching
 [`ProcessingResult`][topmark.pipeline.result.ProcessingResult] snapshots.
 
-It does not introduce per-file streaming consolidation, incremental summary
-updates, or early release of context-owned views. Its purpose is to make the
-handover seam typed and testable so later work can decide whether this boundary
-can move earlier in the processing loop.
+It does not introduce per-file streaming consolidation or incremental summary
+updates. It does provide explicit knobs for whether the handover retains source
+contexts and whether volatile context-owned view payloads are released after
+durable snapshots have been created.
 """
 
 from __future__ import annotations
@@ -41,11 +41,11 @@ class ProcessingReduction:
     """Batch reduction result for processed pipeline contexts.
 
     Attributes:
-        contexts: Immutable tuple of the source mutable processing contexts.
-            These are retained intentionally for current CLI, API, human-output,
-            probe-output, and machine-detail consumers.
+        contexts: Immutable tuple of retained source mutable processing
+            contexts. This is empty when the caller requested a reduced-only
+            handover.
         results: Immutable tuple of durable processing-result snapshots reduced
-            from `contexts` in the same order.
+            from source contexts in the same order.
     """
 
     contexts: tuple[ProcessingContext, ...]
@@ -54,23 +54,41 @@ class ProcessingReduction:
 
 def reduce_processing_contexts(
     contexts: Iterable[ProcessingContext],
+    *,
+    retain_contexts: bool = True,
+    release_views: bool = False,
 ) -> ProcessingReduction:
     """Reduce completed processing contexts to durable results as a batch.
 
-    This helper marks the current post-run handover boundary. It preserves the
-    source contexts while creating detached durable result snapshots, which lets
-    existing context-based consumers keep working while summary and exit-code
-    logic gains a result-compatible seam.
+    This helper marks the current post-run handover boundary. By default it
+    preserves source contexts for compatibility with remaining context-based
+    consumers. Callers that have migrated to durable results can request a
+    reduced-only handover and release volatile view payloads after snapshotting.
 
     Args:
         contexts: Completed or partially completed processing contexts to reduce.
+        retain_contexts: Whether to keep source contexts in the returned
+            reduction object. Use ``False`` once all downstream consumers for
+            the current command operate on durable results.
+        release_views: Whether to release context-owned view payloads after
+            durable snapshots have been created. This never runs before
+            `ProcessingResult.from_context()` has copied result-owned detail
+            fields such as `diff_text`.
 
     Returns:
-        Batch reduction containing the source contexts and corresponding
-        durable results in matching order.
+        Batch reduction containing durable results and, when requested, the
+        retained source contexts in matching order.
     """
     source_contexts: tuple[ProcessingContext, ...] = tuple(contexts)
+    results: tuple[ProcessingResult, ...] = tuple(
+        ProcessingResult.from_context(ctx) for ctx in source_contexts
+    )
+
+    if release_views is True:
+        for ctx in source_contexts:
+            ctx.views.release_all()
+
     return ProcessingReduction(
-        contexts=source_contexts,
-        results=tuple(ProcessingResult.from_context(ctx) for ctx in source_contexts),
+        contexts=source_contexts if retain_contexts is True else (),
+        results=results,
     )

--- a/src/topmark/pipeline/runner.py
+++ b/src/topmark/pipeline/runner.py
@@ -45,9 +45,11 @@ def run(
     Args:
         ctx: Mutable processing context.
         steps: Ordered sequence of pipeline steps. Each step takes and returns a context.
-        prune_views: Release consumed view payloads between steps and trim remaining views at the
-            end of a run to reduce memory usage (default: `True`).
-        keep_diff_view: Whether to preserve the diff view.
+        prune_views: Release consumed view payloads between steps once no remaining
+            step declares them as consumed (default: `True`).
+        keep_diff_view: Whether to preserve the diff view during between-step pruning
+            (required when the pipeline generates a unified diff in
+            [`PatcherStep`][topmark.pipeline.steps.patcher.PatcherStep]).
 
     Returns:
         The final processing context after all steps have run.
@@ -63,11 +65,5 @@ def run(
                 remaining_view_consumers=remaining_view_consumers,
                 keep_diff_view=keep_diff_view,
             )
-
-    if prune_views is True:
-        # Drops large in-memory buffers from heavy in-memory views;
-        # retains only summary-friendly data.
-        logger.debug("Trimming views; keep_diff_view: %r", keep_diff_view)
-        ctx.views.release_all(keep_diff_view=keep_diff_view)
 
     return ctx

--- a/src/topmark/pipeline/views.py
+++ b/src/topmark/pipeline/views.py
@@ -353,23 +353,14 @@ class Views:
 
     def release_all(
         self,
-        *,
-        keep_diff_view: bool = False,
     ) -> None:
-        """Release all non-None views safely (idempotent).
-
-        Args:
-            keep_diff_view: Whether to preserve the diff view.
-        """
-        logger.debug("keep_diff_view: %r", keep_diff_view)
+        """Release all non-None views safely (idempotent)."""
         self.release_image()
         self.release_header()
         self.release_build()
         self.release_render()
         self.release_updated()
-
-        if not keep_diff_view:
-            self.release_diff()
+        self.release_diff()
 
     def release_image(self) -> None:
         """Release the original file image view when it is no longer needed."""

--- a/src/topmark/runtime/model.py
+++ b/src/topmark/runtime/model.py
@@ -52,8 +52,7 @@ class RunOptions:
         stdin_mode: Whether content is being provided on stdin for this run.
         stdin_filename: Synthetic filename associated with stdin content, used
             when header generation requires a file identity.
-        prune_views: Whether heavy views should be trimmed after the run while
-            preserving summary-level results.
+        prune_views: If True, release consumed volatile views between pipeline steps.
         keep_diff_view: Whether to preserve the diff view.
         started_at: Timestamp captured once for the whole run.
     """

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -59,7 +59,7 @@ def run_cli_in(
         argv: CLI argument vector, e.g. `["--apply", "*.py"]`.
         input_text: Optional standard input to pass to the command.
             This can be a string, bytes, or a file-like object for `--stdin` modes.
-        prune_views: If `True`, trim heavy views after the run (keeps summaries).
+        prune_views: If True, release consumed volatile views between pipeline steps.
 
     Returns:
         The `click.testing.Result` produced by `click.testing.CliRunner.invoke`.
@@ -106,7 +106,7 @@ def run_cli(
         input_text: Optional standard input to pass
             to the command. This can be a string, bytes, or a file-like object for
             ``--stdin`` modes.
-        prune_views: If `True`, trim heavy views after the run (keeps summaries).
+        prune_views: If True, release consumed volatile views between pipeline steps.
 
     Returns:
         The `click.testing.Result` produced by `click.testing.CliRunner.invoke`.

--- a/tests/helpers/api.py
+++ b/tests/helpers/api.py
@@ -241,8 +241,7 @@ def run_cli_like(
         apply: Whether the pipeline may mutate files.
         diff: Whether to select the diff-producing pipeline variant when
             supported by `kind` and `apply`.
-        prune_views: Whether to prune heavy context views during pipeline
-            execution.
+        prune_views: If True, release consumed volatile views between pipeline steps.
         include_file_types: Optional file type identifiers to include.
         exclude_file_types: Optional file type identifiers to exclude.
 
@@ -279,5 +278,5 @@ def run_cli_like(
     return CliLikeRun(
         draft_config=draft,
         file_list=files,
-        results=pipeline_run.results,
+        results=pipeline_run.contexts,
     )

--- a/tests/pipeline/integration/test_nested_config_e2e.py
+++ b/tests/pipeline/integration/test_nested_config_e2e.py
@@ -84,9 +84,9 @@ def test_nested_config_applies_only_within_its_subtree(tmp_path: Path) -> None:
     # Limit discovery to Python files so the config files themselves are not part
     # of the processed candidate set for this end-to-end behavior check.
     assert set(api_run.file_list) == {pkg_file.resolve(), docs_file.resolve()}
-    assert len(api_run.results) == 2
+    assert len(api_run.contexts) == 2
 
-    by_path: dict[Path, ProcessingContext] = {ctx.path.resolve(): ctx for ctx in api_run.results}
+    by_path: dict[Path, ProcessingContext] = {ctx.path.resolve(): ctx for ctx in api_run.contexts}
 
     pkg_ctx: ProcessingContext = by_path[pkg_file.resolve()]
     docs_ctx: ProcessingContext = by_path[docs_file.resolve()]

--- a/tests/pipeline/test_engine_path_configs.py
+++ b/tests/pipeline/test_engine_path_configs.py
@@ -107,7 +107,7 @@ def test_run_steps_for_files_uses_path_specific_configs_when_provided(
     )
 
     assert pipeline_run.exit_code is None
-    assert [result.path for result in pipeline_run.results] == [file_a, file_b]
+    assert [result.path for result in pipeline_run.contexts] == [file_a, file_b]
 
     assert len(bootstrap_calls) == 2
     assert bootstrap_calls[0][0] == file_a
@@ -176,7 +176,7 @@ def test_run_steps_for_files_falls_back_to_shared_config_without_path_configs(
     )
 
     assert pipeline_run.exit_code is None
-    assert [result.path for result in pipeline_run.results] == [file_a, file_b]
+    assert [result.path for result in pipeline_run.contexts] == [file_a, file_b]
 
     assert len(bootstrap_calls) == 2
     assert bootstrap_calls[0][1] is shared_cfg

--- a/tests/pipeline/test_hard_link_identity.py
+++ b/tests/pipeline/test_hard_link_identity.py
@@ -53,7 +53,7 @@ def _run_check(paths: list[Path], config: FrozenConfig) -> list[ProcessingContex
         file_list=paths,
     )
     assert pipeline_run.exit_code is None
-    return pipeline_run.results
+    return pipeline_run.contexts
 
 
 def test_hard_link_pair_blocks_all_selected_paths(tmp_path: Path) -> None:

--- a/tests/pipeline/test_reduction.py
+++ b/tests/pipeline/test_reduction.py
@@ -24,6 +24,7 @@ from topmark.pipeline.status import ContentStatus
 from topmark.pipeline.status import FsStatus
 from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import WriteStatus
+from topmark.pipeline.views import DiffView
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -109,3 +110,22 @@ def test_exit_code_selection_preserves_result_priority(
     )
 
     assert exit_code_from_pipeline_results(reduction.results) is ExitCode.PERMISSION_DENIED
+
+
+def test_reduce_processing_contexts_can_release_views_without_retaining_contexts(
+    tmp_path: Path,
+) -> None:
+    """Reduced-only handover should snapshot detail before releasing view payloads."""
+    ctx: ProcessingContext = _make_reduction_context(tmp_path, "sample.py")
+    ctx.views.diff = DiffView(text="--- current\n+++ updated\n")
+
+    reduction: ProcessingReduction = reduce_processing_contexts(
+        [ctx],
+        retain_contexts=False,
+        release_views=True,
+    )
+
+    assert reduction.contexts == ()
+    assert reduction.results[0].detail.diff_text == "--- current\n+++ updated\n"
+    assert ctx.views.diff is not None
+    assert ctx.views.diff.text is None

--- a/tests/pipeline/test_view_pruning.py
+++ b/tests/pipeline/test_view_pruning.py
@@ -170,3 +170,13 @@ def test_pipeline_steps_declare_expected_view_consumers() -> None:
     assert set(steps_by_name) == set(expected_by_step_name)
     for step_name, expected_consumers in expected_by_step_name.items():
         assert steps_by_name[step_name].consumes_views == expected_consumers
+
+
+def test_release_all_releases_diff_payload() -> None:
+    """Views.release_all() releases all payloads, including diff payload."""
+    views = Views(diff=DiffView(text="--- current\n+++ updated\n"))
+
+    views.release_all()
+
+    assert views.diff is not None
+    assert views.diff.text is None

--- a/tools/perf/pipeline_memory_baseline.py
+++ b/tools/perf/pipeline_memory_baseline.py
@@ -749,7 +749,7 @@ def _measure_one(
     final_bytes, peak_bytes = tracemalloc.get_traced_memory()
     end_rss: int | None = _rss_bytes()
     views_before_prune: dict[str, int | bool] = _view_sizes(ctx)
-    ctx.views.release_all(keep_diff_view=mode.keep_diff_view)
+    ctx.views.release_all()
     views_after_prune: dict[str, int | bool] = _view_sizes(ctx)
     max_sample_rss: int = max((sample.rss_bytes or 0 for sample in samples), default=0)
     max_observed_rss: int = max(


### PR DESCRIPTION
## Summary

This PR continues GitHub issue #148 by clarifying ownership and lifecycle
semantics around mutable `ProcessingContext` instances, volatile pipeline
views, and durable `ProcessingResult` snapshots.

The goal is not to introduce streaming or redesign probe behavior, but to
make the current reduction boundary more explicit and easier to reason
about.

## Changes

### Execution-context naming

- Renamed internal execution-layer collections from `results` to
  `contexts` where they still carry mutable `ProcessingContext`
  instances.
- Renamed `PipelineExecution.results` to `PipelineExecution.contexts`.
- Updated CLI and API call sites accordingly.

### Reduction ownership

- Clarified that:
  - `run_steps_for_files()` remains the context-producing execution layer.
  - `reduce_processing_contexts()` is the durable handover boundary.
  - `ProcessingResult` becomes the owner of reduced state after
    snapshotting.

### View lifecycle

- Simplified `Views.release_all()` to release all volatile views,
  including diff views.
- Retained `keep_diff_view` only for between-step pruning scenarios.
- Clarified that runner pruning is limited to releasing consumed views
  between steps.
- Moved final volatile-view release responsibility to the reduction
  boundary after durable snapshot creation.

### CLI/API separation

- Updated `check` and `strip` so post-reduction processing operates on
  durable `ProcessingResult` instances.
- Kept `probe` intentionally context-based because probe-specific durable
  snapshots do not yet exist.
- Added comments and naming updates to reinforce this distinction.

### Documentation

- Updated architecture documentation to describe:
  - execution-context ownership
  - reduction ownership
  - runner pruning responsibilities
  - reduction-driven view release
- Updated performance-baseline documentation to reflect the revised
  lifecycle model.
- Updated changelog entries accordingly.

## Why

Issue #148 has already migrated most consumers to durable
`ProcessingResult` snapshots.

This PR focuses on the remaining ownership question:

- Who owns mutable execution state?
- Who owns durable result state?
- When can volatile views be released?

The resulting model is:

```text
PipelineExecution
        |
        v
ProcessingContext
        |
        v
reduce_processing_contexts()
        |
        v
ProcessingResult
```

with:

- runner-owned between-step pruning
- reduction-owned final view release
- result-owned durable detail state

## Deferred work

This PR intentionally does not:

- migrate probe to durable snapshots
- introduce streaming execution
- redesign pipeline intent handling
- replace difflib

Those remain future follow-up work under issue #148.

Closes the ownership/lifecycle portion of #148.