### PR TITLE
Introduce streaming-capable reduction runtime path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@ ______________________________________________________________________
 - Clarified pipeline intent modelling by renaming derived per-result action intent helpers,
   introducing explicit pipeline catalogue definitions and selection DTOs, and deriving runtime
   execution options from selected pipelines while preserving CLI, API, and machine-output behavior.
+- Introduced streaming-capable execution and reduction seams through `iter_steps_for_files()`,
+  `iter_processing_results()`, and the result-oriented `run_pipeline_results()` runtime adapter,
+  while preserving existing CLI, API, presentation, machine-output, ordering, summary, and exit-code
+  behavior.
 
 ### Breaking Changes - Unreleased
 
@@ -315,6 +319,9 @@ ______________________________________________________________________
 - Documented the pipeline catalogue and selection architecture, including the separation between
   command intent, selected executable pipeline definitions, durable runtime options, and public API
   or machine-output compatibility boundaries.
+- Documented the streaming-capable execution and reduction architecture introduced for GitHub issue
+  165, including iterator-based engine/reduction seams, durable-result runtime orchestration,
+  ownership boundaries, and the rationale for preserving batch-oriented public contracts.
 
 ### Internal - Unreleased
 
@@ -390,6 +397,9 @@ ______________________________________________________________________
 - Reworked internal pipeline selection around `Pipeline`, `PipelineDefinition`, and
   `PipelineSelection`, moved selection ownership into the pipeline catalogue, and added targeted
   coverage for catalogue metadata, selection variants, and runtime-option synchronization.
+- Added result-oriented runtime orchestration through `run_pipeline_results()`, migrated normal
+  check/strip API execution to consume durable `ProcessingResult` snapshots through the new runtime
+  path, and added regression coverage for empty durable-result batches.
 
 ### Notes - Unreleased
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -50,30 +50,42 @@ ______________________________________________________________________
 
 ## Mutable-context to durable-result handover
 
