### PR TITLE
Refactor pipeline intent modelling around explicit catalogue and selection objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,9 @@ ______________________________________________________________________
 - Made pipeline outcome bucketing compatible with durable `ProcessingResult` snapshots by
   introducing typed outcome, pre-insert advisory, and execution-mode snapshots, while preserving
   existing `ProcessingContext` consumers, CLI/API behavior, and machine-output shapes.
+- Clarified pipeline intent modelling by renaming derived per-result action intent helpers,
+  introducing explicit pipeline catalogue definitions and selection DTOs, and deriving runtime
+  execution options from selected pipelines while preserving CLI, API, and machine-output behavior.
 
 ### Breaking Changes - Unreleased
 
@@ -309,6 +312,9 @@ ______________________________________________________________________
   consolidation without changing current runner behavior.
 - Updated architecture documentation to reflect durable probe snapshots, reduced probe state, and
   the completion of the current output-facing mutable-context to durable-result migration.
+- Documented the pipeline catalogue and selection architecture, including the separation between
+  command intent, selected executable pipeline definitions, durable runtime options, and public API
+  or machine-output compatibility boundaries.
 
 ### Internal - Unreleased
 
@@ -381,6 +387,9 @@ ______________________________________________________________________
 - Added typed outcome-classification, pre-insert advisory, and execution-mode snapshots so
   policy-derived bucketing state and invocation intent can be reduced from mutable pipeline contexts
   without retaining volatile execution objects.
+- Reworked internal pipeline selection around `Pipeline`, `PipelineDefinition`, and
+  `PipelineSelection`, moved selection ownership into the pipeline catalogue, and added targeted
+  coverage for catalogue metadata, selection variants, and runtime-option synchronization.
 
 ### Notes - Unreleased
 

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -91,6 +91,14 @@ are preserved per layer (for example under `[[layers]].toml.*` in human output o
 \[`FrozenConfig`\][topmark.config.model.FrozenConfig] represents only the flattened effective
 runtime configuration used during execution.
 
+Pipeline selection is resolved separately from layered configuration. Public API helpers such as
+\[`check()`\][topmark.api.commands.pipeline.check],
+\[`strip()`\][topmark.api.commands.pipeline.strip], and
+\[`probe()`\][topmark.api.commands.pipeline.probe] first select an executable pipeline definition
+from the pipeline catalogue based on command intent and runtime flags. The selected pipeline then
+contributes execution intent (pipeline kind, mutation mode, and diff-view preservation) to durable
+runtime options before processing begins.
+
 ```python
 from topmark import api
 
@@ -137,6 +145,11 @@ identical file-type identity semantics. Local identifiers such as `"python"` are
 unambiguous. Internally, TopMark normalizes identifiers to canonical qualified keys such as
 `"topmark:python"` before filtering, resolution, policy evaluation, and binding lookup.
 
+Public API execution follows the same architecture as the CLI: immutable configuration, pipeline
+selection, runtime-option construction, processing-context execution, reduction into durable
+results, and final report rendering. Internal pipeline-selection objects and execution contexts are
+intentionally not part of the public API surface.
+
 Public API execution also uses the same documented filesystem-identity semantics as the CLI.
 Existing filesystem inputs undergo filesystem-identity evaluation before pipeline execution.
 Multiple path spellings that resolve to the same target, such as a symlink and its target, may
@@ -178,6 +191,10 @@ for fr in result.files:
     for c in fr.candidates:
         print(" -", c.file_type, c.rank, c.selected, c.matched_by)
 ```
+
+Unlike content-processing APIs, probe execution always selects the dedicated read-only probe
+pipeline. It does not perform header generation, mutation planning, comparison, patch generation, or
+writing.
 
 The probe API is read-only and returns stable JSON-friendly DTOs:
 
@@ -262,6 +279,10 @@ This process follows:
 1. Staged config-loading validation
 1. Freeze into immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig]
 1. Runtime overlays (API call arguments such as `diff`, `report`, etc.)
+
+For processing APIs, pipeline selection occurs after configuration resolution and before runtime
+execution. The selected pipeline definition is not part of the public compatibility contract; public
+results expose stable outcome and reporting data rather than internal execution-planning objects.
 
 File-backed TOML sources use configuration-source identity based on the resolved configuration-file
 target. If a configuration file is reached through a symlink, provenance and applicability are based
@@ -351,6 +372,10 @@ for binding in Registry.bindings():
 
 Most public integrations should treat the registry facade as introspection-only and prefer the
 high-level \[`topmark.api`\][topmark.api] execution helpers.
+
+Public integrations should likewise treat pipeline selection and execution planning as internal
+implementation details. The supported compatibility boundary is the documented API DTOs,
+machine-readable output contracts, immutable configuration model, and registry-inspection surfaces.
 
 Advanced registry concepts, including registry layers, runtime overlays, bindings, qualified/local
 identity semantics, and runtime extension examples, are documented in

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -24,6 +24,10 @@ The following architectural contracts are part of the stable 1.x design:
 
 - CLI, API, presentation, runtime, configuration, registry, and pipeline concerns remain separated.
 - Runtime execution intent is kept separate from layered configuration state.
+- Pipeline command intent is selected before execution through an explicit pipeline catalogue and
+  selection model. Pipeline selection is kept separate from durable runtime options: selection
+  identifies the executable pipeline definition, while runtime options carry invocation state onto
+  contexts and reduced results.
 - Workspace-root discovery and configuration-discovery anchoring are evaluated before layered
   configuration state is constructed.
 - File type identity is normalized to canonical qualified keys once resolved.
@@ -122,7 +126,8 @@ TopMark separates configuration concerns into three layers:
   - merging into a mutable config draft
   - field-level merge semantics and precedence rules
 - **Runtime layer** (\[`topmark.runtime`\][topmark.runtime]):
-  - execution-time options (e.g. writer behavior)
+  - execution-time options (e.g. writer behavior, STDIN mode, view pruning)
+  - selected pipeline invocation state copied into durable run options
   - final adjustments before pipeline execution
 
 ```mermaid
@@ -133,7 +138,7 @@ flowchart TD
     D["Deserialize layered fragment into MutableConfig<br/>defensive value parsing and normalization"]
     E["Merge layered config into mutable draft<br/>apply precedence and overrides"]
     F["Freeze final FrozenConfig and validate staged config-loading diagnostics<br/>TOML-source, merged-config, runtime-applicability"]
-    G["Runtime layer<br/>apply execution-only options before pipeline"]
+     G["Runtime layer<br/>select pipeline and apply execution-only options before pipeline"]
 
     A --> B --> C --> D --> E --> F --> G
 ```
@@ -141,6 +146,13 @@ flowchart TD
 Not all TOML-defined values become layered configuration fields. Source-local options such as
 `[config].root` and `[config].strict` are resolved on the TOML side first, then applied to config
 discovery and staged config-loading validation without participating in layered config merging.
+
+Pipeline selection is also outside layered configuration. CLI and API entry points select a concrete
+pipeline definition from the pipeline catalogue using the requested pipeline family (`check`,
+`strip`, or `probe`) and invocation flags such as apply and diff mode.
+\[`RunOptions`\][topmark.runtime.model.RunOptions] then copies the overlapping execution state from
+that selection, so mutation mode and diff-view preservation are not repeated independently by each
+caller.
 
 Project-chain discovery starts from the resolved discovery anchor before configuration-source
 identity is evaluated. This keeps workspace-root discovery separate from configuration-source
@@ -226,7 +238,7 @@ filesystem-identity evaluation.
 Filesystem-identity normalization collapses multiple path spellings that resolve to the same
 filesystem target (for example a symlink and its target) before normal pipeline execution begins.
 This keeps downstream pipeline steps idempotent and avoids processing the same target file more than
-once through different spellings.
+once through different spellings, regardless of which selected pipeline definition is executed.
 
 Filesystem-identity eligibility checks are distinct from normalization. The pipeline engine performs
 the invocation-wide hard-link guard after processing-path selection. If multiple selected processing
@@ -457,6 +469,13 @@ keeps the same command-intent separation through
 \[`topmark.api.strip()`\][topmark.api.commands.pipeline.strip], and
 \[`topmark.api.probe()`\][topmark.api.commands.pipeline.probe].
 
+For path-processing commands, command applicability and pipeline selection are resolved before
+runtime execution. The selected
+\[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection] records the executable
+pipeline definition for that invocation, while \[`RunOptions`\][topmark.runtime.model.RunOptions]
+carries durable execution metadata such as pipeline kind, mutation mode, diff-view preservation,
+STDIN mode, writer behavior, and view-pruning policy onto processing contexts and reduced results.
+
 Important invariants:
 
 - [`check`](../usage/commands/check.md) may compare, render, plan, preview, and mutate headers when
@@ -555,8 +574,8 @@ This page focuses on cross-cutting architectural decisions such as registry desi
 layering, policy resolution, presentation boundaries, and the relationship between human-facing and
 machine-facing interfaces.
 
-- [`Pipelines (Concepts)`](./pipelines.md) - conceptual overview of pipeline structure, phases, and
-  step responsibilities
+- [`Pipelines (Concepts)`](./pipelines.md) - conceptual overview of the pipeline catalogue, pipeline
+  selection, phases, and step responsibilities
 - [`Pipelines (Reference)`](./pipelines-reference.md) - curated entry point into the generated
   internal API reference for pipelines and steps
 - [`Terminology and Canonical Vocabulary`](../terminology.md) - canonical definitions for stable
@@ -580,5 +599,5 @@ isolation, plugin extensibility, file type identifier semantics, and API stabili
 ______________________________________________________________________
 
 **Summary:** TopMark keeps stable user-facing behavior deterministic by separating configuration
-loading, registry composition, resolver decisions, policy resolution, pipeline execution,
-presentation, and machine-readable output into explicit layers.
+loading, registry composition, resolver decisions, policy resolution, pipeline selection, pipeline
+execution, presentation, and machine-readable output into explicit layers.

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -23,8 +23,8 @@ system.
 
 {% include-markdown "\_snippets/terminology.md" %}
 
-Pipelines operate on an immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig] plus runtime
-options assembled via the TOML → FrozenConfig → runtime flow.
+Pipeline execution operates on an immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig], a
+selected pipeline, and runtime options assembled via the TOML → FrozenConfig → runtime flow.
 
 Pipelines also operate on selected processing paths. Filesystem-identity evaluation occurs before
 ordinary pipeline execution begins and includes both processing-path normalization and
@@ -76,10 +76,14 @@ without relying on step-name string matching. The authoritative slot names are e
 
 The updated-file view may contain either a materialized line sequence or an implementation of the
 repeatable \[`UpdatedContent`\][topmark.pipeline.views.UpdatedContent] protocol. This allows
-pipeline steps to represent updated content without necessarily materializing a full replacement
-file image while still supporting repeated consumption by comparison, patch generation, and writing.
-`WriterStep` streams both file writes and STDOUT emission through the updated-line iterator;
-comparer and patcher materialization remain explicit algorithm-level ownership points.
+pipeline definitions and steps to represent updated content without necessarily materializing a full
+replacement file image while still supporting repeated consumption by comparison, patch generation,
+and writing.
+
+`WriterStep` streams both file writes and STDOUT emission through the updated-line iterator.
+`ComparerStep` and `PatcherStep` remain explicit algorithm-level materialization ownership points,
+while the pipeline catalogue and selection model remain agnostic to the concrete updated-content
+representation.
 
 {% include-markdown "\_snippets/config-strictness.md" %}
 
@@ -105,12 +109,23 @@ ______________________________________________________________________
 
 ## Canonical reference (generated)
 
+> [!NOTE]
+>
+> Pipeline execution distinguishes three related concepts:
+>
+> - `Pipeline`: stable catalogue key for a production pipeline variant
+> - `PipelineDefinition`: executable metadata and immutable step sequence
+> - `PipelineSelection`: invocation-specific selection of a concrete pipeline definition
+
 Use the links below (or the documentation search box) to navigate directly to the relevant internal
 API module.
 
 ### Pipeline definitions
 
-- Pipelines module (pipeline definitions and the `Pipeline` enum):
+- Pipelines module (\[`Pipeline`\][topmark.pipeline.pipelines.Pipeline],
+  \[`PipelineDefinition`\][topmark.pipeline.pipelines.PipelineDefinition],
+  \[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection], and the
+  \[`select_pipeline()`\][topmark.pipeline.pipelines.select_pipeline] pipeline selection helper):
   - [`topmark.pipeline.pipelines`](../api/internals/topmark/pipeline/pipelines.md)
 - Step protocol and base lifecycle contract:
   - [`topmark.pipeline.protocols`](../api/internals/topmark/pipeline/protocols.md)

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -12,13 +12,21 @@ topmark:header:end
 
 # Pipelines (Concepts)
 
-TopMark processes files through **explicit, immutable pipelines** composed of small,
-single-responsibility steps. Each pipeline represents a supported execution intent (scan, check,
-strip, apply, patch) and defines **exactly which steps run and in which order**.
+TopMark processes files through a **pipeline catalogue** of explicit, immutable pipeline variants
+composed of small, single-responsibility steps. Each pipeline definition records the selected
+variant's stable name, high-level family, step sequence, and basic capabilities such as whether it
+can mutate files or emit patch output.
 
 A dedicated **probe pipeline** exists for resolution diagnostics
 ([`topmark probe`](../usage/commands/probe.md)). Probe orchestration also reports explicit inputs
 filtered before file-type probing via synthetic probe contexts.
+
+At runtime, command intent is represented separately from the executable step sequence. CLI and API
+entry points first select a \[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection]
+from a high-level pipeline family (`check`, `strip`, or `probe`) plus invocation flags such as
+`--apply` and `--diff`. The selected pipeline then feeds
+\[`RunOptions`\][topmark.runtime.model.RunOptions], so mutation mode and diff-view preservation are
+derived from the selected pipeline instead of being repeated independently by each caller.
 
 Pipelines do not make high-level decisions themselves. Instead:
 
@@ -31,9 +39,12 @@ This design guarantees predictability, debuggability, and idempotence.
 
 {% include-markdown "\_snippets/terminology.md" %}
 
-Pipeline execution consumes an immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig] plus
-runtime options assembled from the TOML → FrozenConfig → runtime flow documented in
-[`Architecture`](architecture.md) and [`Configuration discovery`](../configuration/discovery.md).
+Pipeline execution consumes an immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig], a
+selected pipeline, and runtime options assembled from the TOML → FrozenConfig → runtime flow
+documented in [`Architecture`](architecture.md) and
+[`Configuration discovery`](../configuration/discovery.md). Pipeline selection determines which
+steps are executable for the invocation; runtime options capture execution-wide state that must be
+copied onto processing contexts and durable results.
 
 Pipeline execution also consumes a selected **processing path**. File-list resolution performs
 filesystem-identity evaluation before ordinary pipeline execution begins.
@@ -59,7 +70,10 @@ do not become layered configuration fields.
 This page explains **how the pipelines work** and how the CLI composes them. For the canonical,
 API-backed definitions of pipelines, steps, and enums, see:
 
-- **Pipelines reference hub:** [`Pipelines (Reference)`](./pipelines-reference.md)
+- **Pipelines reference hub:** [`Pipelines (Reference)`](./pipelines-reference.md), including the
+  generated \[`Pipeline`\][topmark.pipeline.pipelines.Pipeline],
+  \[`PipelineDefinition`\][topmark.pipeline.pipelines.PipelineDefinition], and
+  \[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection] API reference
 - **Internals (generated):**
   [`api/internals/topmark/pipeline/pipelines.md`](../api/internals/topmark/pipeline/pipelines.md)
 - **Architecture overview:** [`Architecture`](./architecture.md)
@@ -184,11 +198,16 @@ ______________________________________________________________________
 
 ## Available Pipelines
 
-Pipelines are defined in `src/topmark/pipeline/pipelines.py` and exposed via
-\[`topmark.pipeline.pipelines.Pipeline`\][topmark.pipeline.pipelines.Pipeline].
+Pipelines are defined in `src/topmark/pipeline/pipelines.py`. The
+\[`Pipeline`\][topmark.pipeline.pipelines.Pipeline] enum is the production catalogue key;
+\[`PipelineDefinition`\][topmark.pipeline.pipelines.PipelineDefinition] stores the executable
+metadata and immutable step sequence; and
+\[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection] records the concrete selection
+made for one invocation.
 
-The CLI selects among these immutable pipeline variants based on command intent and flags such as
-`--patch` and `--apply`.
+CLI and API entry points select among these immutable pipeline variants based on command intent and
+flags such as `--patch` and `--apply`. The selected pipeline is then passed through runtime and
+engine layers instead of passing a raw tuple of steps.
 
 ### PROBE
 
@@ -576,13 +595,17 @@ ______________________________________________________________________
 
 ## Key Design Guarantees
 
-- **Immutability:** Pipelines are `Final[tuple[Step, ...]]`
+- **Immutability:** Pipeline definitions expose immutable `tuple[Step, ...]` step sequences
 - **Determinism:** Same input → same outcome
 - **Processing-path identity:** pipeline steps operate on selected processing paths, not raw
   invocation spellings
 - **Filesystem-identity safety:** hard-linked selected processing paths are blocked before ordinary
   per-file step execution without choosing a preferred path
 - **Dry-run safety:** No writes without `--apply`
+- **Selection/runtime separation:**
+  \[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection] identifies the executable
+  pipeline variant, while \[`RunOptions`\][topmark.runtime.model.RunOptions] carries durable
+  invocation state onto processing contexts and results
 - **Separation of concerns:** Steps mutate context, views classify outcomes
 - **Runtime/configuration separation:** pipeline execution consumes resolved runtime configuration
   and runtime options rather than re-running TOML discovery during step execution
@@ -605,7 +628,8 @@ ______________________________________________________________________
   precedence
 
 This pipeline model is the backbone of TopMark's reliability and extensibility. New behavior is
-introduced by adding steps or composing new pipelines, not by special-casing control flow.
+introduced by adding steps, composing new pipeline definitions, or extending selection rules, not by
+special-casing control flow in CLI, API, or presentation layers.
 
 ______________________________________________________________________
 

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -177,7 +177,7 @@ package rather than a single monolithic core namespace. Shared envelope keys rem
 package-local schema modules such as:
 
 - \[`topmark.config.machine.schemas.ConfigKind`\][topmark.config.machine.schemas.ConfigKind]
-- \[`topmark.pipeline.machine.schemas.PipelineKind`\][topmark.pipeline.machine.schemas.PipelineKind]
+- \[`topmark.pipeline.machine.schemas.PipelineRecordKind`\][topmark.pipeline.machine.schemas.PipelineRecordKind]
 - \[`topmark.diagnostic.machine.schemas.DiagnosticKind`\][topmark.diagnostic.machine.schemas.DiagnosticKind]
 - \[`topmark.registry.machine.schemas.RegistryKind`\][topmark.registry.machine.schemas.RegistryKind]
 - \[`topmark.version.machine.schemas.VersionKind`\][topmark.version.machine.schemas.VersionKind]
@@ -267,6 +267,10 @@ The [`topmark probe`](../usage/commands/probe.md) command exposes stable file-ty
 resolution diagnostics. It is a diagnostic command, not a compliance or mutation command: it does
 not compute header changes, diffs, strip plans, or write plans.
 
+Internally, `probe` executes a dedicated read-only pipeline family that is separate from processing
+pipelines. This distinction is informational only: the machine-readable output contract remains the
+probe payloads documented below.
+
 Probe output reports canonical file type identities after identifier normalization and file-type
 filtering.
 
@@ -336,7 +340,7 @@ the `config_diagnostics` and `diagnostic` records, before any `probe` records ar
 
 The JSON `probes` key and NDJSON `probe` kind are defined in
 \[`topmark.pipeline.machine.schemas.PipelineKey`\][topmark.pipeline.machine.schemas.PipelineKey] and
-\[`topmark.pipeline.machine.schemas.PipelineKind`\][topmark.pipeline.machine.schemas.PipelineKind].
+\[`topmark.pipeline.machine.schemas.PipelineRecordKind`\][topmark.pipeline.machine.schemas.PipelineRecordKind].
 The NDJSON stream is produced by:
 
 - \[`topmark.pipeline.machine.envelopes.iter_probe_results_ndjson_records`\][topmark.pipeline.machine.envelopes.iter_probe_results_ndjson_records]
@@ -502,6 +506,11 @@ ______________________________________________________________________
 Processing commands produce either **detail** output (per-file results) or **summary** output
 (bucket counts), depending on whether the CLI is in `--summary` mode.
 
+Before execution begins, TopMark selects a concrete processing pipeline from the requested command
+family (`check` or `strip`) and invocation flags such as apply and diff mode. This selection is an
+internal execution-planning detail; machine-readable output exposes stable processing results rather
+than pipeline-selection metadata.
+
 Processing machine-readable output is unaffected by TEXT verbosity or quiet mode; those flags affect
 only human TEXT output.
 
@@ -658,6 +667,7 @@ At a high level, per-file results include:
   - `path` (selected processing path, serialized with POSIX `/` separators)
   - `file_type` (resolved canonical TopMark file type key, for example `topmark:python`)
 - pipeline execution:
+  - selected processing pipeline family (`check` or `strip`) when exposed through execution metadata
   - executed step names
   - per-axis status objects (`axis`, `name`, `label`)
 - derived intent/outcome helpers:

--- a/src/topmark/api/commands/pipeline.py
+++ b/src/topmark/api/commands/pipeline.py
@@ -30,10 +30,11 @@ from typing import TYPE_CHECKING
 
 from topmark.api.runtime import run_pipeline
 from topmark.api.runtime import run_probe_pipeline
-from topmark.api.runtime import select_pipeline
 from topmark.api.view import finalize_probe_result
 from topmark.api.view import finalize_run_result
 from topmark.core.errors import InvalidReportScopeError
+from topmark.pipeline.pipelines import PipelineSelection
+from topmark.pipeline.pipelines import select_pipeline
 from topmark.pipeline.reduction import reduce_processing_contexts
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.status import PlanStatus
@@ -50,9 +51,7 @@ if TYPE_CHECKING:
     from topmark.api.types import PublicPolicy
     from topmark.api.types import PublicReportScopeLiteral
     from topmark.api.types import RunResult