-TopMark currently uses a batch handover boundary after the existing runner has produced its per-file
-\[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances.
-\[`PipelineExecution`\][topmark.pipeline.engine.PipelineExecution] therefore names those mutable
-execution objects `contexts`, while
-\[`run_steps_for_files()`\][topmark.pipeline.engine.run_steps_for_files] remains the
-context-producing execution layer.
-\[`reduce_processing_contexts()`\][topmark.pipeline.reduction.reduce_processing_contexts] creates
-matching durable \[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] snapshots in the
-same order. Source-context retention is explicit: compatibility callers may keep contexts in the
-\[`ProcessingReduction`\][topmark.pipeline.reduction.ProcessingReduction] handover object, while
-check, strip, and probe callers that now consume durable results use a reduced-only handover and
-release context-owned view payloads after snapshotting.
+TopMark uses a streaming-capable execution and reduction handover internally while preserving
+batch-oriented CLI, API, presentation, and machine-output behavior. The execution layer can yield
+per-file \[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances through
+\[`iter_steps_for_files()`\][topmark.pipeline.engine.iter_steps_for_files]. The reduction layer can
+then snapshot those mutable contexts into durable
+\[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] instances through
+\[`iter_processing_results()`\][topmark.pipeline.reduction.iter_processing_results], releasing
+context-owned volatile view payloads immediately after snapshotting when callers do not retain
+source contexts.
+
+The batch-facing adapters remain explicit.
+\[`run_steps_for_files()`\][topmark.pipeline.engine.run_steps_for_files] materializes a
+\[`PipelineExecution`\][topmark.pipeline.engine.PipelineExecution] containing mutable execution
+contexts for compatibility callers.
+\[`reduce_processing_contexts()`\][topmark.pipeline.reduction.reduce_processing_contexts]
+materializes a \[`ProcessingReduction`\][topmark.pipeline.reduction.ProcessingReduction] from an
+iterable of contexts. At the runtime/API layer,
+\[`run_pipeline_results()`\][topmark.api.runtime.run_pipeline_results] is the result-oriented batch
+adapter for normal check/strip processing, while the context-oriented `run_pipeline()` path remains
+available for compatibility and probe-specific composition.
 
 This boundary is intentionally conservative:
 
-- it does **not** introduce per-file streaming consolidation;
-- it does **not** update summaries incrementally while files are processed;
+- it introduces per-file execution and reduction iterators inside the runtime architecture;
+- it does **not** make public API calls, CLI commands, JSON output, Markdown output, or summary
+  generation incremental;
+- it keeps output ordering, exit-code selection, report-scope filtering, public API DTO assembly,
+  human rendering, and machine-readable result serialization on batch-compatible durable result
+  collections;
 - it keeps runner-owned pruning limited to between-step release of consumed volatile views, while
   final view release happens only after
   \[`ProcessingResult.from_context()`\][topmark.pipeline.result.ProcessingResult.from_context] has
   copied durable detail fields such as `detail.diff_text`;
-- it does make summary, exit-code, report-scope filtering, public API DTO assembly, human rendering,
-  and machine-readable result serialization testable against durable results without changing runner
-  ownership or output contracts.
+- it makes summary, exit-code, report-scope filtering, public API DTO assembly, human rendering, and
+  machine-readable result serialization testable against durable results without requiring
+  output-facing consumers to retain mutable contexts.
 
 Report filtering is intentionally protocol-based at this boundary: both mutable contexts and durable
 results expose the status, diagnostics, and outcome flags needed to decide whether an entry belongs
@@ -84,10 +96,10 @@ field is `diff_text`, copied from the diff view by
 \[`ProcessingResult.from_context()`\][topmark.pipeline.result.ProcessingResult.from_context] without
 retaining the view object, original file image, or updated file image.
 
-The public Python API `check()` and `strip()` result packaging now consumes durable
-`ProcessingResult` snapshots after the reduction boundary. This keeps API DTO assembly, report
-filtering, write counting, diagnostics aggregation, outcome bucketing, and public diff exposure on
-reduced result state rather than on live context views.
+The public Python API `check()` and `strip()` result packaging now consume durable
+`ProcessingResult` snapshots through the result-oriented runtime path. This keeps API DTO assembly,
+report filtering, write counting, diagnostics aggregation, outcome bucketing, and public diff
+exposure on reduced result state rather than on live context views.
 
 Check/strip human rendering and machine-readable result serialization now consume durable
 `ProcessingResult` snapshots, including reduced display-path state and the reduced
@@ -101,11 +113,12 @@ reduction boundary and are no longer required by output, reporting, or API packa
 Unified diff headers generated by the patcher remain pre-reduction context consumers because they
 are created while mutable views still own the planned patch content.
 
-Future streaming-oriented work can use this seam to evaluate whether reduction can move from an
-end-of-run batch step into the per-file processing loop, followed by incremental reporting updates
-and earlier release of memory-heavy context state. Diff generation should remain isolated behind
-that durable boundary so a later performance issue can evaluate whether `difflib` is still an
-appropriate backend or whether TopMark should adopt a lower-memory diff strategy.
+This design deliberately stops short of a streaming public API. Public and CLI consumers still see
+complete result collections, and final summaries remain batch-derived. Future work can build on the
+same iterator seam for probe-specific result composition or for truly incremental output formats,
+but those would be separate contract decisions. Diff generation should remain isolated behind the
+durable boundary so a later performance issue can evaluate whether `difflib` is still an appropriate
+backend or whether TopMark should adopt a lower-memory diff strategy.
 
 ______________________________________________________________________
 

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -536,6 +536,42 @@ authoritative file-image representation would not provide a realistic measurable
 the current benchmark evidence. Track B should therefore treat end-to-end output streaming as
 evaluated but not currently warranted.
 
+### Streaming-oriented reduction architecture follow-up (GitHub issue 165)
+
+GitHub issue 165 introduced streaming-capable execution and reduction seams while preserving the
+existing batch-oriented public API, CLI, presentation, and machine-output contracts. The new
+internal ownership path is:
+
+```text
+iter_steps_for_files()
+    -> ProcessingContext
+    -> iter_processing_results()
+    -> ProcessingResult
+    -> run_pipeline_results()
+```
+
+The implementation makes the engine able to yield per-file mutable processing contexts and makes the
+reduction layer able to snapshot each context into a durable `ProcessingResult` before releasing
+context-owned volatile views. Normal check and strip API orchestration now uses the result-oriented
+runtime adapter, while compatibility and probe-specific paths may still materialize mutable contexts
+before reduction.
+
+This change primarily improves ownership clarity and context lifetime boundaries. It is not expected
+to materially change the existing single-file benchmark results because the current benchmark corpus
+still measures one generated file per isolated subprocess, and public API/CLI outputs continue to
+materialize ordered result collections for summaries, exit-code selection, and stable output
+contracts.
+
+The most relevant performance implication is therefore lifecycle-local rather than benchmark-wide:
+per-file reduction can now release volatile views immediately after durable snapshotting when
+callers do not retain source contexts. Measuring whether this reduces peak memory for
+repository-scale runs would require a future many-file benchmark suite, because the current
+scenarios do not measure cumulative `ProcessingContext` retention across large file sets.
+
+For the current baseline corpus, the expected result is effectively flat peak traced allocations and
+RSS. Any future streaming-output, probe-result, or public iterator API work should be benchmarked
+separately so memory changes remain attributable to a specific architectural layer.
+
 ______________________________________________________________________
 
 ## Known caveats
@@ -565,3 +601,4 @@ ______________________________________________________________________
 - GitHub issue 140: Review view-pruning lifecycle and memory-release opportunities
 - GitHub issue 141: Evaluate alternative FileImageView implementations
 - GitHub issue 147: Design end-to-end streaming output architecture for CLI and machine formats
+- GitHub issue 165: Evaluate streaming-oriented reduction and incremental reporting architecture

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -26,6 +26,16 @@ system.
 Pipeline execution operates on an immutable \[`FrozenConfig`\][topmark.config.model.FrozenConfig], a
 selected pipeline, and runtime options assembled via the TOML → FrozenConfig → runtime flow.
 
+Internally, pipeline execution is streaming-capable. The engine can yield per-file
+\[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances through
+\[`iter_steps_for_files()`\][topmark.pipeline.engine.iter_steps_for_files], and the reduction layer
+can snapshot those mutable contexts into durable
+\[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] instances through
+\[`iter_processing_results()`\][topmark.pipeline.reduction.iter_processing_results]. Runtime/API
+orchestration for normal check and strip execution uses the result-oriented
+\[`run_pipeline_results()`\][topmark.api.runtime.run_pipeline_results] adapter while preserving
+batch-compatible ordering, summaries, and output contracts.
+
 Pipelines also operate on selected processing paths. Filesystem-identity evaluation occurs before
 ordinary pipeline execution begins and includes both processing-path normalization and
 processing-target eligibility checks.
@@ -127,11 +137,18 @@ API module.
   \[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection], and the
   \[`select_pipeline()`\][topmark.pipeline.pipelines.select_pipeline] pipeline selection helper):
   - [`topmark.pipeline.pipelines`](../api/internals/topmark/pipeline/pipelines.md)
+- Engine execution helpers:
+  - [`topmark.pipeline.engine`](../api/internals/topmark/pipeline/engine.md)
+- Reduction helpers and durable-result handover:
+  - [`topmark.pipeline.reduction`](../api/internals/topmark/pipeline/reduction.md)
+  - [`topmark.pipeline.result`](../api/internals/topmark/pipeline/result.md)
 - Step protocol and base lifecycle contract:
   - [`topmark.pipeline.protocols`](../api/internals/topmark/pipeline/protocols.md)
   - [`topmark.pipeline.steps.base`](../api/internals/topmark/pipeline/steps/base.md)
 - Pipeline view slots, view models, and repeatable updated-content abstractions:
   - [`topmark.pipeline.views`](../api/internals/topmark/pipeline/views.md)
+- Runtime orchestration helpers:
+  - [`topmark.api.runtime`](../api/internals/topmark/api/runtime.md)
 - Conceptual overview:
   - [`Pipelines (Concepts)`](./pipelines.md)
 

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -46,6 +46,17 @@ documented in [`Architecture`](architecture.md) and
 steps are executable for the invocation; runtime options capture execution-wide state that must be
 copied onto processing contexts and durable results.
 
+Pipeline execution is streaming-capable internally, even though public CLI, API, presentation, and
+machine-output surfaces remain batch-oriented. The engine can yield per-file
+\[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances through
+\[`iter_steps_for_files()`\][topmark.pipeline.engine.iter_steps_for_files]. The reduction layer then
+snapshots those mutable contexts into durable
+\[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] instances through
+\[`iter_processing_results()`\][topmark.pipeline.reduction.iter_processing_results]. Normal check
+and strip orchestration use the result-oriented runtime adapter
+\[`run_pipeline_results()`\][topmark.api.runtime.run_pipeline_results], while compatibility and
+probe-specific paths may still materialize mutable contexts before reduction.
+
 Pipeline execution also consumes a selected **processing path**. File-list resolution performs
 filesystem-identity evaluation before ordinary pipeline execution begins.
 
@@ -168,6 +179,7 @@ TopMark pipelines are:
 - side-effect constrained
 - idempotent
 - processing-path based
+- streaming-capable internally
 - presentation-independent
 
 Pipeline steps mutate processing context state. CLI views, API DTOs, and machine-readable output
@@ -606,6 +618,9 @@ ______________________________________________________________________
   \[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection] identifies the executable
   pipeline variant, while \[`RunOptions`\][topmark.runtime.model.RunOptions] carries durable
   invocation state onto processing contexts and results
+- **Streaming-capable reduction seam:** the engine can yield per-file mutable processing contexts,
+  the reduction layer can snapshot them into durable processing results, and public CLI/API surfaces
+  can continue to collect those results for stable ordering, summaries, and machine-output schemas
 - **Separation of concerns:** Steps mutate context, views classify outcomes
 - **Runtime/configuration separation:** pipeline execution consumes resolved runtime configuration
   and runtime options rather than re-running TOML discovery during step execution

--- a/src/topmark/api/commands/pipeline.py
+++ b/src/topmark/api/commands/pipeline.py
@@ -28,14 +28,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from topmark.api.runtime import run_pipeline
+from topmark.api.runtime import run_pipeline_results
 from topmark.api.runtime import run_probe_pipeline
 from topmark.api.view import finalize_probe_result
 from topmark.api.view import finalize_run_result
 from topmark.core.errors import InvalidReportScopeError
 from topmark.pipeline.pipelines import PipelineSelection
 from topmark.pipeline.pipelines import select_pipeline
-from topmark.pipeline.reduction import reduce_processing_contexts
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.status import PlanStatus
 from topmark.runtime.model import RunOptions
@@ -46,6 +45,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
+    from topmark.api.runtime import ApiPipelineResultRun
     from topmark.api.types import ApiPipelineRun
     from topmark.api.types import ProbeRunResult
     from topmark.api.types import PublicPolicy
@@ -143,7 +143,7 @@ def check(
         prune_views=prune_views,
     )
 
-    api_run: ApiPipelineRun = run_pipeline(
+    api_run: ApiPipelineResultRun = run_pipeline_results(
         pipeline=pipeline,
         paths=paths,
         run_options=run_options,
@@ -164,11 +164,7 @@ def check(
     report_scope: ReportScope = _resolve_public_report_scope(report)
 
     return finalize_run_result(
-        results=reduce_processing_contexts(
-            api_run.contexts,
-            retain_contexts=False,
-            release_views=True,
-        ).results,
+        results=api_run.results,
         file_list=api_run.file_list,
         apply=apply,
         report_scope=report_scope,
@@ -237,7 +233,7 @@ def strip(
         prune_views=prune_views,
     )
 
-    api_run: ApiPipelineRun = run_pipeline(
+    api_run: ApiPipelineResultRun = run_pipeline_results(
         pipeline=pipeline,
         paths=paths,
         run_options=run_options,
@@ -256,11 +252,7 @@ def strip(
     report_scope: ReportScope = _resolve_public_report_scope(report)
 
     return finalize_run_result(
-        results=reduce_processing_contexts(
-            api_run.contexts,
-            retain_contexts=False,
-            release_views=True,
-        ).results,
+        results=api_run.results,
         file_list=api_run.file_list,
         apply=apply,
         report_scope=report_scope,
@@ -339,6 +331,8 @@ def probe(
 
     # Probe has a dedicated public result shape; do not route it through the
     # check/strip finalizer.
+    from topmark.pipeline.reduction import reduce_processing_contexts
+
     return finalize_probe_result(
         results=reduce_processing_contexts(api_run.contexts).results,
         file_list=api_run.file_list,

--- a/src/topmark/api/runtime.py
+++ b/src/topmark/api/runtime.py
@@ -52,8 +52,11 @@ from topmark.core.constants import TOPMARK_VERSION
 from topmark.core.errors import InvalidPolicyError
 from topmark.core.logging import get_logger
 from topmark.pipeline.engine import PipelineExecution
+from topmark.pipeline.engine import PipelineExecutionState
 from topmark.pipeline.engine import exit_code_from_pipeline_results
+from topmark.pipeline.engine import iter_steps_for_files
 from topmark.pipeline.engine import run_steps_for_files
+from topmark.pipeline.reduction import iter_processing_results
 from topmark.pipeline.synthetic import build_filtered_probe_contexts
 from topmark.pipeline.synthetic import build_missing_file_contexts
 from topmark.resolution.files import probe_explicit_file_selection
@@ -63,6 +66,7 @@ from topmark.runtime.writer_options import apply_resolved_writer_options
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from collections.abc import Iterator
     from collections.abc import Mapping
     from collections.abc import Sequence
 
@@ -73,6 +77,7 @@ if TYPE_CHECKING:
     from topmark.core.logging import TopmarkLogger
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.pipelines import PipelineSelection
+    from topmark.pipeline.result import ProcessingResult
     from topmark.resolution.discovery import FileSelectionProbeResult
     from topmark.resolution.files import FileListResolution
     from topmark.runtime.model import RunOptions
@@ -106,6 +111,32 @@ class PreparedApiRun:
     file_resolution: FileListResolution
     file_list: list[Path]
     discovered_layers: Sequence[ConfigLayer] | None
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ApiPipelineResultRun:
+    """Resolved runtime state and durable pipeline results for one API execution.
+
+    This internal value object mirrors `ApiPipelineRun`, but carries durable
+    [`ProcessingResult`][topmark.pipeline.result.ProcessingResult] snapshots
+    instead of mutable [`ProcessingContext`][topmark.pipeline.context.model.ProcessingContext]
+    instances. It is the API/runtime batch adapter over the streaming-capable
+    execution and reduction helpers.
+
+    Attributes:
+        effective_cfg: Final runtime config after layered discovery, runtime
+            overlays, and execution-scoped adjustments.
+        file_list: Files selected for pipeline execution after discovery and
+            filtering.
+        results: Durable processing-result snapshots produced by pipeline
+            execution and per-file reduction.
+        exit_code: Fatal pipeline-level exit code, if one was encountered.
+    """
+
+    effective_cfg: FrozenConfig
+    file_list: list[Path]
+    results: tuple[ProcessingResult, ...]
+    exit_code: ExitCode | None
 
 
 # ---- API run prepared value objects ----
@@ -659,6 +690,116 @@ def _execute_pipeline_for_file_list(
         file_list=prepared.file_list,
     )
     return pipeline_run
+
+
+def _iter_pipeline_results_for_file_list(
+    *,
+    prepared: PreparedApiRun,
+    pipeline: PipelineSelection,
+    state: PipelineExecutionState,
+) -> Iterator[ProcessingResult]:
+    """Yield durable pipeline results for the selected files in a prepared API run.
+
+    This helper is the API/runtime streaming-capable seam for normal content
+    processing runs. It executes each selected file, reduces the yielded
+    [`ProcessingContext`][topmark.pipeline.context.model.ProcessingContext]
+    into a durable [`ProcessingResult`][topmark.pipeline.result.ProcessingResult],
+    and releases context-owned volatile views immediately after snapshotting.
+
+    Args:
+        prepared: Shared resolved state for the API run.
+        pipeline: Pipeline steps to execute.
+        state: Mutable execution state updated with the first fatal
+            engine-level exit code encountered while iterating.
+
+    Yields:
+        Durable processing results in selected-file order.
+    """
+    if not prepared.file_list:
+        return
+
+    path_configs: dict[Path, FrozenConfig] = _build_path_configs(
+        layers=prepared.discovered_layers,
+        file_list=prepared.file_list,
+        effective_cfg=prepared.effective_cfg,
+    )
+
+    contexts: Iterator[ProcessingContext] = iter_steps_for_files(
+        run_options=prepared.run_options,
+        config=prepared.effective_cfg,
+        path_configs=path_configs,
+        pipeline=pipeline,
+        file_list=prepared.file_list,
+        state=state,
+    )
+    yield from iter_processing_results(contexts, release_views=True)
+
+
+def run_pipeline_results(
+    *,
+    pipeline: PipelineSelection,
+    paths: Iterable[Path | str],
+    run_options: RunOptions,
+    base_config: Mapping[str, object] | FrozenConfig | None,
+    include_file_types: Sequence[str] | None = None,
+    exclude_file_types: Sequence[str] | None = None,
+    # public-policy overlays (None = no override)
+    policy: PublicPolicy | None = None,
+    policy_by_type: Mapping[str, PublicPolicy] | None = None,
+) -> ApiPipelineResultRun:
+    """Resolve shared API runtime state and run a pipeline to durable results.
+
+    This is the result-oriented batch adapter over the streaming-capable
+    engine and reduction helpers. It preserves existing API/CLI batch behavior
+    while avoiding mutable-context handoff for normal check/strip consumers.
+
+    Args:
+        pipeline: The pipeline steps to apply.
+        paths: Files and/or directories to process.
+        run_options: Invocation-wide execution-only runtime options for the run.
+        base_config: `None` for normal layered discovery; otherwise an explicit
+            config seed supplied directly by the caller.
+        include_file_types: Optional allowlist of file type identifiers used for
+            file-list resolution.
+        exclude_file_types: Optional denylist of file type identifiers used for
+            file-list resolution.
+        policy: Optional global public policy overlay applied after config
+            resolution and before file discovery.
+        policy_by_type: Optional per-type public policy overlays applied after
+            config resolution and before file discovery.
+
+    Returns:
+        Resolved runtime state and durable processing-result snapshots.
+    """
+    logger.info("Building config and file list for paths: %s", paths)
+
+    prepared: PreparedApiRun = _prepare_api_pipeline_run(
+        paths=paths,
+        run_options=run_options,
+        base_config=base_config,
+        include_file_types=include_file_types,
+        exclude_file_types=exclude_file_types,
+        policy=policy,
+        policy_by_type=policy_by_type,
+    )
+
+    state: PipelineExecutionState = PipelineExecutionState()
+    results: tuple[ProcessingResult, ...] = tuple(
+        _iter_pipeline_results_for_file_list(
+            prepared=prepared,
+            pipeline=pipeline,
+            state=state,
+        )
+    )
+
+    logger.info("Processing %d file(s) with TopMark %s", len(prepared.file_list), TOPMARK_VERSION)
+
+    return ApiPipelineResultRun(
+        effective_cfg=prepared.effective_cfg,
+        file_list=prepared.file_list,
+        results=results,
+        exit_code=state.exit_code,
+    )
 
 
 def run_pipeline(

--- a/src/topmark/pipeline/engine.py
+++ b/src/topmark/pipeline/engine.py
@@ -64,6 +64,7 @@ from topmark.resolution.probe import ResolutionProbeResult
 from topmark.resolution.probe import ResolutionProbeStatus
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from collections.abc import Mapping
     from collections.abc import Sequence
     from os import stat_result
@@ -188,7 +189,7 @@ def _build_hard_link_duplicate_context(
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class PipelineExecution:
-    """Result of running pipeline steps over a selected file list.
+    """Materialized result of running pipeline steps over a selected file list.
 
     Attributes:
         contexts: Ordered per-file processing contexts produced by pipeline execution,
@@ -200,6 +201,18 @@ class PipelineExecution:
 
     contexts: list[ProcessingContext]
     exit_code: ExitCode | None
+
+
+@dataclass(kw_only=True, slots=True)
+class PipelineExecutionState:
+    """Mutable state updated while iterating pipeline execution.
+
+    Attributes:
+        exit_code: First non-success engine-level exit code encountered while
+            iterating files, or `None` when no such error occurred.
+    """
+
+    exit_code: ExitCode | None = None
 
 
 def exit_code_from_pipeline_results(
@@ -260,17 +273,20 @@ def exit_code_from_pipeline_results(
     return None
 
 
-def run_steps_for_files(
+def iter_steps_for_files(
     *,
     run_options: RunOptions,
     config: FrozenConfig,
     path_configs: Mapping[Path, FrozenConfig] | None = None,
     pipeline: PipelineSelection,
     file_list: list[Path],
-) -> PipelineExecution:
-    """Run a pipeline for each file and return structured engine results.
+    state: PipelineExecutionState | None = None,
+) -> Iterator[ProcessingContext]:
+    """Yield pipeline contexts for files in input order.
 
-    Catches common filesystem/encoding errors so command bodies don't duplicate try/except.
+    This helper is the streaming-capable engine boundary. It preserves the
+    existing per-file error handling semantics while allowing callers to reduce
+    and release each yielded context before the next file is processed.
 
     Args:
         run_options: Invocation-wide runtime options shared by all files in the run.
@@ -280,12 +296,14 @@ def run_steps_for_files(
             is used.
         pipeline: The pipeline steps to execute for the run.
         file_list: List of file Path instances to be processed in the run.
+        state: Optional mutable execution state updated with the first
+            non-success engine-level exit code encountered while iterating.
 
-    Returns:
-        Structured engine result containing ordered per-file
-        `ProcessingContext` objects and the first encountered non-success exit
-        code, if any. The exit code is suitable for reporting or process exit
-        in the CLI layer.
+    Yields:
+        Processing contexts in input-file order for files that were processed
+        successfully by the engine layer. Files that raise handled engine-level
+        filesystem, permission, encoding, or unexpected errors are logged and
+        skipped while preserving the first corresponding exit code in `state`.
 
     Exit code mapping:
         FILE_NOT_FOUND
@@ -304,8 +322,9 @@ def run_steps_for_files(
         - When multiple files are processed, only the *first* error code is preserved
           (a conventional behavior for batch tools). Subsequent files continue to run.
     """
-    results: list[ProcessingContext] = []
-    encountered_exit_code: ExitCode | None = None
+    execution_state: PipelineExecutionState = (
+        state if state is not None else PipelineExecutionState()
+    )
     default_policy_registry: PolicyRegistry | None = (
         None if path_configs is not None else make_policy_registry(config)
     )
@@ -324,13 +343,11 @@ def run_steps_for_files(
                 else default_policy_registry
             )
             if path in hard_link_duplicate_paths:
-                results.append(
-                    _build_hard_link_duplicate_context(
-                        path=path,
-                        config=effective_config,
-                        run_options=run_options,
-                        policy_registry=policy_registry,
-                    )
+                yield _build_hard_link_duplicate_context(
+                    path=path,
+                    config=effective_config,
+                    run_options=run_options,
+                    policy_registry=policy_registry,
                 )
                 continue
 
@@ -341,29 +358,75 @@ def run_steps_for_files(
                 run_options=run_options,
                 policy_registry_override=policy_registry,
             )
-            ctx_obj = runner.run(
+            yield runner.run(
                 ctx_obj,
                 pipeline.steps,
                 prune_views=run_options.prune_views,
                 keep_diff_view=run_options.keep_diff_view,
             )
-            results.append(ctx_obj)
         except (FileNotFoundError, PermissionError, IsADirectoryError) as e:
             logger.error("Filesystem error while processing %s: %s", path, e)
             if isinstance(e, FileNotFoundError | IsADirectoryError):
                 logger.error("%s: %s", e, path)
-                encountered_exit_code = encountered_exit_code or ExitCode.FILE_NOT_FOUND
+                execution_state.exit_code = execution_state.exit_code or ExitCode.FILE_NOT_FOUND
             else:
                 logger.error("%s: %s", e, path)
-                encountered_exit_code = encountered_exit_code or ExitCode.PERMISSION_DENIED
+                execution_state.exit_code = execution_state.exit_code or ExitCode.PERMISSION_DENIED
             continue
         except UnicodeDecodeError as e:
             logger.error("Encoding error while reading %s: %s", path, e)
-            encountered_exit_code = encountered_exit_code or ExitCode.ENCODING_ERROR
+            execution_state.exit_code = execution_state.exit_code or ExitCode.ENCODING_ERROR
             continue
         except Exception as e:  # pragma: no cover
             logger.exception("Unexpected error processing %s: %s", path, e)
-            encountered_exit_code = encountered_exit_code or ExitCode.PIPELINE_ERROR
+            execution_state.exit_code = execution_state.exit_code or ExitCode.PIPELINE_ERROR
             continue
 
-    return PipelineExecution(contexts=results, exit_code=encountered_exit_code)
+
+def run_steps_for_files(
+    *,
+    run_options: RunOptions,
+    config: FrozenConfig,
+    path_configs: Mapping[Path, FrozenConfig] | None = None,
+    pipeline: PipelineSelection,
+    file_list: list[Path],
+) -> PipelineExecution:
+    """Run a pipeline for each file and return structured engine results.
+
+    Catches common filesystem/encoding errors so command bodies don't duplicate try/except.
+    This batch helper materializes the streaming-capable `iter_steps_for_files()`
+    boundary for existing callers that need all contexts at once.
+
+    Args:
+        run_options: Invocation-wide runtime options shared by all files in the run.
+        config: Default layered TopMark configuration for the run.
+        path_configs: Optional per-path effective layered configs. When provided, a
+            path-specific config is used for bootstrap; otherwise the shared `config`
+            is used.
+        pipeline: The pipeline steps to execute for the run.
+        file_list: List of file Path instances to be processed in the run.
+
+    Returns:
+        Structured engine result containing ordered per-file
+        `ProcessingContext` objects and the first encountered non-success exit
+        code, if any. The exit code is suitable for reporting or process exit
+        in the CLI layer.
+
+    Notes:
+        - This helper **never prints**; it only logs. Callers are responsible for
+          user-visible messaging and exiting the process if desired.
+        - When multiple files are processed, only the *first* error code is preserved
+          (a conventional behavior for batch tools). Subsequent files continue to run.
+    """
+    state: PipelineExecutionState = PipelineExecutionState()
+    contexts: list[ProcessingContext] = list(
+        iter_steps_for_files(
+            run_options=run_options,
+            config=config,
+            path_configs=path_configs,
+            pipeline=pipeline,
+            file_list=file_list,
+            state=state,
+        ),
+    )
+    return PipelineExecution(contexts=contexts, exit_code=state.exit_code)

--- a/src/topmark/pipeline/reduction.py
+++ b/src/topmark/pipeline/reduction.py
@@ -8,19 +8,19 @@
 #
 # topmark:header:end
 
-"""Batch handover helpers for durable pipeline result reduction.
+"""Reduction helpers for durable pipeline result snapshots.
 
 This module defines the explicit boundary between mutable pipeline execution
-state and durable result state. The current helper is intentionally a *batch*
-reducer: it consumes already-produced
+state and durable result state. The iterator helper reduces completed
 [`ProcessingContext`][topmark.pipeline.context.model.ProcessingContext]
-instances and returns matching
-[`ProcessingResult`][topmark.pipeline.result.ProcessingResult] snapshots.
+instances one at a time, allowing callers to release volatile context-owned
+view payloads immediately after each durable
+[`ProcessingResult`][topmark.pipeline.result.ProcessingResult] snapshot is
+created.
 
-It does not introduce per-file streaming consolidation or incremental summary
-updates. It does provide explicit knobs for whether the handover retains source
-contexts and whether volatile context-owned view payloads are released after
-durable snapshots have been created.
+The batch helper remains available for callers that need stable, ordered
+materialization for summaries, machine-output envelopes, public API DTOs, or
+other full-run reporting contracts.
 """
 
 from __future__ import annotations
@@ -32,6 +32,7 @@ from topmark.pipeline.result import ProcessingResult
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from collections.abc import Iterator
 
     from topmark.pipeline.context.model import ProcessingContext
 
@@ -50,6 +51,36 @@ class ProcessingReduction:
 
     contexts: tuple[ProcessingContext, ...]
     results: tuple[ProcessingResult, ...]
+
+
+def iter_processing_results(
+    contexts: Iterable[ProcessingContext],
+    *,
+    release_views: bool = False,
+) -> Iterator[ProcessingResult]:
+    """Yield durable processing results from completed contexts.
+
+    This helper is the streaming-capable reduction boundary. It snapshots each
+    mutable context into a durable result before advancing to the next context.
+    When requested, volatile view payloads owned by that context are released
+    immediately after the snapshot is created.
+
+    Args:
+        contexts: Completed or partially completed processing contexts to reduce.
+        release_views: Whether to release context-owned view payloads after each
+            durable snapshot has been created. This never runs before
+            `ProcessingResult.from_context()` has copied result-owned detail
+            fields such as `diff_text`.
+
+    Yields:
+        Durable processing-result snapshots in the same order as the input
+        contexts.
+    """
+    for ctx in contexts:
+        result: ProcessingResult = ProcessingResult.from_context(ctx)
+        if release_views is True:
+            ctx.views.release_all()
+        yield result
 
 
 def reduce_processing_contexts(
@@ -79,16 +110,14 @@ def reduce_processing_contexts(
         Batch reduction containing durable results and, when requested, the
         retained source contexts in matching order.
     """
-    source_contexts: tuple[ProcessingContext, ...] = tuple(contexts)
-    results: tuple[ProcessingResult, ...] = tuple(
-        ProcessingResult.from_context(ctx) for ctx in source_contexts
-    )
-
-    if release_views is True:
-        for ctx in source_contexts:
-            ctx.views.release_all()
+    if retain_contexts is True:
+        source_contexts: tuple[ProcessingContext, ...] = tuple(contexts)
+        results: tuple[ProcessingResult, ...] = tuple(
+            iter_processing_results(source_contexts, release_views=release_views),
+        )
+        return ProcessingReduction(contexts=source_contexts, results=results)
 
     return ProcessingReduction(
-        contexts=source_contexts if retain_contexts is True else (),
-        results=results,
+        contexts=(),
+        results=tuple(iter_processing_results(contexts, release_views=release_views)),
     )

--- a/tests/api/test_api_check_and_strip.py
+++ b/tests/api/test_api_check_and_strip.py
@@ -22,8 +22,13 @@ from tests.helpers.api import api_strip_dir
 from tests.helpers.api import by_path_outcome
 from tests.helpers.io import read_text
 from topmark import api
+from topmark.api.runtime import ApiPipelineResultRun
+from topmark.api.runtime import run_pipeline_results
 from topmark.api.types import PublicPolicy
 from topmark.core.constants import TOPMARK_START_MARKER
+from topmark.pipeline.pipelines import PipelineSelection
+from topmark.pipeline.pipelines import select_pipeline
+from topmark.runtime.model import RunOptions
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -188,3 +193,31 @@ def test_strip_diff_is_available_when_views_are_pruned(
     assert f"+++ {path}" in diff
     assert "@@" in diff
     assert f"-# {TOPMARK_START_MARKER}" in diff
+
+
+def test_run_pipeline_results_handles_empty_file_list(tmp_path: Path) -> None:
+    """Empty file discovery yields an empty durable ProcessingResult batch.
+
+    Verifies the result-oriented runtime path introduced for streaming-capable
+    reduction handles runs with no selected files without producing results or
+    pipeline-level errors.
+    """
+    pipeline: PipelineSelection = select_pipeline(
+        "check",
+        apply=False,
+        diff=False,
+    )
+    run_options: RunOptions = RunOptions.from_pipeline_selection(pipeline)
+
+    result: ApiPipelineResultRun = run_pipeline_results(
+        pipeline=pipeline,
+        paths=[tmp_path],
+        run_options=run_options,
+        base_config={
+            "files": {"include": ["*.does-not-exist"]},
+        },
+    )
+
+    assert result.file_list == []
+    assert result.results == ()
+    assert result.exit_code is None

--- a/tests/pipeline/test_engine_path_configs.py
+++ b/tests/pipeline/test_engine_path_configs.py
@@ -34,6 +34,7 @@ from topmark.pipeline import engine
 from topmark.runtime.model import RunOptions
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from topmark.config.model import FrozenConfig
@@ -190,3 +191,104 @@ def test_run_steps_for_files_falls_back_to_shared_config_without_path_configs(
     assert policy_calls == [shared_cfg]
     assert bootstrap_calls[0][3] == {"header_fields": ("project", "file")}
     assert bootstrap_calls[1][3] == {"header_fields": ("project", "file")}
+
+
+@pytest.mark.pipeline
+def test_iter_steps_for_files_yields_contexts_before_later_files_are_bootstrapped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming engine iteration should not materialize all contexts up front."""
+    file_a: Path = tmp_path / "a.py"
+    file_b: Path = tmp_path / "b.py"
+    file_a.write_text("print('a')\n", encoding="utf-8")
+    file_b.write_text("print('b')\n", encoding="utf-8")
+
+    shared_cfg: FrozenConfig = make_frozen_config(header_fields=["project"])
+    bootstrapped_paths: list[Path] = []
+
+    class FakeProcessingContext:
+        """Minimal stand-in exposing the bootstrap contract used by the engine."""
+
+        @classmethod
+        def bootstrap(
+            cls,
+            *,
+            path: Path,
+            config: FrozenConfig,
+            run_options: RunOptions,
+            policy_registry_override: PolicyRegistry | None = None,
+        ) -> Any:
+            bootstrapped_paths.append(path)
+            return SimpleNamespace(path=path, config=config, run_options=run_options)
+
+    monkeypatch.setattr(engine, "ProcessingContext", FakeProcessingContext)
+    monkeypatch.setattr(engine.runner, "run", _fake_runner_run)
+
+    state: engine.PipelineExecutionState = engine.PipelineExecutionState()
+    contexts: Iterator[Any] = engine.iter_steps_for_files(
+        run_options=RunOptions(apply_changes=False),
+        config=shared_cfg,
+        path_configs=None,
+        pipeline=TEST_NOOP_PIPELINE_SELECTION,
+        file_list=[file_a, file_b],
+        state=state,
+    )
+
+    first: Any = next(contexts)
+
+    assert first.path == file_a
+    assert bootstrapped_paths == [file_a]
+    assert state.exit_code is None
+
+    second: Any = next(contexts)
+
+    assert second.path == file_b
+    assert bootstrapped_paths == [file_a, file_b]
+
+
+@pytest.mark.pipeline
+def test_iter_steps_for_files_records_engine_exit_code_in_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming engine iteration should preserve batch error-code semantics."""
+    missing: Path = tmp_path / "missing.py"
+    present: Path = tmp_path / "present.py"
+    present.write_text("print('present')\n", encoding="utf-8")
+
+    shared_cfg: FrozenConfig = make_frozen_config(header_fields=["project"])
+
+    class FakeProcessingContext:
+        """Minimal stand-in exposing the bootstrap contract used by the engine."""
+
+        @classmethod
+        def bootstrap(
+            cls,
+            *,
+            path: Path,
+            config: FrozenConfig,
+            run_options: RunOptions,
+            policy_registry_override: PolicyRegistry | None = None,
+        ) -> Any:
+            if path == missing:
+                raise FileNotFoundError(path)
+            return SimpleNamespace(path=path, config=config, run_options=run_options)
+
+    monkeypatch.setattr(engine, "ProcessingContext", FakeProcessingContext)
+    monkeypatch.setattr(engine.runner, "run", _fake_runner_run)
+
+    state: engine.PipelineExecutionState = engine.PipelineExecutionState()
+    contexts: list[Any] = list(
+        engine.iter_steps_for_files(
+            run_options=RunOptions(apply_changes=False),
+            config=shared_cfg,
+            path_configs=None,
+            pipeline=TEST_NOOP_PIPELINE_SELECTION,
+            file_list=[missing, present],
+            state=state,
+        ),
+    )
+
+    assert [ctx.path for ctx in contexts] == [present]
+    assert state.exit_code is engine.ExitCode.FILE_NOT_FOUND

--- a/tests/pipeline/test_reduction.py
+++ b/tests/pipeline/test_reduction.py
@@ -19,6 +19,7 @@ from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.core.exit_codes import ExitCode
 from topmark.pipeline.engine import exit_code_from_pipeline_results
 from topmark.pipeline.reduction import ProcessingReduction
+from topmark.pipeline.reduction import iter_processing_results
 from topmark.pipeline.reduction import reduce_processing_contexts
 from topmark.pipeline.status import ContentStatus
 from topmark.pipeline.status import FsStatus
@@ -27,10 +28,12 @@ from topmark.pipeline.status import WriteStatus
 from topmark.pipeline.views import DiffView
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from topmark.config.model import FrozenConfig
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.result import ProcessingResult
 
 
 def _make_reduction_context(
@@ -129,3 +132,41 @@ def test_reduce_processing_contexts_can_release_views_without_retaining_contexts
     assert reduction.results[0].detail.diff_text == "--- current\n+++ updated\n"
     assert ctx.views.diff is not None
     assert ctx.views.diff.text is None
+
+
+def test_iter_processing_results_reduces_and_releases_one_context_at_a_time(
+    tmp_path: Path,
+) -> None:
+    """Iterator reduction should release each context before consuming the next one."""
+    first: ProcessingContext = _make_reduction_context(tmp_path, "first.py")
+    second: ProcessingContext = _make_reduction_context(tmp_path, "second.py")
+    first.views.diff = DiffView(text="--- first\n+++ first\n")
+    second.views.diff = DiffView(text="--- second\n+++ second\n")
+
+    consumed_second: bool = False
+
+    def contexts() -> Iterator[ProcessingContext]:
+        nonlocal consumed_second
+        yield first
+        consumed_second = True
+        yield second
+
+    result_iter: Iterator[ProcessingResult] = iter_processing_results(
+        contexts(),
+        release_views=True,
+    )
+
+    first_result: ProcessingResult = next(result_iter)
+
+    assert first_result.detail.diff_text == "--- first\n+++ first\n"
+    assert first.views.diff is not None
+    assert first.views.diff.text is None
+    assert consumed_second is False
+    assert second.views.diff is not None
+    assert second.views.diff.text == "--- second\n+++ second\n"
+
+    second_result: ProcessingResult = next(result_iter)
+
+    assert second_result.detail.diff_text == "--- second\n+++ second\n"
+    assert second.views.diff is not None
+    assert second.views.diff.text is None


### PR DESCRIPTION
## Summary

This PR implements the first phase of GitHub issue #165 ("Evaluate streaming-oriented reduction and incremental reporting architecture").

The goal is to introduce streaming-capable execution and reduction seams internally while preserving all existing CLI, API, rendering, machine-output, ordering, summary, and exit-code behavior.

## What changed

### Engine-level iterator boundary

Added:

- `iter_steps_for_files()`

The engine can now yield per-file `ProcessingContext` instances in input order while preserving existing error-handling semantics.

`run_steps_for_files()` remains available as the existing batch materialization adapter.

### Reduction-level iterator boundary

The reduction layer now provides an iterator-oriented path through:

- `iter_processing_results()`

allowing callers to reduce contexts individually and release context-owned volatile views immediately after durable snapshotting.

`reduce_processing_contexts()` remains available as the batch materialization adapter.

### Runtime/API result-oriented orchestration

Added:

- `run_pipeline_results()`
- `ApiPipelineResultRun`

Normal `check()` and `strip()` API execution now consume durable `ProcessingResult` snapshots through the new runtime path.

This removes mutable-context handoff from the normal check/strip runtime flow while preserving existing public behavior.

### Documentation

Updated:

- `docs/dev/architecture.md`
- `docs/dev/pipelines.md`
- `docs/dev/pipelines-reference.md`
- `docs/dev/performance-baselines.md`

to document the new execution/reduction architecture and ownership boundaries.

### Tests

Added targeted regression coverage for empty durable-result batches.

## What did not change

This PR intentionally does **not**:

- change CLI behavior;
- change public API DTO shapes;
- change JSON or NDJSON schemas;
- change output ordering;
- change summary generation;
- change exit-code behavior;
- introduce incremental reporting;
- introduce streaming CLI output.

## Deferred follow-up work

Issue #165 remains open.

The following work is intentionally deferred:

- probe-specific migration onto a durable-result runtime path;
- evaluation of incremental reporting/output formats;
- any future Option D public streaming architecture;
- broader performance evaluation using repository-scale multi-file workloads.

## Validation

Expected validation:

```bash
uv run pytest
uv run pyright
uv run ruff check
uv run mdformat --check .
```

## Related issues

- Parent issue: #165
- Builds on:
  - #148 durable ProcessingResult migration
  - #166 pipeline intent modelling