-    from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.kinds import PipelineKindLiteral
-    from topmark.pipeline.protocols import Step
 
 __all__ = (
     "check",
@@ -130,7 +129,7 @@ def check(
     """
     PIPELINE_KIND: PipelineKindLiteral = "check"
     # Choose the concrete content-processing pipeline variant.
-    pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
+    pipeline: PipelineSelection = select_pipeline(
         PIPELINE_KIND,
         apply=apply,
         diff=diff,
@@ -139,11 +138,9 @@ def check(
     # Run the pipeline; runtime helpers handle config discovery, policy overlays,
     # file-list resolution, per-path config, and pipeline execution.
 
-    run_options: RunOptions = RunOptions(
-        pipeline_kind=PIPELINE_KIND,
-        apply_changes=apply,
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        pipeline,
         prune_views=prune_views,
-        keep_diff_view=diff,
     )
 
     api_run: ApiPipelineRun = run_pipeline(
@@ -226,7 +223,7 @@ def strip(
     """
     PIPELINE_KIND: PipelineKindLiteral = "strip"
     # Choose the concrete content-processing pipeline variant.
-    pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
+    pipeline: PipelineSelection = select_pipeline(
         PIPELINE_KIND,
         apply=apply,
         diff=diff,
@@ -235,11 +232,9 @@ def strip(
     # Run the pipeline; runtime helpers handle config discovery, policy overlays,
     # file-list resolution, per-path config, and pipeline execution.
 
-    run_options: RunOptions = RunOptions(
-        pipeline_kind=PIPELINE_KIND,
-        apply_changes=apply,
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        pipeline,
         prune_views=prune_views,
-        keep_diff_view=diff,
     )
 
     api_run: ApiPipelineRun = run_pipeline(
@@ -318,7 +313,7 @@ def probe(
     """
     PIPELINE_KIND: PipelineKindLiteral = "probe"
     # Probe has a single read-only diagnostic pipeline.
-    pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
+    pipeline: PipelineSelection = select_pipeline(
         PIPELINE_KIND,
         apply=False,
         diff=False,
@@ -326,9 +321,8 @@ def probe(
     # Run the probe pipeline; runtime helpers also attach synthetic contexts for
     # missing literals and explicit inputs filtered before probing.
 
-    run_options: RunOptions = RunOptions(
-        pipeline_kind=PIPELINE_KIND,
-        apply_changes=False,
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        selection=pipeline,
         prune_views=prune_views,
     )
 

--- a/src/topmark/api/runtime.py
+++ b/src/topmark/api/runtime.py
@@ -54,7 +54,6 @@ from topmark.core.logging import get_logger
 from topmark.pipeline.engine import PipelineExecution
 from topmark.pipeline.engine import exit_code_from_pipeline_results
 from topmark.pipeline.engine import run_steps_for_files
-from topmark.pipeline.pipelines import Pipeline
 from topmark.pipeline.synthetic import build_filtered_probe_contexts
 from topmark.pipeline.synthetic import build_missing_file_contexts
 from topmark.resolution.files import probe_explicit_file_selection
@@ -73,8 +72,7 @@ if TYPE_CHECKING:
     from topmark.core.exit_codes import ExitCode
     from topmark.core.logging import TopmarkLogger
     from topmark.pipeline.context.model import ProcessingContext
-    from topmark.pipeline.kinds import PipelineKindLiteral
-    from topmark.pipeline.protocols import Step
+    from topmark.pipeline.pipelines import PipelineSelection
     from topmark.resolution.discovery import FileSelectionProbeResult
     from topmark.resolution.files import FileListResolution
     from topmark.runtime.model import RunOptions
@@ -453,54 +451,6 @@ def _apply_runtime_policy_overlays(
     return draft.freeze()
 
 
-def select_pipeline(
-    kind: PipelineKindLiteral,
-    *,
-    apply: bool,
-    diff: bool,
-) -> Sequence[Step[ProcessingContext]]:
-    """Return the concrete pipeline steps for the requested operation and mode.
-
-    Args:
-        kind: The pipeline family to use (`"probe"`, `"check"` or `"strip"`).
-        apply: If `True`, choose a mutating variant for commands that support mutation.
-            Ignored for `"probe"`, which is always read-only.
-        diff: If `True`, choose a patch-producing variant for commands that support diffs.
-            Ignored for `"probe"`, which does not produce content diffs.
-
-    Returns:
-        The ordered immutable sequence of steps to execute.
-
-    Raises:
-        RuntimeError: if an invalid pipeline kind was specified.
-    """
-    pipeline: Pipeline
-    match kind:
-        case "check":
-            if apply:  # Mutate files
-                pipeline = Pipeline.CHECK_APPLY_PATCH if diff else Pipeline.CHECK_APPLY
-            else:  # Dry-run
-                pipeline = Pipeline.CHECK_PATCH if diff else Pipeline.CHECK
-
-        case "strip":
-            if apply:  # Mutate files
-                pipeline = Pipeline.STRIP_APPLY_PATCH if diff else Pipeline.STRIP_APPLY
-            else:  # Dry-run
-                pipeline = Pipeline.STRIP_PATCH if diff else Pipeline.STRIP
-
-        case "probe":
-            # Probe has a single diagnostic pipeline. It never writes files and
-            # does not have patch/apply variants.
-            pipeline = Pipeline.PROBE
-
-        case _:
-            # Defensive guard:
-            raise RuntimeError(f"Invalid pipeline kind specified: {kind}")
-
-    logger.info("Selected pipeline: %r", pipeline)
-    return pipeline.steps
-
-
 def _resolve_public_header_mutation_mode(
     value: str,
 ) -> HeaderMutationMode:
@@ -674,7 +624,7 @@ def _prepare_api_pipeline_run(
 def _execute_pipeline_for_file_list(
     *,
     prepared: PreparedApiRun,
-    pipeline: Sequence[Step[ProcessingContext]],
+    pipeline: PipelineSelection,
 ) -> PipelineExecution:
     """Execute pipeline steps for the selected files in a prepared API run.
 
@@ -713,7 +663,7 @@ def _execute_pipeline_for_file_list(
 
 def run_pipeline(
     *,
-    pipeline: Sequence[Step[ProcessingContext]],
+    pipeline: PipelineSelection,
     paths: Iterable[Path | str],
     run_options: RunOptions,
     base_config: Mapping[str, object] | FrozenConfig | None,
@@ -775,7 +725,7 @@ def run_pipeline(
 
 def run_probe_pipeline(
     *,
-    pipeline: Sequence[Step[ProcessingContext]],
+    pipeline: PipelineSelection,
     paths: Iterable[Path | str],
     run_options: RunOptions,
     base_config: Mapping[str, object] | FrozenConfig | None,

--- a/src/topmark/cli/cmd_common.py
+++ b/src/topmark/cli/cmd_common.py
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
     from topmark.core.errors import ConfigValidationError
     from topmark.core.machine.schemas import MetaPayload
     from topmark.diagnostic.model import FrozenDiagnosticLog
-    from topmark.pipeline.kinds import PipelineKindLiteral
+    from topmark.pipeline.pipelines import PipelineSelection
     from topmark.toml.resolution import ResolvedTopmarkTomlSources
 
 
@@ -183,26 +183,28 @@ def build_file_resolution(
 
 def build_run_options(
     *,
-    pipeline_kind: PipelineKindLiteral | None,
-    apply_changes: bool,
+    pipeline: PipelineSelection,
     write_mode: str | None,
     stdin_mode: bool,
     stdin_filename: str | None,
     prune_views: bool = True,
-    keep_diff_view: bool = False,
 ) -> RunOptions:
-    """Build invocation-wide runtime options for a CLI command.
+    """Build invocation-wide runtime options for a pipeline CLI command.
+
+    This helper combines the selected pipeline with CLI-specific output routing
+    options. Pipeline-derived fields such as pipeline kind, mutation mode, and
+    diff-view preservation are copied from `pipeline` via
+    [`RunOptions.from_pipeline_selection`][topmark.runtime.model.RunOptions.from_pipeline_selection].
+    CLI-only choices such as STDIN mode, synthetic STDIN filename, write mode,
+    and view pruning remain explicit parameters here.
 
     Args:
-        pipeline_kind: The pipeline kind (`check`, `strip`, `probe`).
-        apply_changes: Whether the command should write changes.
+        pipeline: The selected pipeline, including the command family and
+            concrete execution flags chosen by pipeline selection.
         write_mode: Effective CLI write mode (`stdout`, `atomic`, or `inplace`).
         stdin_mode: Whether the command is operating in content-on-STDIN mode.
         stdin_filename: Synthetic file name associated with STDIN content, if any.
         prune_views: If True, release consumed volatile views between pipeline steps.
-        keep_diff_view: Whether to preserve the diff view during between-step pruning;
-            must be true for pipelines containing `PatcherStep` until reduction
-            snapshots `ProcessingDetailSnapshot.diff_text`.
 
     Returns:
         The execution-only runtime options for the current CLI invocation.
@@ -215,7 +217,7 @@ def build_run_options(
     output_target: OutputTarget | None = None
     file_write_strategy: FileWriteStrategy | None = None
 
-    if stdin_mode and apply_changes or write_mode == OutputTarget.STDOUT.value:
+    if (stdin_mode and pipeline.definition.mutates) or write_mode == OutputTarget.STDOUT.value:
         output_target = OutputTarget.STDOUT
         file_write_strategy = None
     elif write_mode == FileWriteStrategy.ATOMIC.value:
@@ -225,15 +227,13 @@ def build_run_options(
         output_target = OutputTarget.FILE
         file_write_strategy = FileWriteStrategy.INPLACE
 
-    run_options = RunOptions(
-        pipeline_kind=pipeline_kind,
-        apply_changes=apply_changes,
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        selection=pipeline,
         output_target=output_target,
         file_write_strategy=file_write_strategy,
         stdin_mode=stdin_mode,
         stdin_filename=stdin_filename,
         prune_views=prune_views,
-        keep_diff_view=keep_diff_view,
     )
 
     ctx: click.Context | None = click.get_current_context(silent=True)

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -54,7 +54,6 @@ import click
 import rich_click
 
 from topmark.api.runtime import ensure_config_valid
-from topmark.api.runtime import select_pipeline
 from topmark.cli.cmd_common import build_file_resolution
 from topmark.cli.cmd_common import build_resolved_toml_sources_and_config_for_plan
 from topmark.cli.cmd_common import build_run_options
@@ -104,6 +103,7 @@ from topmark.pipeline.context.model import ProcessingContext
 from topmark.pipeline.engine import PipelineExecution
 from topmark.pipeline.engine import exit_code_from_pipeline_results
 from topmark.pipeline.engine import run_steps_for_files
+from topmark.pipeline.pipelines import select_pipeline
 from topmark.pipeline.reduction import ProcessingReduction
 from topmark.pipeline.reduction import reduce_processing_contexts
 from topmark.pipeline.reporting import ReportFilterResult
@@ -137,7 +137,7 @@ if TYPE_CHECKING:
     from topmark.diagnostic.model import FrozenDiagnosticLog
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.kinds import PipelineKindLiteral
-    from topmark.pipeline.protocols import Step
+    from topmark.pipeline.pipelines import PipelineSelection
     from topmark.pipeline.result import ProcessingResult
     from topmark.resolution.files import FileListResolution
     from topmark.runtime.model import RunOptions
@@ -389,14 +389,19 @@ def check_command(
         relative_to=relative_to,
     )
 
+    # Select the concrete pipeline variant.
+    pipeline: PipelineSelection = select_pipeline(
+        PIPELINE_KIND,
+        apply=apply_changes,
+        diff=diff,
+    )
+
     run_options: RunOptions = build_run_options(
-        pipeline_kind=PIPELINE_KIND,
-        apply_changes=apply_changes,
+        pipeline=pipeline,
         write_mode=write_mode,
         stdin_mode=plan.stdin_mode,
         stdin_filename=plan.stdin_filename,
         prune_views=prune_views,
-        keep_diff_view=diff,
     )
 
     logger.debug("run options: %s", run_options)
@@ -477,13 +482,7 @@ def check_command(
         # Nothing to do
         return
 
-    # Choose and run the concrete pipeline variant.
-    pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
-        PIPELINE_KIND,
-        apply=apply_changes,
-        diff=diff,
-    )
-
+    # Run the concrete pipeline variant.
     pipeline_run: PipelineExecution = run_steps_for_files(
         run_options=run_options,
         config=config,

--- a/src/topmark/cli/commands/config_dump.py
+++ b/src/topmark/cli/commands/config_dump.py
@@ -32,7 +32,6 @@ import click
 import rich_click
 
 from topmark.cli.cmd_common import build_resolved_toml_sources_and_config_for_plan
-from topmark.cli.cmd_common import build_run_options
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_route_console_to_stderr
 from topmark.cli.emitters.machine import emit_config_machine
@@ -65,6 +64,7 @@ from topmark.presentation.markdown.diagnostic import render_diagnostics_markdown
 from topmark.presentation.shared.config import build_config_dump_human_report
 from topmark.presentation.text.config import render_config_dump_text
 from topmark.presentation.text.diagnostic import render_diagnostics_text
+from topmark.runtime.model import RunOptions
 from topmark.utils.file import safe_unlink
 
 if TYPE_CHECKING:
@@ -80,7 +80,6 @@ if TYPE_CHECKING:
     from topmark.core.machine.schemas import MetaPayload
     from topmark.diagnostic.model import FrozenDiagnosticLog
     from topmark.presentation.shared.config import ConfigDumpHumanReport
-    from topmark.runtime.model import RunOptions
 
 logger: TopmarkLogger = get_logger(__name__)
 
@@ -224,6 +223,9 @@ def config_dump_command(
     # Retrieve effective human facing program-output verbosity for gating extra details
     verbosity_level: int = state.verbosity
 
+    # Select the console
+    console: ConsoleProtocol = state.console
+
     # Machine metadata
     meta: MetaPayload = build_meta_payload()
 
@@ -266,12 +268,10 @@ def config_dump_command(
         relative_to=relative_to,
     )
 
-    run_options: RunOptions = build_run_options(
-        pipeline_kind=None,  # Not relevant for `config dump`
-        apply_changes=False,  # Not relevant for `config dump`
-        write_mode=None,  # Not relevant for `config dump`
+    # Config dump is not a pipeline command. Use minimal run options only to
+    # reuse stdout/stderr routing logic for STDIN-backed pattern-source input.
+    run_options: RunOptions = RunOptions(
         stdin_mode=plan.stdin_mode,
-        stdin_filename=plan.stdin_filename,
     )
 
     logger.debug("run options: %s", run_options)

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -87,7 +87,7 @@ from topmark.core.logging import get_logger
 from topmark.core.machine.payloads import build_meta_payload
 from topmark.pipeline.engine import exit_code_from_pipeline_results
 from topmark.pipeline.engine import run_steps_for_files
-from topmark.pipeline.pipelines import Pipeline
+from topmark.pipeline.pipelines import select_pipeline
 from topmark.pipeline.reduction import reduce_processing_contexts
 from topmark.pipeline.synthetic import build_filtered_probe_contexts
 from topmark.pipeline.synthetic import build_missing_file_contexts
@@ -101,7 +101,6 @@ from topmark.resolution.files import probe_explicit_file_selection
 from topmark.utils.file import safe_unlink
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from pathlib import Path
 
     from topmark.cli.console.color import ColorMode
@@ -115,7 +114,7 @@ if TYPE_CHECKING:
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.engine import PipelineExecution
     from topmark.pipeline.kinds import PipelineKindLiteral
-    from topmark.pipeline.protocols import Step
+    from topmark.pipeline.pipelines import PipelineSelection
     from topmark.pipeline.result import ProcessingResult
     from topmark.resolution.discovery import FileSelectionProbeResult
     from topmark.resolution.files import FileListResolution
@@ -305,9 +304,15 @@ def probe_command(
         relative_to=None,  # Not relevant for `topmark probe`
     )
 
+    # Select the concrete pipeline variant.
+    pipeline: PipelineSelection = select_pipeline(
+        PIPELINE_KIND,
+        apply=False,
+        diff=False,
+    )
+
     run_options: RunOptions = build_run_options(
-        pipeline_kind=PIPELINE_KIND,
-        apply_changes=False,  # Not relevant for `topmark probe`
+        pipeline=pipeline,
         write_mode=None,  # Not relevant for `topmark probe`
         stdin_mode=plan.stdin_mode,
         stdin_filename=plan.stdin_filename,
@@ -402,9 +407,7 @@ def probe_command(
         # Nothing to do
         return
 
-    # Choose and run the concrete pipeline variant.
-    pipeline: Sequence[Step[ProcessingContext]] = Pipeline.PROBE
-
+    # Run the concrete pipeline variant.
     pipeline_run: PipelineExecution = run_steps_for_files(
         run_options=run_options,
         config=config,

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -50,7 +50,6 @@ import click
 import rich_click
 
 from topmark.api.runtime import ensure_config_valid
-from topmark.api.runtime import select_pipeline
 from topmark.cli.cmd_common import build_file_resolution
 from topmark.cli.cmd_common import build_resolved_toml_sources_and_config_for_plan
 from topmark.cli.cmd_common import build_run_options
@@ -96,6 +95,7 @@ from topmark.core.machine.payloads import build_meta_payload
 from topmark.pipeline.engine import PipelineExecution
 from topmark.pipeline.engine import exit_code_from_pipeline_results
 from topmark.pipeline.engine import run_steps_for_files
+from topmark.pipeline.pipelines import select_pipeline
 from topmark.pipeline.reduction import ProcessingReduction
 from topmark.pipeline.reduction import reduce_processing_contexts
 from topmark.pipeline.reporting import ReportFilterResult
@@ -128,10 +128,11 @@ if TYPE_CHECKING:
     from topmark.diagnostic.model import FrozenDiagnosticLog
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.kinds import PipelineKindLiteral
-    from topmark.pipeline.protocols import Step
+    from topmark.pipeline.pipelines import PipelineSelection
     from topmark.pipeline.result import ProcessingResult
     from topmark.resolution.files import FileListResolution
     from topmark.runtime.model import RunOptions
+
 
 logger: TopmarkLogger = get_logger(__name__)
 
@@ -348,14 +349,19 @@ def strip_command(
         relative_to=None,  # Not relevant for `strip``
     )
 
+    # Select the concrete pipeline variant.
+    pipeline: PipelineSelection = select_pipeline(
+        PIPELINE_KIND,
+        apply=apply_changes,
+        diff=diff,
+    )
+
     run_options: RunOptions = build_run_options(
-        pipeline_kind=PIPELINE_KIND,
-        apply_changes=apply_changes,
+        pipeline=pipeline,
         write_mode=write_mode,
         stdin_mode=plan.stdin_mode,
         stdin_filename=plan.stdin_filename,
         prune_views=prune_views,
-        keep_diff_view=diff,
     )
 
     logger.debug("run options: %s", run_options)
@@ -436,13 +442,7 @@ def strip_command(
         # Nothing to do
         return
 
-    # Choose and run the concrete pipeline variant.
-    pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
-        PIPELINE_KIND,
-        apply=apply_changes,
-        diff=diff,
-    )
-
+    # Run the concrete pipeline variant.
     pipeline_run: PipelineExecution = run_steps_for_files(
         run_options=run_options,
         config=config,

--- a/src/topmark/pipeline/engine.py
+++ b/src/topmark/pipeline/engine.py
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
 
     from topmark.config.model import FrozenConfig
     from topmark.core.logging import TopmarkLogger
-    from topmark.pipeline.protocols import Step
+    from topmark.pipeline.pipelines import PipelineSelection
     from topmark.runtime.model import RunOptions
 
 logger: TopmarkLogger = get_logger(__name__)
@@ -265,7 +265,7 @@ def run_steps_for_files(
     run_options: RunOptions,
     config: FrozenConfig,
     path_configs: Mapping[Path, FrozenConfig] | None = None,
-    pipeline: Sequence[Step[ProcessingContext]],
+    pipeline: PipelineSelection,
     file_list: list[Path],
 ) -> PipelineExecution:
     """Run a pipeline for each file and return structured engine results.
@@ -343,7 +343,7 @@ def run_steps_for_files(
             )
             ctx_obj = runner.run(
                 ctx_obj,
-                pipeline,
+                pipeline.steps,
                 prune_views=run_options.prune_views,
                 keep_diff_view=run_options.keep_diff_view,
             )

--- a/src/topmark/pipeline/machine/envelopes.py
+++ b/src/topmark/pipeline/machine/envelopes.py
@@ -55,7 +55,7 @@ from topmark.pipeline.machine.payloads import iter_probe_results_payload_items
 from topmark.pipeline.machine.payloads import iter_processing_results_payload_items
 from topmark.pipeline.machine.payloads import iter_processing_results_summary_entries
 from topmark.pipeline.machine.schemas import PipelineKey
-from topmark.pipeline.machine.schemas import PipelineKind
+from topmark.pipeline.machine.schemas import PipelineRecordKind
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -158,7 +158,7 @@ def iter_probe_results_ndjson_records(
     # One probe record per context, including synthetic filtered contexts.
     for payload in iter_probe_results_payload_items(results):
         yield build_ndjson_record(
-            kind=PipelineKind.PROBE,
+            kind=PipelineRecordKind.PROBE,
             meta=meta,
             payload=payload,
         )
@@ -305,14 +305,14 @@ def iter_processing_results_ndjson_records(
             results,
         ):
             yield build_ndjson_record(
-                kind=PipelineKind.SUMMARY,
+                kind=PipelineRecordKind.SUMMARY,
                 meta=meta,
                 payload=record,
             )
     else:
         for r in results:
             yield build_ndjson_record(
-                kind=PipelineKind.RESULT,
+                kind=PipelineRecordKind.RESULT,
                 meta=meta,
                 payload=r.to_dict(),
             )

--- a/src/topmark/pipeline/machine/schemas.py
+++ b/src/topmark/pipeline/machine/schemas.py
@@ -36,7 +36,7 @@ fragments** (not full JSON/NDJSON envelopes):
       ```
 
 - **Probe output** uses `PipelineKey.PROBES` for the JSON `"probes"` collection and
-  `PipelineKind.PROBE` / `PipelineKey.PROBE` for one NDJSON `kind="probe"` record per
+  `PipelineRecordKind.PROBE` / `PipelineKey.PROBE` for one NDJSON `kind="probe"` record per
   probe result. Individual probe payloads are built from
   [`ResolutionProbeResult`][topmark.resolution.probe.ResolutionProbeResult], including
   filtered explicit inputs that never reached file-type probing.
@@ -74,8 +74,8 @@ class PipelineKey(str, Enum):
     SUMMARY = "summary"
 
 
-class PipelineKind(str, Enum):
-    """Stable NDJSON kinds emitted by the pipeline machine-readable output domain.
+class PipelineRecordKind(str, Enum):
+    """Stable NDJSON record kinds emitted by the pipeline machine-readable output domain.
 
     Attributes:
         PROBE: One per-path resolution probe record, including filtered explicit inputs.

--- a/src/topmark/pipeline/outcomes.py
+++ b/src/topmark/pipeline/outcomes.py
@@ -172,12 +172,12 @@ class SupportsOutcomeClassification(Protocol):
         ...
 
 
-class Intent(Enum):
-    """High-level action intent inferred from pipeline status.
+class ResultActionIntent(str, Enum):
+    """Per-result action intent inferred from pipeline status.
 
-    Intent is a small internal classification used by `map_bucket()` to decide
-    whether a detected change should be reported as an insert, update, strip,
-    or a more generic change.
+    `ResultActionIntent` is a small internal classification used by
+    `map_bucket()` to decide whether a detected change should be reported as an
+    insert, update, strip, or a more generic change.
 
     This is intentionally derived from status axes rather than from the chosen
     pipeline name so that bucketing remains robust across pipeline variants.
@@ -189,8 +189,10 @@ class Intent(Enum):
     NONE = "none"  # insufficient information to infer a concrete action
 
 
-def determine_intent(ctx: SupportsOutcomeClassification) -> Intent:
-    """Infer the high-level action intent from the current context.
+def determine_result_action_intent(
+    ctx: SupportsOutcomeClassification,
+) -> ResultActionIntent:
+    """Infer the per-result action intent from the current context.
 
     The inferred intent is used only for public bucketing. It is intentionally
     derived from status axes so that it still works when different pipeline
@@ -207,15 +209,15 @@ def determine_intent(ctx: SupportsOutcomeClassification) -> Intent:
         ctx: The processing context.
 
     Returns:
-        The inferred bucketing intent.
+        The inferred bucketing action intent.
     """
     if ctx.status.strip != StripStatus.PENDING:
-        return Intent.STRIP
+        return ResultActionIntent.STRIP
     if ctx.status.header == HeaderStatus.MISSING:
-        return Intent.INSERT
+        return ResultActionIntent.INSERT
     if ctx.status.header != HeaderStatus.PENDING:
-        return Intent.UPDATE
-    return Intent.NONE
+        return ResultActionIntent.UPDATE
+    return ResultActionIntent.NONE
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -289,7 +291,7 @@ def map_bucket(
     Returns:
         Bucket containing public Outcome and a human label.
     """
-    intent: Intent = determine_intent(ctx)
+    intent: ResultActionIntent = determine_result_action_intent(ctx)
     logger.trace("intent: %s; apply: %s; status: %s", intent.value, apply, ctx.status)
 
     def ret(
@@ -393,7 +395,7 @@ def map_bucket(
         )
 
     # 4) Strip mapping (strip pipelines may omit comparer; do not depend on comparison)
-    if intent == Intent.STRIP:
+    if intent == ResultActionIntent.STRIP:
         if ctx.status.strip == StripStatus.READY:
             return ret(
                 debug_tag="strip:ready",
@@ -438,9 +440,9 @@ def map_bucket(
     strip_lbl: str = ctx.status.strip.value
 
     # Helper for constructing the most specific reason for a detected change.
-    def changed_reason_for(current_intent: Intent) -> str:
+    def changed_reason_for(current_intent: ResultActionIntent) -> str:
         """Return the most specific human-facing reason for a detected change."""
-        if current_intent == Intent.STRIP:
+        if current_intent == ResultActionIntent.STRIP:
             return f"{header_lbl}, {strip_lbl}"
         return f"{header_lbl}, {comparison_lbl}"
 
@@ -455,20 +457,20 @@ def map_bucket(
     # Compute the Outcome value for a change (only meaningful when change is intended/detected).
     outcome_if_changed: Outcome
     if apply:
-        if intent == Intent.STRIP:
+        if intent == ResultActionIntent.STRIP:
             outcome_if_changed = Outcome.STRIPPED
-        elif intent == Intent.INSERT:
+        elif intent == ResultActionIntent.INSERT:
             outcome_if_changed = Outcome.INSERTED
-        elif intent == Intent.UPDATE:
+        elif intent == ResultActionIntent.UPDATE:
             outcome_if_changed = Outcome.UPDATED
         else:
             outcome_if_changed = Outcome.CHANGED
     else:
-        if intent == Intent.STRIP:
+        if intent == ResultActionIntent.STRIP:
             outcome_if_changed = Outcome.WOULD_STRIP
-        elif intent == Intent.INSERT:
+        elif intent == ResultActionIntent.INSERT:
             outcome_if_changed = Outcome.WOULD_INSERT
-        elif intent == Intent.UPDATE:
+        elif intent == ResultActionIntent.UPDATE:
             outcome_if_changed = Outcome.WOULD_UPDATE
         else:
             outcome_if_changed = Outcome.WOULD_CHANGE
@@ -498,9 +500,11 @@ def map_bucket(
     if ctx.status.comparison == ComparisonStatus.CHANGED:
         return ret(
             debug_tag="changed:strip"
-            if intent == Intent.STRIP
+            if intent == ResultActionIntent.STRIP
             else (
-                "changed:header" if intent in (Intent.INSERT, Intent.UPDATE) else "changed:generic"
+                "changed:header"
+                if intent in (ResultActionIntent.INSERT, ResultActionIntent.UPDATE)
+                else "changed:generic"
             ),
             outcome=outcome_if_changed,
             reason=reason_if_changed,
@@ -510,7 +514,7 @@ def map_bucket(
     # These branches matter most for summary/dry-run pipelines where later mutation
     # steps (planner/writer) may not have run.
     if not apply:
-        if intent in (Intent.INSERT, Intent.UPDATE):
+        if intent in (ResultActionIntent.INSERT, ResultActionIntent.UPDATE):
             if ctx.outcome.effective_would_add_or_update:
                 return ret(
                     debug_tag="would-change:header",
@@ -522,7 +526,7 @@ def map_bucket(
                 outcome=outcome_if_changed,
                 reason=header_lbl,
             )
-        if intent == Intent.STRIP:
+        if intent == ResultActionIntent.STRIP:
             if ctx.outcome.effective_would_strip:
                 # Prefer the strip axis label for summaries.
                 return ret(

--- a/src/topmark/pipeline/pipelines.py
+++ b/src/topmark/pipeline/pipelines.py
@@ -73,11 +73,12 @@ Notes:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING
 from typing import Final
 
-from topmark.pipeline.context.model import ProcessingContext
-from topmark.pipeline.protocols import Step
+from topmark.core.logging import get_logger
 from topmark.pipeline.steps import builder
 from topmark.pipeline.steps import comparer
 from topmark.pipeline.steps import patcher
@@ -90,6 +91,22 @@ from topmark.pipeline.steps import scanner
 from topmark.pipeline.steps import sniffer
 from topmark.pipeline.steps import stripper
 from topmark.pipeline.steps import writer
+
+if TYPE_CHECKING:
+    from topmark.core.logging import TopmarkLogger
+    from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.kinds import PipelineKindLiteral
+    from topmark.pipeline.protocols import Step
+
+
+logger: TopmarkLogger = get_logger(__name__)
+
+__all__ = (
+    "Pipeline",
+    "PipelineDefinition",
+    "PipelineSelection",
+    "select_pipeline",
+)
 
 PROBE_PIPELINE: Final[tuple[Step[ProcessingContext], ...]] = (
     prober.ProberStep(),  # Probe file type/processor resolution and halt.
@@ -158,35 +175,260 @@ STRIP_APPLY_PATCH_PIPELINE: Final[tuple[Step[ProcessingContext], ...]] = STRIP_P
 )
 
 
-class Pipeline(tuple[Step[ProcessingContext], ...], Enum):
-    """Available execution pipelines for file processing, mapped to their step sequences."""
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PipelineDefinition:
+    """Concrete executable pipeline definition.
 
-    # Note: Enum members use underscores instead of hyphens for valid Python identifiers.
+    Attributes:
+        name: Stable internal variant name.
+        family: High-level pipeline family represented by this variant, or
+            `None` for reusable internal building blocks such as `scan`.
+        steps: Concrete ordered step sequence for execution.
+        mutates: Whether this variant can write file/stdout content.
+        emits_patch: Whether this variant can emit unified-diff patch output.
+    """
 
-    PROBE = PROBE_PIPELINE
+    name: str
+    family: PipelineKindLiteral | None
+    steps: tuple[Step[ProcessingContext], ...]
+    mutates: bool = False
+    emits_patch: bool = False
 
-    SCAN = SCAN_PIPELINE
-    CHECK_RENDER = CHECK_RENDER_PIPELINE
 
-    # "check" maps to the summary pipeline in the current PIPELINES dict
-    CHECK = CHECK_SUMMMARY_PIPELINE
-    CHECK_APPLY = CHECK_APPLY_PIPELINE
-    CHECK_APPLY_PATCH = CHECK_APPLY_PATCH_PIPELINE
-    CHECK_PATCH = CHECK_PATCH_PIPELINE
+class Pipeline(str, Enum):
+    """Available named pipeline variants for file processing.
 
-    # "strip" maps to the summary pipeline in the current PIPELINES dict
-    STRIP = STRIP_PIPELINE
-    STRIP_APPLY = STRIP_APPLY_PIPELINE
-    STRIP_APPLY_PATCH = STRIP_APPLY_PATCH_PIPELINE
-    STRIP_PATCH = STRIP_PATCH_PIPELINE
+    Enum values are stable internal variant identifiers. Rich execution metadata
+    is provided by [`PipelineDefinition`][topmark.pipeline.pipelines.PipelineDefinition]
+    through the [`definition`][topmark.pipeline.pipelines.Pipeline.definition]
+    property.
+    """
+
+    PROBE = "probe"
+    SCAN = "scan"
+    CHECK_RENDER = "check-render"
+    CHECK = "check"
+    CHECK_APPLY = "check-apply"
+    CHECK_APPLY_PATCH = "check-apply-patch"
+    CHECK_PATCH = "check-patch"
+    STRIP = "strip"
+    STRIP_APPLY = "strip-apply"
+    STRIP_APPLY_PATCH = "strip-apply-patch"
+    STRIP_PATCH = "strip-patch"
+
+    @property
+    def definition(self) -> PipelineDefinition:
+        """Return the rich catalogue definition for this pipeline variant.
+
+        Returns:
+            The immutable pipeline definition registered for this variant.
+        """
+        return PIPELINE_DEFINITIONS[self]
 
     @property
     def steps(self) -> tuple[Step[ProcessingContext], ...]:
         """Return the instantiated, ordered step sequence for this pipeline.
 
         Returns:
-            tuple[Step, ...]: An immutable tuple of step *instances* that
-            implement the [`Step`][topmark.pipeline.protocols.Step] protocol. The
-            runner will invoke them as callables in order.
+            An immutable tuple of step instances that implement the
+            [`Step`][topmark.pipeline.protocols.Step] protocol. The runner will
+            invoke them as callables in order.
         """
-        return self.value
+        return self.definition.steps
+
+    @property
+    def family(self) -> PipelineKindLiteral | None:
+        """Return the high-level invocation family for this variant, if any.
+
+        Returns:
+            The pipeline family, or `None` for internal reusable variants.
+        """
+        return self.definition.family
+
+    @property
+    def mutates(self) -> bool:
+        """Return whether this pipeline variant can mutate content.
+
+        Returns:
+            True when the variant includes a writer step.
+        """
+        return self.definition.mutates
+
+    @property
+    def emits_patch(self) -> bool:
+        """Return whether this pipeline variant can emit patch output.
+
+        Returns:
+            True when the variant includes a patcher step.
+        """
+        return self.definition.emits_patch
+
+
+PIPELINE_DEFINITIONS: Final[dict[Pipeline, PipelineDefinition]] = {
+    Pipeline.PROBE: PipelineDefinition(
+        name=Pipeline.PROBE.value,
+        family="probe",
+        steps=PROBE_PIPELINE,
+    ),
+    Pipeline.SCAN: PipelineDefinition(
+        name=Pipeline.SCAN.value,
+        family=None,
+        steps=SCAN_PIPELINE,
+    ),
+    Pipeline.CHECK_RENDER: PipelineDefinition(
+        name=Pipeline.CHECK_RENDER.value,
+        family="check",
+        steps=CHECK_RENDER_PIPELINE,
+    ),
+    Pipeline.CHECK: PipelineDefinition(
+        name=Pipeline.CHECK.value,
+        family="check",
+        steps=CHECK_SUMMMARY_PIPELINE,
+    ),
+    Pipeline.CHECK_APPLY: PipelineDefinition(
+        name=Pipeline.CHECK_APPLY.value,
+        family="check",
+        steps=CHECK_APPLY_PIPELINE,
+        mutates=True,
+    ),
+    Pipeline.CHECK_APPLY_PATCH: PipelineDefinition(
+        name=Pipeline.CHECK_APPLY_PATCH.value,
+        family="check",
+        steps=CHECK_APPLY_PATCH_PIPELINE,
+        mutates=True,
+        emits_patch=True,
+    ),
+    Pipeline.CHECK_PATCH: PipelineDefinition(
+        name=Pipeline.CHECK_PATCH.value,
+        family="check",
+        steps=CHECK_PATCH_PIPELINE,
+        emits_patch=True,
+    ),
+    Pipeline.STRIP: PipelineDefinition(
+        name=Pipeline.STRIP.value,
+        family="strip",
+        steps=STRIP_PIPELINE,
+    ),
+    Pipeline.STRIP_APPLY: PipelineDefinition(
+        name=Pipeline.STRIP_APPLY.value,
+        family="strip",
+        steps=STRIP_APPLY_PIPELINE,
+        mutates=True,
+    ),
+    Pipeline.STRIP_APPLY_PATCH: PipelineDefinition(
+        name=Pipeline.STRIP_APPLY_PATCH.value,
+        family="strip",
+        steps=STRIP_APPLY_PATCH_PIPELINE,
+        mutates=True,
+        emits_patch=True,
+    ),
+    Pipeline.STRIP_PATCH: PipelineDefinition(
+        name=Pipeline.STRIP_PATCH.value,
+        family="strip",
+        steps=STRIP_PATCH_PIPELINE,
+        emits_patch=True,
+    ),
+}
+"""Catalogue of available named pipeline variants."""
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PipelineSelection:
+    """Concrete pipeline selected for a high-level invocation.
+
+    Attributes:
+        kind: High-level pipeline family requested by the caller.
+        apply: Whether the invocation allows mutation. This is retained even
+            when the selected kind ignores it, such as `probe`.
+        diff: Whether the invocation requested patch/diff output. This is
+            retained even when the selected kind ignores it, such as `probe`.
+        definition: Concrete executable pipeline definition selected for this
+            invocation.
+    """
+
+    kind: PipelineKindLiteral
+    apply: bool
+    diff: bool
+    definition: PipelineDefinition
+
+    def __post_init__(self) -> None:
+        """Validate that the selected definition matches the invocation family.
+
+        Raises:
+            ValueError: If the selected definition declares a different concrete
+                pipeline family than the requested invocation kind.
+        """
+        if self.definition.family is None:
+            return
+        if self.definition.family != self.kind:
+            msg: str = (
+                "Pipeline definition family does not match selection kind: "
+                f"{self.definition.family!r} != {self.kind!r}"
+            )
+            raise ValueError(msg)
+
+    @property
+    def steps(self) -> tuple[Step[ProcessingContext], ...]:
+        """Return the immutable step sequence for the selected pipeline.
+
+        Returns:
+            Concrete ordered pipeline steps ready for execution by the pipeline
+            engine.
+        """
+        return self.definition.steps
+
+
+def select_pipeline(
+    kind: PipelineKindLiteral,
+    *,
+    apply: bool,
+    diff: bool,
+) -> PipelineSelection:
+    """Select a concrete pipeline variant for the requested invocation.
+
+    Args:
+        kind: Pipeline family to use: `"probe"`, `"check"`, or `"strip"`.
+        apply: Whether to choose a mutating variant for pipeline families that
+            support mutation. Ignored for `"probe"`, which is always read-only.
+        diff: Whether to choose a patch-producing variant for pipeline families
+            that support diffs. Ignored for `"probe"`, which does not produce
+            content diffs.
+
+    Returns:
+        The selected concrete pipeline variant together with the invocation
+        flags that led to the selection.
+
+    Raises:
+        RuntimeError: If an invalid pipeline kind was specified.
+    """
+    pipeline: Pipeline
+    match kind:
+        case "check":
+            if apply:  # Mutate files
+                pipeline = Pipeline.CHECK_APPLY_PATCH if diff else Pipeline.CHECK_APPLY
+            else:  # Dry-run
+                pipeline = Pipeline.CHECK_PATCH if diff else Pipeline.CHECK
+
+        case "strip":
+            if apply:  # Mutate files
+                pipeline = Pipeline.STRIP_APPLY_PATCH if diff else Pipeline.STRIP_APPLY
+            else:  # Dry-run
+                pipeline = Pipeline.STRIP_PATCH if diff else Pipeline.STRIP
+
+        case "probe":
+            # Probe has a single diagnostic pipeline. It never writes files and
+            # does not have patch/apply variants.
+            pipeline = Pipeline.PROBE
+
+        case _:
+            # Defensive guard:
+            raise RuntimeError(f"Invalid pipeline kind specified: {kind}")
+
+    selection = PipelineSelection(
+        kind=kind,
+        apply=apply,
+        diff=diff,
+        definition=pipeline.definition,
+    )
+    logger.info("Selected pipeline: %s", selection.definition.name)
+    return selection

--- a/src/topmark/pipeline/protocols.py
+++ b/src/topmark/pipeline/protocols.py
@@ -38,12 +38,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Protocol
-from typing import TypeAlias
 from typing import TypeVar
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from topmark.pipeline.hints import Axis
     from topmark.pipeline.views import ViewSlot
 
@@ -114,25 +111,4 @@ class Step(Protocol[Ctx]):
         Returns:
             The same context object, for chaining.
         """
-        ...
-
-
-AnyStep: TypeAlias = Step[object]
-
-
-class StepContext(Protocol):
-    """Minimum context surface required by the step lifecycle (BaseStep/runner)."""
-
-    @property
-    def steps(self) -> Sequence[AnyStep]:
-        """Executed steps (context type not relevant here)."""
-        ...
-
-    def request_halt(self, reason: str, at_step: AnyStep) -> None:
-        """Record an early halt requested by a step."""
-        ...
-
-    @property
-    def is_halted(self) -> bool:
-        """Return True if a step has requested an early halt for this file."""
         ...

--- a/src/topmark/presentation/markdown/pipeline.py
+++ b/src/topmark/presentation/markdown/pipeline.py
@@ -31,10 +31,10 @@ from topmark.cli.errors import TopmarkCliPipelineError
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.core.logging import get_logger
-from topmark.pipeline.outcomes import Intent
+from topmark.pipeline.outcomes import ResultActionIntent
 from topmark.pipeline.outcomes import ResultBucket
 from topmark.pipeline.outcomes import collect_outcome_reason_counts
-from topmark.pipeline.outcomes import determine_intent
+from topmark.pipeline.outcomes import determine_result_action_intent
 from topmark.pipeline.outcomes import map_bucket
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.status import HeaderStatus
@@ -175,7 +175,7 @@ def _render_check_guidance_message_markdown(
     apply_changes: bool | None = result.execution_mode.apply_changes
 
     path_label: str = render_path_display_markdown(result)
-    intent: Intent = determine_intent(result)
+    intent: ResultActionIntent = determine_result_action_intent(result)
 
     if apply_changes:
         if result.status.write == WriteStatus.FAILED:
@@ -193,9 +193,9 @@ def _render_check_guidance_message_markdown(
 
     apply_cmd: str = _render_apply_command_markdown(command=CliCmd.CHECK, result=result)
 
-    if intent == Intent.INSERT:
+    if intent == ResultActionIntent.INSERT:
         action: str = "add a TopMark header to this file"
-    elif intent == Intent.UPDATE:
+    elif intent == ResultActionIntent.UPDATE:
         action = "update the TopMark header in this file"
     else:
         raise TopmarkCliPipelineError(
@@ -226,7 +226,7 @@ def _render_strip_guidance_message_markdown(
     apply_changes: bool | None = result.execution_mode.apply_changes
 
     path_label: str = render_path_display_markdown(result)
-    intent: Intent = determine_intent(result)
+    intent: ResultActionIntent = determine_result_action_intent(result)
 
     if apply_changes:
         if result.status.write == WriteStatus.FAILED:
@@ -240,7 +240,7 @@ def _render_strip_guidance_message_markdown(
 
     apply_cmd: str = _render_apply_command_markdown(command=CliCmd.STRIP, result=result)
 
-    if intent == Intent.STRIP:
+    if intent == ResultActionIntent.STRIP:
         action: str = "strip the TopMark header from this file"
     else:
         raise TopmarkCliPipelineError(

--- a/src/topmark/presentation/text/pipeline.py
+++ b/src/topmark/presentation/text/pipeline.py
@@ -42,9 +42,9 @@ from topmark.cli.rendering.unified_diff import format_patch_styled
 from topmark.core.logging import get_logger
 from topmark.core.presentation import StyleRole
 from topmark.pipeline.hints import Cluster
-from topmark.pipeline.outcomes import Intent
+from topmark.pipeline.outcomes import ResultActionIntent
 from topmark.pipeline.outcomes import ResultBucket
-from topmark.pipeline.outcomes import determine_intent
+from topmark.pipeline.outcomes import determine_result_action_intent
 from topmark.pipeline.outcomes import map_bucket
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.status import HeaderStatus
@@ -241,7 +241,7 @@ def _render_check_guidance_message_text(
     apply_changes: bool | None = result.execution_mode.apply_changes
 
     path_label: str = render_path_display_text(result)
-    intent: Intent = determine_intent(result)
+    intent: ResultActionIntent = determine_result_action_intent(result)
 
     if apply_changes:
         if result.status.write == WriteStatus.FAILED:
@@ -259,9 +259,9 @@ def _render_check_guidance_message_text(
 
     apply_cmd: str = _render_apply_command_text(command=CliCmd.CHECK, result=result)
 
-    if intent == Intent.INSERT:
+    if intent == ResultActionIntent.INSERT:
         action: str = "add a TopMark header to this file"
-    elif intent == Intent.UPDATE:
+    elif intent == ResultActionIntent.UPDATE:
         action = "update the TopMark header in this file"
     else:
         raise TopmarkCliPipelineError(
@@ -291,7 +291,7 @@ def _render_strip_guidance_message_text(
     apply_changes: bool | None = result.execution_mode.apply_changes
 
     path_label: str = render_path_display_text(result)
-    intent: Intent = determine_intent(result)
+    intent: ResultActionIntent = determine_result_action_intent(result)
 
     if apply_changes:
         if result.status.write == WriteStatus.FAILED:
@@ -305,7 +305,7 @@ def _render_strip_guidance_message_text(
 
     apply_cmd: str = _render_apply_command_text(command=CliCmd.STRIP, result=result)
 
-    if intent == Intent.STRIP:
+    if intent == ResultActionIntent.STRIP:
         action: str = "strip the TopMark header from this file"
     else:
         raise TopmarkCliPipelineError(

--- a/src/topmark/runtime/model.py
+++ b/src/topmark/runtime/model.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field
 from typing import TYPE_CHECKING
+from typing import Protocol
 
 from topmark.utils.timestamp import get_utc_now
 
@@ -33,6 +34,31 @@ if TYPE_CHECKING:
     from topmark.config.types import FileWriteStrategy
     from topmark.config.types import OutputTarget
     from topmark.pipeline.kinds import PipelineKindLiteral
+
+
+class _PipelineSelectionLike(Protocol):
+    """Structural subset of pipeline selection data needed by `RunOptions`.
+
+    The runtime model deliberately avoids importing
+    [`PipelineSelection`][topmark.pipeline.pipelines.PipelineSelection] so that
+    execution-only runtime state does not depend on the concrete pipeline
+    catalogue or step modules.
+    """
+
+    @property
+    def kind(self) -> PipelineKindLiteral:
+        """Pipeline kind."""
+        ...
+
+    @property
+    def apply(self) -> bool:
+        """Whether the pipeline should write changes."""
+        ...
+
+    @property
+    def diff(self) -> bool:
+        """Whether the pipeline generates a diff."""
+        ...
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -67,3 +93,58 @@ class RunOptions:
     keep_diff_view: bool = False
 
     started_at: datetime = field(default_factory=get_utc_now)
+
+    @classmethod
+    def from_pipeline_selection(
+        cls,
+        selection: _PipelineSelectionLike,
+        *,
+        output_target: OutputTarget | None = None,
+        file_write_strategy: FileWriteStrategy | None = None,
+        stdin_mode: bool = False,
+        stdin_filename: str | None = None,
+        prune_views: bool = True,
+        started_at: datetime | None = None,
+    ) -> RunOptions:
+        """Build runtime options from a selected pipeline.
+
+        This helper keeps duplicated invocation state synchronized between a
+        selected pipeline and `RunOptions` without importing the concrete
+        pipeline catalogue into the runtime model. Pipeline selection remains
+        the short-lived executable choice, while `RunOptions` remains the
+        durable runtime state copied onto processing contexts and reduced into
+        processing results.
+
+        The selected pipeline supplies the overlapping execution intent:
+        `selection.kind` becomes `pipeline_kind`, `selection.apply` becomes
+        `apply_changes`, and `selection.diff` becomes `keep_diff_view`. In other
+        words, mutation mode and diff-view preservation are derived from the
+        selected pipeline rather than repeated by the caller.
+
+        Args:
+            selection: Selected pipeline data exposing the pipeline kind,
+                mutation flag, and diff-preservation flag.
+            output_target: Where output should be emitted for this run.
+            file_write_strategy: How file writes should be performed when
+                `output_target` targets files.
+            stdin_mode: Whether content is being provided on stdin for this run.
+            stdin_filename: Synthetic filename associated with stdin content.
+            prune_views: If True, release consumed volatile views between pipeline steps.
+            started_at: Optional timestamp captured once for the whole run. When
+                omitted, the normal `RunOptions` timestamp factory is used.
+
+        Returns:
+            Runtime options whose overlapping fields are derived from
+            `selection`.
+        """
+        return cls(
+            pipeline_kind=selection.kind,
+            apply_changes=selection.apply,
+            stdin_mode=stdin_mode,
+            stdin_filename=stdin_filename,
+            output_target=output_target,
+            file_write_strategy=file_write_strategy,
+            prune_views=prune_views,
+            keep_diff_view=selection.diff,
+            started_at=started_at or get_utc_now(),
+        )

--- a/tests/helpers/api.py
+++ b/tests/helpers/api.py
@@ -31,18 +31,17 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from topmark import api
-from topmark.api.runtime import select_pipeline
 from topmark.config.model import MutableConfig
 from topmark.config.resolution.bridge import resolve_toml_sources_and_build_mutable_config
 from topmark.pipeline.engine import PipelineExecution
 from topmark.pipeline.engine import run_steps_for_files
+from topmark.pipeline.pipelines import select_pipeline
 from topmark.resolution.files import resolve_file_list_with_diagnostics
 from topmark.runtime.model import RunOptions
 from topmark.toml.keys import Toml
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from collections.abc import Sequence
     from pathlib import Path
 
     from topmark.api.types import PublicPolicy
@@ -52,7 +51,7 @@ if TYPE_CHECKING:
     from topmark.config.resolution.bridge import ResolvedConfigDraft
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.kinds import PipelineKindLiteral
-    from topmark.pipeline.protocols import Step
+    from topmark.pipeline.pipelines import PipelineSelection
     from topmark.toml.types import TomlValue
 
 
@@ -262,12 +261,15 @@ def run_cli_like(
 
     cfg: FrozenConfig = draft.freeze()
     files: list[Path] = list(resolve_file_list_with_diagnostics(cfg).selected)
-    run_options: RunOptions = RunOptions(
-        apply_changes=apply,
+    pipeline: PipelineSelection = select_pipeline(
+        kind,
+        apply=apply,
+        diff=diff,
+    )
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        pipeline,
         prune_views=prune_views,
     )
-
-    pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(kind, apply=apply, diff=diff)
     pipeline_run: PipelineExecution = run_steps_for_files(
         run_options=run_options,
         config=cfg,

--- a/tests/helpers/pipeline.py
+++ b/tests/helpers/pipeline.py
@@ -38,6 +38,8 @@ from topmark.core.constants import STANDARD_NEWLINES
 from topmark.pipeline.context.model import ProcessingContext
 from topmark.pipeline.pipelines import CHECK_PATCH_PIPELINE
 from topmark.pipeline.pipelines import CHECK_SUMMMARY_PIPELINE
+from topmark.pipeline.pipelines import PipelineDefinition
+from topmark.pipeline.pipelines import PipelineSelection
 from topmark.pipeline.status import ContentStatus
 from topmark.pipeline.status import FsStatus
 from topmark.pipeline.status import ResolveStatus
@@ -64,6 +66,20 @@ if TYPE_CHECKING:
     from topmark.pipeline.protocols import Step
     from topmark.processors.base import HeaderProcessor
 
+TEST_NOOP_PIPELINE_DEFINITION: PipelineDefinition = PipelineDefinition(
+    name="test-noop",
+    family=None,
+    steps=(),
+)
+"""No-op pipeline definition for engine tests that exercise setup behavior only."""
+
+TEST_NOOP_PIPELINE_SELECTION: PipelineSelection = PipelineSelection(
+    kind="check",
+    apply=False,
+    diff=False,
+    definition=TEST_NOOP_PIPELINE_DEFINITION,
+)
+"""No-op pipeline selection for engine tests that exercise setup behavior only."""
 
 # Common step chains used by tests
 SCAN_STEPS: list[Step[ProcessingContext]] = [

--- a/tests/pipeline/integration/test_nested_config_e2e.py
+++ b/tests/pipeline/integration/test_nested_config_e2e.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from topmark.api.runtime import run_pipeline
-from topmark.pipeline.pipelines import Pipeline
+from topmark.pipeline.pipelines import select_pipeline
 from topmark.runtime.model import RunOptions
 
 if TYPE_CHECKING:
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
     from topmark.api.types import ApiPipelineRun
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.pipelines import PipelineSelection
 
 
 def _write(path: Path, content: str) -> None:
@@ -70,9 +71,16 @@ def test_nested_config_applies_only_within_its_subtree(tmp_path: Path) -> None:
     pkg_file.write_text("print('pkg')\n", encoding="utf-8")
     docs_file.write_text("print('docs')\n", encoding="utf-8")
 
-    run_options = RunOptions(apply_changes=False)
+    pipeline: PipelineSelection = select_pipeline(
+        "check",
+        apply=False,
+        diff=False,
+    )
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        selection=pipeline,
+    )
     api_run: ApiPipelineRun = run_pipeline(
-        pipeline=Pipeline.CHECK.steps,
+        pipeline=pipeline,
         paths=[pkg_file, docs_file],
         run_options=run_options,
         base_config=None,

--- a/tests/pipeline/test_engine_path_configs.py
+++ b/tests/pipeline/test_engine_path_configs.py
@@ -29,6 +29,7 @@ from typing import Any
 import pytest
 
 from tests.helpers.config import make_frozen_config
+from tests.helpers.pipeline import TEST_NOOP_PIPELINE_SELECTION
 from topmark.pipeline import engine
 from topmark.runtime.model import RunOptions
 
@@ -102,7 +103,7 @@ def test_run_steps_for_files_uses_path_specific_configs_when_provided(
         run_options=run_options,
         config=shared_cfg,
         path_configs=path_configs,
-        pipeline=(),
+        pipeline=TEST_NOOP_PIPELINE_SELECTION,
         file_list=[file_a, file_b],
     )
 
@@ -171,7 +172,7 @@ def test_run_steps_for_files_falls_back_to_shared_config_without_path_configs(
         run_options=run_options,
         config=shared_cfg,
         path_configs=None,
-        pipeline=(),
+        pipeline=TEST_NOOP_PIPELINE_SELECTION,
         file_list=[file_a, file_b],
     )
 

--- a/tests/pipeline/test_hard_link_identity.py
+++ b/tests/pipeline/test_hard_link_identity.py
@@ -21,7 +21,7 @@ from tests.helpers.config import make_frozen_config
 from topmark.pipeline.engine import run_steps_for_files
 from topmark.pipeline.hints import Cluster
 from topmark.pipeline.hints import KnownCode
-from topmark.pipeline.pipelines import Pipeline
+from topmark.pipeline.pipelines import select_pipeline
 from topmark.pipeline.status import FsStatus
 from topmark.runtime.model import RunOptions
 
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.engine import PipelineExecution
     from topmark.pipeline.hints import Hint
+    from topmark.pipeline.pipelines import PipelineSelection
 
 
 def _link_or_skip(source: Path, target: Path) -> None:
@@ -44,12 +45,19 @@ def _link_or_skip(source: Path, target: Path) -> None:
 
 def _run_check(paths: list[Path], config: FrozenConfig) -> list[ProcessingContext]:
     """Run the check pipeline for `paths` and return per-file contexts."""
-    run_options = RunOptions()
+    pipeline: PipelineSelection = select_pipeline(
+        "check",
+        apply=False,
+        diff=False,
+    )
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        selection=pipeline,
+    )
     pipeline_run: PipelineExecution = run_steps_for_files(
         run_options=run_options,
         config=config,
         path_configs=None,
-        pipeline=Pipeline.CHECK.steps,
+        pipeline=pipeline,
         file_list=paths,
     )
     assert pipeline_run.exit_code is None

--- a/tests/pipeline/test_outcomes.py
+++ b/tests/pipeline/test_outcomes.py
@@ -22,12 +22,12 @@ from topmark.config.policy import HeaderMutationMode
 from topmark.core.outcomes import NO_REASON_PROVIDED
 from topmark.core.outcomes import Outcome
 from topmark.pipeline.context.model import ProcessingContext
-from topmark.pipeline.outcomes import Intent
 from topmark.pipeline.outcomes import OutcomeReasonCount
+from topmark.pipeline.outcomes import ResultActionIntent
 from topmark.pipeline.outcomes import ResultBucket
 from topmark.pipeline.outcomes import classify_outcome
 from topmark.pipeline.outcomes import collect_outcome_reason_counts
-from topmark.pipeline.outcomes import determine_intent
+from topmark.pipeline.outcomes import determine_result_action_intent
 from topmark.pipeline.outcomes import map_bucket
 from topmark.pipeline.result import ProcessingResult
 from topmark.pipeline.status import ComparisonStatus
@@ -80,24 +80,24 @@ def test_result_bucket_repr_uses_fallback_reason() -> None:
 @pytest.mark.parametrize(
     ("header", "strip", "expected"),
     [
-        (HeaderStatus.PENDING, StripStatus.READY, Intent.STRIP),
-        (HeaderStatus.MISSING, StripStatus.PENDING, Intent.INSERT),
-        (HeaderStatus.DETECTED, StripStatus.PENDING, Intent.UPDATE),
-        (HeaderStatus.PENDING, StripStatus.PENDING, Intent.NONE),
+        (HeaderStatus.PENDING, StripStatus.READY, ResultActionIntent.STRIP),
+        (HeaderStatus.MISSING, StripStatus.PENDING, ResultActionIntent.INSERT),
+        (HeaderStatus.DETECTED, StripStatus.PENDING, ResultActionIntent.UPDATE),
+        (HeaderStatus.PENDING, StripStatus.PENDING, ResultActionIntent.NONE),
     ],
 )
-def test_determine_intent_from_status_axes(
+def test_determine_result_action_intent_from_status_axes(
     tmp_path: Path,
     header: HeaderStatus,
     strip: StripStatus,
-    expected: Intent,
+    expected: ResultActionIntent,
 ) -> None:
     """Intent inference should depend on status axes, not pipeline names."""
     ctx: ProcessingContext = _make_context(tmp_path)
     ctx.status.header = header
     ctx.status.strip = strip
 
-    assert determine_intent(ctx) is expected
+    assert determine_result_action_intent(ctx) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/pipeline/test_pipelines.py
+++ b/tests/pipeline/test_pipelines.py
@@ -1,0 +1,210 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_pipelines.py
+#   file_relpath : tests/pipeline/test_pipelines.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Pipeline tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from topmark.pipeline.pipelines import CHECK_APPLY_PATCH_PIPELINE
+from topmark.pipeline.pipelines import CHECK_APPLY_PIPELINE
+from topmark.pipeline.pipelines import CHECK_PATCH_PIPELINE
+from topmark.pipeline.pipelines import CHECK_SUMMMARY_PIPELINE
+from topmark.pipeline.pipelines import PIPELINE_DEFINITIONS
+from topmark.pipeline.pipelines import PROBE_PIPELINE
+from topmark.pipeline.pipelines import STRIP_APPLY_PATCH_PIPELINE
+from topmark.pipeline.pipelines import STRIP_APPLY_PIPELINE
+from topmark.pipeline.pipelines import STRIP_PATCH_PIPELINE
+from topmark.pipeline.pipelines import STRIP_PIPELINE
+from topmark.pipeline.pipelines import Pipeline
+from topmark.pipeline.pipelines import PipelineDefinition
+from topmark.pipeline.pipelines import PipelineSelection
+from topmark.pipeline.pipelines import select_pipeline
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "expected_name", "expected_family", "expected_steps"),
+    [
+        (Pipeline.PROBE, "probe", "probe", PROBE_PIPELINE),
+        (Pipeline.CHECK, "check", "check", CHECK_SUMMMARY_PIPELINE),
+        (Pipeline.CHECK_PATCH, "check-patch", "check", CHECK_PATCH_PIPELINE),
+        (Pipeline.CHECK_APPLY, "check-apply", "check", CHECK_APPLY_PIPELINE),
+        (
+            Pipeline.CHECK_APPLY_PATCH,
+            "check-apply-patch",
+            "check",
+            CHECK_APPLY_PATCH_PIPELINE,
+        ),
+        (Pipeline.STRIP, "strip", "strip", STRIP_PIPELINE),
+        (Pipeline.STRIP_PATCH, "strip-patch", "strip", STRIP_PATCH_PIPELINE),
+        (Pipeline.STRIP_APPLY, "strip-apply", "strip", STRIP_APPLY_PIPELINE),
+        (
+            Pipeline.STRIP_APPLY_PATCH,
+            "strip-apply-patch",
+            "strip",
+            STRIP_APPLY_PATCH_PIPELINE,
+        ),
+    ],
+)
+def test_pipeline_definition_metadata(
+    pipeline: Pipeline,
+    expected_name: str,
+    expected_family: str,
+    expected_steps: object,
+) -> None:
+    """Pipeline enum members expose their registered executable definitions."""
+    definition: PipelineDefinition = pipeline.definition
+
+    assert PIPELINE_DEFINITIONS[pipeline] is definition
+    assert definition.name == expected_name
+    assert definition.family == expected_family
+    assert definition.steps is expected_steps
+    assert pipeline.steps is expected_steps
+    assert pipeline.family == expected_family
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "mutates", "emits_patch"),
+    [
+        (Pipeline.PROBE, False, False),
+        (Pipeline.CHECK, False, False),
+        (Pipeline.CHECK_PATCH, False, True),
+        (Pipeline.CHECK_APPLY, True, False),
+        (Pipeline.CHECK_APPLY_PATCH, True, True),
+        (Pipeline.STRIP, False, False),
+        (Pipeline.STRIP_PATCH, False, True),
+        (Pipeline.STRIP_APPLY, True, False),
+        (Pipeline.STRIP_APPLY_PATCH, True, True),
+    ],
+)
+def test_pipeline_capability_flags(
+    pipeline: Pipeline,
+    *,
+    mutates: bool,
+    emits_patch: bool,
+) -> None:
+    """Pipeline capability flags describe selected side effects and outputs."""
+    assert pipeline.definition.mutates is mutates
+    assert pipeline.definition.emits_patch is emits_patch
+    assert pipeline.mutates is mutates
+    assert pipeline.emits_patch is emits_patch
+
+
+@pytest.mark.parametrize(
+    ("apply", "diff", "expected"),
+    [
+        (False, False, Pipeline.CHECK),
+        (False, True, Pipeline.CHECK_PATCH),
+        (True, False, Pipeline.CHECK_APPLY),
+        (True, True, Pipeline.CHECK_APPLY_PATCH),
+    ],
+)
+def test_select_pipeline_for_check_variants(
+    *,
+    apply: bool,
+    diff: bool,
+    expected: Pipeline,
+) -> None:
+    """Check selection maps apply/diff flags to the expected catalogue variant."""
+    selection: PipelineSelection = select_pipeline(
+        "check",
+        apply=apply,
+        diff=diff,
+    )
+
+    assert selection.kind == "check"
+    assert selection.apply is apply
+    assert selection.diff is diff
+    assert selection.definition is expected.definition
+    assert selection.steps is expected.steps
+
+
+@pytest.mark.parametrize(
+    ("apply", "diff", "expected"),
+    [
+        (False, False, Pipeline.STRIP),
+        (False, True, Pipeline.STRIP_PATCH),
+        (True, False, Pipeline.STRIP_APPLY),
+        (True, True, Pipeline.STRIP_APPLY_PATCH),
+    ],
+)
+def test_select_pipeline_for_strip_variants(
+    *,
+    apply: bool,
+    diff: bool,
+    expected: Pipeline,
+) -> None:
+    """Strip selection maps apply/diff flags to the expected catalogue variant."""
+    selection: PipelineSelection = select_pipeline(
+        "strip",
+        apply=apply,
+        diff=diff,
+    )
+
+    assert selection.kind == "strip"
+    assert selection.apply is apply
+    assert selection.diff is diff
+    assert selection.definition is expected.definition
+    assert selection.steps is expected.steps
+
+
+@pytest.mark.parametrize(
+    ("apply", "diff"), [(False, False), (False, True), (True, False), (True, True)]
+)
+def test_select_pipeline_for_probe_ignores_variant_flags(*, apply: bool, diff: bool) -> None:
+    """Probe always selects the read-only probe pipeline."""
+    selection: PipelineSelection = select_pipeline(
+        "probe",
+        apply=apply,
+        diff=diff,
+    )
+
+    assert selection.kind == "probe"
+    assert selection.apply is apply
+    assert selection.diff is diff
+    assert selection.definition is Pipeline.PROBE.definition
+    assert selection.steps is PROBE_PIPELINE
+
+
+def test_pipeline_selection_accepts_familyless_internal_definition() -> None:
+    """Family-less definitions support no-op test pipelines without catalogue leaks."""
+    definition = PipelineDefinition(
+        name="test-noop",
+        family=None,
+        steps=(),
+    )
+
+    selection = PipelineSelection(
+        kind="check",
+        apply=False,
+        diff=False,
+        definition=definition,
+    )
+
+    assert selection.definition is definition
+    assert selection.steps == ()
+
+
+def test_pipeline_selection_rejects_mismatched_family() -> None:
+    """Selections must not pair one command family with another family definition."""
+    with pytest.raises(ValueError, match="family does not match selection kind"):
+        PipelineSelection(
+            kind="check",
+            apply=False,
+            diff=False,
+            definition=Pipeline.STRIP.definition,
+        )
+
+
+def test_select_pipeline_rejects_unknown_kind() -> None:
+    """Selection fails defensively for invalid runtime pipeline families."""
+    with pytest.raises(RuntimeError, match="Invalid pipeline kind"):
+        select_pipeline("unknown", apply=False, diff=False)  # pyright: ignore[reportArgumentType]

--- a/tools/perf/pipeline_memory_baseline.py
+++ b/tools/perf/pipeline_memory_baseline.py
@@ -45,7 +45,6 @@ from typing import TYPE_CHECKING
 from typing import Final
 from typing import Literal
 
-from topmark.api.runtime import select_pipeline
 from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.config.policy import make_policy_registry
 from topmark.config.types import FileWriteStrategy
@@ -54,6 +53,7 @@ from topmark.core.typing_guards import as_object_dict
 from topmark.core.typing_guards import is_any_list
 from topmark.core.typing_guards import is_mapping
 from topmark.pipeline.context.model import ProcessingContext
+from topmark.pipeline.pipelines import select_pipeline
 from topmark.runtime.model import RunOptions
 
 if TYPE_CHECKING:
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     from topmark.config.model import MutableConfig
     from topmark.config.policy import PolicyRegistry
     from topmark.core.exit_codes import ExitCode
+    from topmark.pipeline.pipelines import PipelineSelection
     from topmark.pipeline.protocols import Step
     from topmark.pipeline.views import ViewSlot
 
@@ -263,7 +264,7 @@ def _line_count(value: object) -> int:
     if value is None:
         return 0
     if hasattr(value, "__len__"):
-        return len(value)  # type: ignore[arg-type]
+        return len(value)  # pyright: ignore[reportArgumentType]
     return -1
 
 
@@ -663,12 +664,16 @@ def _run_steps_with_samples(
     policy_registry: PolicyRegistry,
 ) -> tuple[ProcessingContext, list[StepSample], str]:
     """Run one scenario/mode pair and collect step-level samples."""
-    run_options = RunOptions(
-        apply_changes=mode.apply,
+    pipeline: PipelineSelection = select_pipeline(
+        mode.kind,
+        apply=mode.apply,
+        diff=mode.diff,
+    )
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        selection=pipeline,
         output_target=mode.output_target,
         file_write_strategy=FileWriteStrategy.ATOMIC,
         prune_views=mode.prune_views,
-        keep_diff_view=mode.keep_diff_view,
     )
     ctx: ProcessingContext = ProcessingContext.bootstrap(
         path=scenario.path,
@@ -676,24 +681,20 @@ def _run_steps_with_samples(
         run_options=run_options,
         policy_registry_override=policy_registry,
     )
-    pipeline: Sequence[Step[ProcessingContext]] = select_pipeline(
-        mode.kind,
-        apply=mode.apply,
-        diff=mode.diff,
-    )
+    steps: tuple[Step[ProcessingContext], ...] = pipeline.steps
     samples: list[StepSample] = []
     stdout_capture = io.StringIO()
 
-    step_count: int = len(pipeline)
+    step_count: int = len(steps)
     with contextlib.redirect_stdout(stdout_capture):
-        for index, step in enumerate(pipeline):
+        for index, step in enumerate(steps):
             step_start: int = time.perf_counter_ns()
             ctx = step(ctx)
             # Mirror the production runner lifecycle so per-step samples reflect
             # the retained views available to later steps, not only final cleanup.
             if mode.prune_views:
                 remaining_view_consumers: set[ViewSlot] = set()
-                for remaining_step in pipeline[index + 1 : step_count]:
+                for remaining_step in steps[index + 1 : step_count]:
                     remaining_view_consumers.update(remaining_step.consumes_views)
                 ctx.views.release_consumed(
                     remaining_view_consumers=remaining_view_consumers,


### PR DESCRIPTION
## Summary

This PR clarifies TopMark's pipeline-intent architecture by introducing an explicit separation between:

- pipeline catalogue definitions (`PipelineDefinition`)
- invocation-time pipeline selection (`PipelineSelection`)
- durable runtime execution state (`RunOptions`)

The change follows the durable-result work completed in #148 and addresses the architectural evaluation requested in #166.

## Motivation

Prior to this change, pipeline intent was represented through a mixture of:

- command-specific execution paths
- pipeline kind literals
- runtime options
- derived outcome intent helpers
- implicit step-sequence selection

While functional, the architecture made it difficult to distinguish:

- command intent
- executable pipeline selection
- durable runtime state
- reporting intent

This PR makes those concepts explicit while preserving existing CLI, API, and machine-output behavior.

## Changes

### Pipeline catalogue and selection

- Introduce `PipelineDefinition` as the executable pipeline metadata model
- Introduce `PipelineSelection` as the invocation-time selection DTO
- Move pipeline selection ownership into the pipeline catalogue layer
- Pass selected pipelines through runtime and engine layers instead of raw step tuples
- Add selection validation and catalogue metadata tests

### Intent clarification

- Rename derived reporting intent types and helpers to clarify that they represent result-action intent rather than command intent
- Retain explicit command intent through pipeline selection

### Runtime synchronization

- Add `RunOptions.from_pipeline_selection()`
- Derive pipeline kind, mutation mode, and diff-view preservation from selected pipelines
- Reduce duplicated execution-intent state across call sites
- Keep `RunOptions` independent from concrete pipeline catalogue imports

### Naming cleanup

- Rename machine-output `PipelineKind` to `PipelineRecordKind`
- Remove obsolete `StepContext` and `AnyStep` protocol helpers

### Documentation

Update:

- `docs/dev/pipelines.md`
- `docs/dev/pipelines-reference.md`
- `docs/dev/architecture.md`
- `docs/api/public.md`
- `docs/usage/machine-output.md`

to reflect the pipeline catalogue and selection architecture and clarify public compatibility boundaries.

## Compatibility

No user-visible behavior changes are intended.

The following remain unchanged:

- CLI behavior
- public API behavior
- machine-readable output schemas
- result DTO contracts
- pipeline execution semantics

This is an internal architecture and documentation refactor.

## Related Issues

- Continues architecture work from #148
- Closes #166