### PR TITLE
Complete probe durable-result runtime path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ ______________________________________________________________________
 - Migrated `probe` public API DTO assembly, machine-readable output, and TEXT/Markdown rendering to
   consume durable `ProcessingResult` snapshots carrying reduced `ProbeSnapshot` state, completing
   the current mutable-context to durable-result handover for output-facing consumers.
+- Migrated probe API orchestration onto the result-oriented `run_probe_pipeline_results()` runtime
+  adapter so real probe contexts and synthetic probe outcomes are reduced to durable
+  `ProcessingResult` snapshots before public API finalization.
 - Made human report-scope filtering result-compatible by introducing protocol-based filtering
   support for durable `ProcessingResult` snapshots while preserving context-based filtering support
   for pre-reduction probe consumers.
@@ -141,9 +144,11 @@ ______________________________________________________________________
   introducing explicit pipeline catalogue definitions and selection DTOs, and deriving runtime
   execution options from selected pipelines while preserving CLI, API, and machine-output behavior.
 - Introduced streaming-capable execution and reduction seams through `iter_steps_for_files()`,
-  `iter_processing_results()`, and the result-oriented `run_pipeline_results()` runtime adapter,
-  while preserving existing CLI, API, presentation, machine-output, ordering, summary, and exit-code
+  `iter_processing_results()`, `run_pipeline_results()`, and `run_probe_pipeline_results()`, while
+  preserving existing CLI, API, presentation, machine-output, ordering, summary, and exit-code
   behavior.
+- Strengthened public API `FileResult` DTO invariants so `bucket_key` and `bucket_label` are always
+  populated strings, matching the aggregation data produced by durable result finalization.
 
 ### Breaking Changes - Unreleased
 
@@ -319,9 +324,10 @@ ______________________________________________________________________
 - Documented the pipeline catalogue and selection architecture, including the separation between
   command intent, selected executable pipeline definitions, durable runtime options, and public API
   or machine-output compatibility boundaries.
-- Documented the streaming-capable execution and reduction architecture introduced for GitHub issue
-  165, including iterator-based engine/reduction seams, durable-result runtime orchestration,
-  ownership boundaries, and the rationale for preserving batch-oriented public contracts.
+- Documented the streaming-capable execution and reduction architecture completed for GitHub issue
+  165, including iterator-based engine/reduction seams, check/strip and probe durable-result runtime
+  adapters, synthetic probe-result ownership, and the rationale for preserving batch-oriented public
+  contracts.
 
 ### Internal - Unreleased
 
@@ -397,9 +403,13 @@ ______________________________________________________________________
 - Reworked internal pipeline selection around `Pipeline`, `PipelineDefinition`, and
   `PipelineSelection`, moved selection ownership into the pipeline catalogue, and added targeted
   coverage for catalogue metadata, selection variants, and runtime-option synchronization.
-- Added result-oriented runtime orchestration through `run_pipeline_results()`, migrated normal
-  check/strip API execution to consume durable `ProcessingResult` snapshots through the new runtime
-  path, and added regression coverage for empty durable-result batches.
+- Added result-oriented runtime orchestration through `run_pipeline_results()` and
+  `run_probe_pipeline_results()`, migrated check, strip, and probe API execution to consume durable
+  `ProcessingResult` snapshots through result-oriented runtime paths, and added regression coverage
+  for empty durable-result batches and filtered explicit probe inputs.
+- Removed the remaining context-oriented API runtime helpers `run_pipeline()` and
+  `run_probe_pipeline()` after their check/strip, probe, and nested-configuration test consumers
+  were migrated to durable result-oriented paths.
 
 ### Notes - Unreleased
 
@@ -427,6 +437,10 @@ ______________________________________________________________________
   path from the hard-link group.
 - Performance baseline outputs are written to Git-ignored `artifacts/perf/` run directories and are
   intended for local analysis rather than source control.
+- GitHub issue 165 performance validation regenerated an informational smoke benchmark after the
+  probe runtime migration. The current benchmark corpus remains effectively flat because it measures
+  single-file check/strip processing rather than cumulative probe orchestration or public streaming
+  output.
 
 ______________________________________________________________________
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -68,8 +68,10 @@ contexts for compatibility callers.
 materializes a \[`ProcessingReduction`\][topmark.pipeline.reduction.ProcessingReduction] from an
 iterable of contexts. At the runtime/API layer,
 \[`run_pipeline_results()`\][topmark.api.runtime.run_pipeline_results] is the result-oriented batch
-adapter for normal check/strip processing, while the context-oriented `run_pipeline()` path remains
-available for compatibility and probe-specific composition.
+adapter for normal check/strip processing, while
+\[`run_probe_pipeline_results()`\][topmark.api.runtime.run_probe_pipeline_results] provides the
+probe-specific result-oriented adapter, including durable synthetic results for missing or filtered
+explicit probe inputs.
 
 This boundary is intentionally conservative:
 
@@ -115,10 +117,10 @@ are created while mutable views still own the planned patch content.
 
 This design deliberately stops short of a streaming public API. Public and CLI consumers still see
 complete result collections, and final summaries remain batch-derived. Future work can build on the
-same iterator seam for probe-specific result composition or for truly incremental output formats,
-but those would be separate contract decisions. Diff generation should remain isolated behind the
-durable boundary so a later performance issue can evaluate whether `difflib` is still an appropriate
-backend or whether TopMark should adopt a lower-memory diff strategy.
+same iterator seam for truly incremental output formats, but those would be separate contract
+decisions. Diff generation should remain isolated behind the durable boundary so a later performance
+issue can evaluate whether `difflib` is still an appropriate backend or whether TopMark should adopt
+a lower-memory diff strategy.
 
 ______________________________________________________________________
 
@@ -294,14 +296,15 @@ machine output rather than projecting from raw pipeline contexts or resolver obj
   discovery-filtered inputs as filtered semantic outcomes because its purpose is to explain
   resolution and filtering.
 
-Synthetic contexts are built for resolver-level hard failures that occur before normal pipeline
-execution can begin. This keeps human output, machine-readable output, summaries, and exit-code
+Synthetic execution contexts are built for resolver-level hard failures that occur before normal
+pipeline execution can begin, then reduced to durable results at the same runtime boundary as normal
+pipeline contexts. This keeps human output, machine-readable output, summaries, and exit-code
 selection based on the same result collection instead of requiring separate side channels.
 
-For probe specifically, TopMark also builds synthetic probe contexts for explicit inputs filtered
-before file-type resolution. Missing explicit paths remain hard filesystem/input errors; they are
-not also emitted as filtered probe results. This keeps the public API and CLI probe output from
-reporting the same path twice.
+For probe specifically, TopMark also creates durable synthetic probe results for explicit inputs
+filtered before file-type resolution. Missing explicit paths remain hard filesystem/input errors;
+they are not also emitted as filtered probe results. This keeps the public API and CLI probe output
+from reporting the same path twice.
 
 Exit-code selection is centralized after pipeline execution by summarizing result statuses. The CLI
 layer remains responsible for process-level exit behavior, while pipeline and presentation layers

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -552,9 +552,13 @@ iter_steps_for_files()
 
 The implementation makes the engine able to yield per-file mutable processing contexts and makes the
 reduction layer able to snapshot each context into a durable `ProcessingResult` before releasing
-context-owned volatile views. Normal check and strip API orchestration now uses the result-oriented
-runtime adapter, while compatibility and probe-specific paths may still materialize mutable contexts
-before reduction.
+context-owned volatile views. Normal check and strip API orchestration uses the result-oriented
+runtime adapter. Probe API orchestration now uses the same durable-result runtime shape for real
+file-backed probe results and synthetic missing or filtered probe results, while preserving the
+existing public probe DTO contract. CLI probe output still materializes an ordered durable result
+tuple before rendering so exit-code precedence, machine-output schemas, and human output ordering
+remain unchanged, but it no longer retains source contexts or context-owned volatile views after
+reduction.
 
 This change primarily improves ownership clarity and context lifetime boundaries. It is not expected
 to materially change the existing single-file benchmark results because the current benchmark corpus
@@ -569,7 +573,12 @@ repository-scale runs would require a future many-file benchmark suite, because 
 scenarios do not measure cumulative `ProcessingContext` retention across large file sets.
 
 For the current baseline corpus, the expected result is effectively flat peak traced allocations and
-RSS. Any future streaming-output, probe-result, or public iterator API work should be benchmarked
+RSS. The issue 165 smoke baseline was regenerated after the probe-result adapter work. The run
+remained consistent with the expected flat profile for the current single-file benchmark corpus:
+`small_1kb_missing_header` in `check` mode measured about 412.3 KiB peak traced allocation and 43.9
+MiB max RSS. The result is informational rather than a new canonical baseline because the changed
+code path is probe orchestration, while the current benchmark corpus exercises check/strip
+processing paths. Any future streaming-output or public iterator API work should be benchmarked
 separately so memory changes remain attributable to a specific architectural layer.
 
 ______________________________________________________________________

--- a/docs/dev/pipelines-reference.md
+++ b/docs/dev/pipelines-reference.md
@@ -33,8 +33,11 @@ can snapshot those mutable contexts into durable
 \[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] instances through
 \[`iter_processing_results()`\][topmark.pipeline.reduction.iter_processing_results]. Runtime/API
 orchestration for normal check and strip execution uses the result-oriented
-\[`run_pipeline_results()`\][topmark.api.runtime.run_pipeline_results] adapter while preserving
-batch-compatible ordering, summaries, and output contracts.
+\[`run_pipeline_results()`\][topmark.api.runtime.run_pipeline_results] adapter. Probe orchestration
+uses \[`run_probe_pipeline_results()`\][topmark.api.runtime.run_probe_pipeline_results] to reduce
+real probe contexts and synthetic probe results across the same durable result boundary. Public CLI,
+API, presentation, and machine-output contracts still preserve batch-compatible ordering, summaries,
+and output schemas.
 
 Pipelines also operate on selected processing paths. Filesystem-identity evaluation occurs before
 ordinary pipeline execution begins and includes both processing-path normalization and

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -19,7 +19,7 @@ can mutate files or emit patch output.
 
 A dedicated **probe pipeline** exists for resolution diagnostics
 ([`topmark probe`](../usage/commands/probe.md)). Probe orchestration also reports explicit inputs
-filtered before file-type probing via synthetic probe contexts.
+filtered before file-type probing via durable synthetic probe results.
 
 At runtime, command intent is represented separately from the executable step sequence. CLI and API
 entry points first select a \[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection]
@@ -54,8 +54,11 @@ snapshots those mutable contexts into durable
 \[`ProcessingResult`\][topmark.pipeline.result.ProcessingResult] instances through
 \[`iter_processing_results()`\][topmark.pipeline.reduction.iter_processing_results]. Normal check
 and strip orchestration use the result-oriented runtime adapter
-\[`run_pipeline_results()`\][topmark.api.runtime.run_pipeline_results], while compatibility and
-probe-specific paths may still materialize mutable contexts before reduction.
+\[`run_pipeline_results()`\][topmark.api.runtime.run_pipeline_results]. Probe orchestration uses
+\[`run_probe_pipeline_results()`\][topmark.api.runtime.run_probe_pipeline_results], including
+durable synthetic results for missing or filtered explicit probe inputs. Public surfaces still
+collect the ordered durable results where stable summaries, exit codes, and machine-output schemas
+require batch-compatible state.
 
 Pipeline execution also consumes a selected **processing path**. File-list resolution performs
 filesystem-identity evaluation before ordinary pipeline execution begins.
@@ -114,7 +117,7 @@ handles symlink behavior: file symlink spellings and their targets are collapsed
 processing target before pipeline steps run. Filesystem-identity eligibility checks handle safety
 policy such as hard-link detection: hard-linked selected processing paths are blocked before
 ordinary step execution, while unrelated selected paths continue through the requested pipeline.
-Synthetic probe contexts for filtered or missing explicit inputs preserve diagnostic input
+Durable synthetic probe results for filtered or missing explicit inputs preserve diagnostic input
 information only for those paths that never became normal processing paths.
 
 ### Unified Pipeline Flow
@@ -252,8 +255,8 @@ This pipeline powers [`topmark probe`](../usage/commands/probe.md) and
 **resolution-only**.
 
 It halts immediately after probing and does not perform inspection, comparison, or mutation.
-Discovery-level filtering is reported by orchestration via synthetic probe results for explicitly
-requested paths that did not reach probing.
+Discovery-level filtering is reported by orchestration via durable synthetic probe results for
+explicitly requested paths that did not reach probing.
 
 Probe results that do reach runtime probing report processing paths. They should not be interpreted
 as a lossless echo of the original invocation spelling.
@@ -861,6 +864,6 @@ flowchart TD
 ```
 
 Filtered or missing explicit inputs are not produced by
-\[`ProberStep`\][topmark.pipeline.steps.prober.ProberStep] itself. They are represented by synthetic
-contexts created by probe orchestration before final presentation, API, and machine-readable output
+\[`ProberStep`\][topmark.pipeline.steps.prober.ProberStep] itself. Probe orchestration represents
+them as durable synthetic probe results before final presentation, API, and machine-readable output
 packaging.

--- a/src/topmark/api/commands/pipeline.py
+++ b/src/topmark/api/commands/pipeline.py
@@ -20,16 +20,19 @@ Call styles:
 Notes:
 - These functions choose the concrete pipeline, build execution-only run options,
   and delegate runtime setup/execution to [`topmark.api.runtime`][topmark.api.runtime] helpers.
-- `check()` and `strip()` apply public report-scope filtering in the view layer.
-  `probe()` returns the probe result set assembled by the probe-specific view helper.
+- Runtime helpers reduce mutable execution contexts to durable processing results
+  before this module assembles public DTOs in the view layer.
+- `check()` and `strip()` apply public report-scope filtering in the common run
+  finalizer. `probe()` uses the probe-specific finalizer.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import Final
 
 from topmark.api.runtime import run_pipeline_results
-from topmark.api.runtime import run_probe_pipeline
+from topmark.api.runtime import run_probe_pipeline_results
 from topmark.api.view import finalize_probe_result
 from topmark.api.view import finalize_run_result
 from topmark.core.errors import InvalidReportScopeError
@@ -46,7 +49,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from topmark.api.runtime import ApiPipelineResultRun
-    from topmark.api.types import ApiPipelineRun
     from topmark.api.types import ProbeRunResult
     from topmark.api.types import PublicPolicy
     from topmark.api.types import PublicReportScopeLiteral
@@ -57,6 +59,20 @@ __all__ = (
     "check",
     "probe",
     "strip",
+)
+
+_CHECK_UPDATE_STATUSES: Final[frozenset[PlanStatus]] = frozenset(
+    {
+        PlanStatus.INSERTED,
+        PlanStatus.REPLACED,
+        PlanStatus.REMOVED,
+    }
+)
+
+_STRIP_UPDATE_STATUSES: Final[frozenset[PlanStatus]] = frozenset(
+    {
+        PlanStatus.REMOVED,
+    }
 )
 
 
@@ -81,6 +97,80 @@ def _resolve_public_report_scope(
             message=f"Invalid value for report: {value!r}",
             report_value=value,
         ) from exc
+
+
+def _run_content_pipeline(
+    paths: Iterable[Path | str],
+    *,
+    pipeline_kind: PipelineKindLiteral,
+    apply: bool,
+    diff: bool,
+    config: Mapping[str, object] | None,
+    policy: PublicPolicy | None,
+    policy_by_type: Mapping[str, PublicPolicy] | None,
+    include_file_types: Sequence[str] | None,
+    exclude_file_types: Sequence[str] | None,
+    report: PublicReportScopeLiteral,
+    prune_views: bool,
+    update_statuses: frozenset[PlanStatus],
+) -> RunResult:
+    """Run a content-processing pipeline and assemble the public result DTO.
+
+    Args:
+        paths: Files and/or directories to process.
+        pipeline_kind: Selected public pipeline family, either `check` or `strip`.
+        apply: If `True`, write changes in-place; otherwise perform a dry run.
+        diff: If `True`, include unified diffs for changes where applicable.
+        config: Optional plain mapping or immutable configuration object used as
+            the runtime configuration seed.
+        policy: Optional global policy overrides in the public API shape.
+        policy_by_type: Optional per-type policy overrides in the public API shape.
+        include_file_types: Optional whitelist of file type identifiers.
+        exclude_file_types: Optional blacklist of file type identifiers.
+        report: Reporting scope for the returned API view.
+        prune_views: If True, release consumed volatile views between pipeline steps.
+        update_statuses: Plan statuses counted as write/update candidates by the
+            public result finalizer.
+
+    Returns:
+        Filtered per-file outcomes, counts, diagnostics, and write stats.
+    """
+    # Choose the concrete content-processing pipeline variant.
+    pipeline: PipelineSelection = select_pipeline(
+        pipeline_kind,
+        apply=apply,
+        diff=diff,
+    )
+
+    # Run the pipeline; runtime helpers handle config discovery, policy overlays,
+    # file-list resolution, per-path config, and pipeline execution.
+
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        pipeline,
+        prune_views=prune_views,
+    )
+
+    api_run: ApiPipelineResultRun = run_pipeline_results(
+        pipeline=pipeline,
+        paths=paths,
+        run_options=run_options,
+        base_config=config,  # None preserves discovery; mapping/Config is honored.
+        include_file_types=include_file_types,
+        exclude_file_types=exclude_file_types,
+        policy=policy,
+        policy_by_type=policy_by_type,
+    )
+
+    report_scope: ReportScope = _resolve_public_report_scope(report)
+
+    return finalize_run_result(
+        results=api_run.results,
+        file_list=api_run.file_list,
+        apply=apply,
+        report_scope=report_scope,
+        update_statuses=update_statuses,
+        encountered_exit_code=api_run.exit_code,
+    )
 
 
 def check(
@@ -127,49 +217,19 @@ def check(
         Reporting/view filtering is handled by the public view layer. It does not
         change which files are eligible to be written when `apply=True`.
     """
-    PIPELINE_KIND: PipelineKindLiteral = "check"
-    # Choose the concrete content-processing pipeline variant.
-    pipeline: PipelineSelection = select_pipeline(
-        PIPELINE_KIND,
+    return _run_content_pipeline(
+        paths,
+        pipeline_kind="check",
         apply=apply,
         diff=diff,
-    )
-
-    # Run the pipeline; runtime helpers handle config discovery, policy overlays,
-    # file-list resolution, per-path config, and pipeline execution.
-
-    run_options: RunOptions = RunOptions.from_pipeline_selection(
-        pipeline,
-        prune_views=prune_views,
-    )
-
-    api_run: ApiPipelineResultRun = run_pipeline_results(
-        pipeline=pipeline,
-        paths=paths,
-        run_options=run_options,
-        base_config=config,  # None preserves discovery; mapping/FrozenConfig is honored.
-        include_file_types=include_file_types,
-        exclude_file_types=exclude_file_types,
+        config=config,
         policy=policy,
         policy_by_type=policy_by_type,
-    )
-
-    # Use common content-processing result assembly with check write statuses.
-    update_statuses: set[PlanStatus] = {
-        PlanStatus.INSERTED,
-        PlanStatus.REPLACED,
-        PlanStatus.REMOVED,
-    }
-
-    report_scope: ReportScope = _resolve_public_report_scope(report)
-
-    return finalize_run_result(
-        results=api_run.results,
-        file_list=api_run.file_list,
-        apply=apply,
-        report_scope=report_scope,
-        update_statuses=update_statuses,
-        encountered_exit_code=api_run.exit_code,
+        include_file_types=include_file_types,
+        exclude_file_types=exclude_file_types,
+        report=report,
+        prune_views=prune_views,
+        update_statuses=_CHECK_UPDATE_STATUSES,
     )
 
 
@@ -210,54 +270,25 @@ def strip(
         prune_views: If True, release consumed volatile views between pipeline steps.
 
     Returns:
-        Resolved runtime config, selected file list, filtered results, and any
-        fatal pipeline-level exit code.
+        Filtered per-file outcomes, counts, diagnostics, and write stats.
 
     Notes:
         Reporting/view filtering is handled by the public view layer and does not
         modify pipeline write decisions.
     """
-    PIPELINE_KIND: PipelineKindLiteral = "strip"
-    # Choose the concrete content-processing pipeline variant.
-    pipeline: PipelineSelection = select_pipeline(
-        PIPELINE_KIND,
+    return _run_content_pipeline(
+        paths,
+        pipeline_kind="strip",
         apply=apply,
         diff=diff,
-    )
-
-    # Run the pipeline; runtime helpers handle config discovery, policy overlays,
-    # file-list resolution, per-path config, and pipeline execution.
-
-    run_options: RunOptions = RunOptions.from_pipeline_selection(
-        pipeline,
-        prune_views=prune_views,
-    )
-
-    api_run: ApiPipelineResultRun = run_pipeline_results(
-        pipeline=pipeline,
-        paths=paths,
-        run_options=run_options,
-        base_config=config,  # None preserves discovery; mapping/Config is honored.
-        include_file_types=include_file_types,
-        exclude_file_types=exclude_file_types,
+        config=config,
         policy=policy,
         policy_by_type=policy_by_type,
-    )
-
-    # Use common content-processing result assembly with strip write statuses.
-    update_statuses: set[PlanStatus] = {
-        PlanStatus.REMOVED,
-    }
-
-    report_scope: ReportScope = _resolve_public_report_scope(report)
-
-    return finalize_run_result(
-        results=api_run.results,
-        file_list=api_run.file_list,
-        apply=apply,
-        report_scope=report_scope,
-        update_statuses=update_statuses,
-        encountered_exit_code=api_run.exit_code,
+        include_file_types=include_file_types,
+        exclude_file_types=exclude_file_types,
+        report=report,
+        prune_views=prune_views,
+        update_statuses=_STRIP_UPDATE_STATUSES,
     )
 
 
@@ -296,29 +327,28 @@ def probe(
             Probe results are built from resolution data, not presentation views.
 
     Returns:
-        Resolved runtime config, selected file list, probe results, and any
-        fatal pipeline-level exit code.
+        Stable probe results, summary counts, diagnostics, and any fatal
+        pipeline-level exit code.
 
     Notes:
         `probe()` is always read-only. It has no `apply` or `diff` mode because it
         explains resolution rather than planning or applying header mutations.
     """
-    PIPELINE_KIND: PipelineKindLiteral = "probe"
-    # Probe has a single read-only diagnostic pipeline.
+    # Probe has a single read-only diagnostic pipeline. Runtime helpers also
+    # attach synthetic durable results for missing literals and explicit inputs
+    # filtered before real probe execution.
     pipeline: PipelineSelection = select_pipeline(
-        PIPELINE_KIND,
+        "probe",
         apply=False,
         diff=False,
     )
-    # Run the probe pipeline; runtime helpers also attach synthetic contexts for
-    # missing literals and explicit inputs filtered before probing.
 
     run_options: RunOptions = RunOptions.from_pipeline_selection(
         selection=pipeline,
         prune_views=prune_views,
     )
 
-    api_run: ApiPipelineRun = run_probe_pipeline(
+    api_run: ApiPipelineResultRun = run_probe_pipeline_results(
         pipeline=pipeline,
         paths=paths,
         run_options=run_options,
@@ -331,10 +361,8 @@ def probe(
 
     # Probe has a dedicated public result shape; do not route it through the
     # check/strip finalizer.
-    from topmark.pipeline.reduction import reduce_processing_contexts
-
     return finalize_probe_result(
-        results=reduce_processing_contexts(api_run.contexts).results,
+        results=api_run.results,
         file_list=api_run.file_list,
         encountered_exit_code=api_run.exit_code,
     )

--- a/src/topmark/api/runtime.py
+++ b/src/topmark/api/runtime.py
@@ -17,7 +17,7 @@ This module contains typed helpers that orchestrate:
 - execution-only `RunOptions` consumption
 - config/preflight validation using effective resolved strictness across
   staged validation logs
-- pipeline selection and execution
+- pipeline execution and durable result reduction
 
 These functions are **internal to the `topmark.api` package**:
 - They are not re-exported from `topmark.api`.
@@ -34,7 +34,6 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from topmark.api.types import ApiPipelineRun
 from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.config.io.deserializers import mutable_config_from_mapping
 from topmark.config.model import FrozenConfig
@@ -51,11 +50,9 @@ from topmark.config.resolution.synthetic import SyntheticConfigSource
 from topmark.core.constants import TOPMARK_VERSION
 from topmark.core.errors import InvalidPolicyError
 from topmark.core.logging import get_logger
-from topmark.pipeline.engine import PipelineExecution
 from topmark.pipeline.engine import PipelineExecutionState
 from topmark.pipeline.engine import exit_code_from_pipeline_results
 from topmark.pipeline.engine import iter_steps_for_files
-from topmark.pipeline.engine import run_steps_for_files
 from topmark.pipeline.reduction import iter_processing_results
 from topmark.pipeline.synthetic import build_filtered_probe_contexts
 from topmark.pipeline.synthetic import build_missing_file_contexts
@@ -191,7 +188,7 @@ def ensure_mutable_config(
         logger.debug("Supplied config is MutableConfig - returning as is")
         return config
     if isinstance(config, FrozenConfig):
-        # Thaw a n immutable FrozenConfig into a mutable draft while preserving
+        # Thaw an immutable FrozenConfig into a mutable draft while preserving
         # staged validation logs and the flattened compatibility diagnostics.
         logger.debug("Supplied config is FrozenConfig - returning config.thaw()")
         return config.thaw()
@@ -406,7 +403,8 @@ def _build_path_configs(
 
     When provenance layers are available, each file path receives a config built from the subset of
     layers whose scope applies to that path. Config-like runtime policy overlays are copied onto the
-    per-path effective config.
+    per-path effective config so pipeline steps see the same invocation policy regardless of where
+    the file-specific fields came from.
 
     When no layers are available, this helper falls back to using the single run-level config for
     every path.
@@ -414,7 +412,7 @@ def _build_path_configs(
     Args:
         layers: Optional discovered config provenance layers for the run.
         file_list: Files that will be processed.
-        effective_cfg: Final runtime runtime config carrying any runtime policy overlays.
+        effective_cfg: Final runtime config carrying any runtime policy overlays.
 
     Returns:
         A mapping from file path to the effective runtime config that should be used when
@@ -652,46 +650,6 @@ def _prepare_api_pipeline_run(
     )
 
 
-def _execute_pipeline_for_file_list(
-    *,
-    prepared: PreparedApiRun,
-    pipeline: PipelineSelection,
-) -> PipelineExecution:
-    """Execute pipeline steps for the selected files in a prepared API run.
-
-    Args:
-        prepared: Shared resolved state for the API run.
-        pipeline: Pipeline steps to execute.
-
-    Returns:
-        Pipeline execution result containing processing contexts and any fatal
-        exit code reported by the pipeline engine. If no files were selected,
-        returns an empty context list with no exit code.
-    """
-    if not prepared.file_list:
-        return PipelineExecution(
-            contexts=[],
-            exit_code=None,
-        )
-
-    # (1) Build per-path effective configs for layered discovery.
-    path_configs: dict[Path, FrozenConfig] = _build_path_configs(
-        layers=prepared.discovered_layers,
-        file_list=prepared.file_list,
-        effective_cfg=prepared.effective_cfg,
-    )
-
-    # (2) Execute the selected pipeline for each resolved file.
-    pipeline_run: PipelineExecution = run_steps_for_files(
-        run_options=prepared.run_options,
-        config=prepared.effective_cfg,
-        path_configs=path_configs,
-        pipeline=pipeline,
-        file_list=prepared.file_list,
-    )
-    return pipeline_run
-
-
 def _iter_pipeline_results_for_file_list(
     *,
     prepared: PreparedApiRun,
@@ -750,7 +708,7 @@ def run_pipeline_results(
     """Resolve shared API runtime state and run a pipeline to durable results.
 
     This is the result-oriented batch adapter over the streaming-capable
-    engine and reduction helpers. It preserves existing API/CLI batch behavior
+    engine and reduction helpers. It preserves existing API batch behavior
     while avoiding mutable-context handoff for normal check/strip consumers.
 
     Args:
@@ -802,7 +760,7 @@ def run_pipeline_results(
     )
 
 
-def run_pipeline(
+def run_probe_pipeline_results(
     *,
     pipeline: PipelineSelection,
     paths: Iterable[Path | str],
@@ -813,75 +771,13 @@ def run_pipeline(
     # public-policy overlays (None = no override)
     policy: PublicPolicy | None = None,
     policy_by_type: Mapping[str, PublicPolicy] | None = None,
-) -> ApiPipelineRun:
-    """Resolve shared API runtime state and run a content-processing pipeline.
+) -> ApiPipelineResultRun:
+    """Resolve shared API runtime state and run probe to durable results.
 
-    Args:
-        pipeline: The pipeline steps to apply.
-        paths: Files and/or directories to process.
-        run_options: Invocation-wide execution-only runtime options for the run.
-        base_config: `None` for normal layered discovery; otherwise an explicit
-            config seed supplied directly by the caller.
-        include_file_types: Optional allowlist of file type identifiers used for
-            file-list resolution.
-        exclude_file_types: Optional denylist of file type identifiers used for
-            file-list resolution.
-        policy: Optional global public policy overlay applied after config
-            resolution and before file discovery.
-        policy_by_type: Optional per-type public policy overlays applied after
-            config resolution and before file discovery.
-
-    Returns:
-        A tuple containing the resolved runtime config, selected file list, pipeline
-        contexts, and any fatal exit code.
-    """
-    logger.info("Building config and file list for paths: %s", paths)
-
-    prepared: PreparedApiRun = _prepare_api_pipeline_run(
-        paths=paths,
-        run_options=run_options,
-        base_config=base_config,
-        include_file_types=include_file_types,
-        exclude_file_types=exclude_file_types,
-        policy=policy,
-        policy_by_type=policy_by_type,
-    )
-
-    execution: PipelineExecution = _execute_pipeline_for_file_list(
-        prepared=prepared,
-        pipeline=pipeline,
-    )
-    results: list[ProcessingContext] = execution.contexts
-    encountered_exit_code: ExitCode | None = execution.exit_code
-
-    logger.info("Processing %d file(s) with TopMark %s", len(prepared.file_list), TOPMARK_VERSION)
-
-    return ApiPipelineRun(
-        effective_cfg=prepared.effective_cfg,
-        file_list=prepared.file_list,
-        contexts=results,
-        exit_code=encountered_exit_code,
-    )
-
-
-def run_probe_pipeline(
-    *,
-    pipeline: PipelineSelection,
-    paths: Iterable[Path | str],
-    run_options: RunOptions,
-    base_config: Mapping[str, object] | FrozenConfig | None,
-    include_file_types: Sequence[str] | None = None,
-    exclude_file_types: Sequence[str] | None = None,
-    # public-policy overlays (None = no override)
-    policy: PublicPolicy | None = None,
-    policy_by_type: Mapping[str, PublicPolicy] | None = None,
-) -> ApiPipelineRun:
-    """Resolve shared API runtime state and run the probe pipeline.
-
-    Probe has one behavior beyond `run_pipeline()`: it preserves explicit inputs
-    that disappear before normal pipeline execution. Those inputs receive
-    synthetic contexts so `topmark.api.probe()` can explain missing literals and
-    discovery-filtered paths without exposing resolver internals.
+    This is the result-oriented probe adapter over the streaming-capable engine
+    and reduction helpers. It preserves the existing probe API batch contract
+    while reducing real per-file probe contexts immediately after each file is
+    executed and reducing synthetic probe contexts as soon as they are built.
 
     Args:
         pipeline: The probe pipeline steps to execute.
@@ -899,8 +795,8 @@ def run_probe_pipeline(
             config resolution and before file discovery.
 
     Returns:
-        A tuple containing the resolved runtime config, selected file list, real plus
-        synthetic probe contexts, and any fatal exit code.
+        Resolved runtime state, selected file list, durable real plus synthetic
+        probe results, and any fatal pipeline-level exit code.
     """
     logger.info("Building probe config and file list for paths: %s", paths)
 
@@ -928,41 +824,52 @@ def run_probe_pipeline(
         )
     )
 
-    execution: PipelineExecution = _execute_pipeline_for_file_list(
-        prepared=prepared,
-        pipeline=pipeline,
+    state: PipelineExecutionState = PipelineExecutionState()
+    real_results: tuple[ProcessingResult, ...] = tuple(
+        _iter_pipeline_results_for_file_list(
+            prepared=prepared,
+            pipeline=pipeline,
+            state=state,
+        )
     )
-    results: list[ProcessingContext] = execution.contexts
-    encountered_exit_code: ExitCode | None = execution.exit_code
 
     # Missing explicit literals are hard resolver-level failures. Add them
     # before fatal precedence is derived so they can influence `had_errors`.
-    results.extend(
-        build_missing_file_contexts(
-            paths=prepared.file_resolution.missing_literals,
-            config=prepared.effective_cfg,
-            run_options=prepared.run_options,
+    missing_results: tuple[ProcessingResult, ...] = tuple(
+        iter_processing_results(
+            build_missing_file_contexts(
+                paths=prepared.file_resolution.missing_literals,
+                config=prepared.effective_cfg,
+                run_options=prepared.run_options,
+            ),
+            release_views=True,
         )
     )
 
-    pipeline_error_code: ExitCode | None = exit_code_from_pipeline_results(results)
-    encountered_exit_code = encountered_exit_code or pipeline_error_code
+    hard_error_results: tuple[ProcessingResult, ...] = real_results + missing_results
+    pipeline_error_code: ExitCode | None = exit_code_from_pipeline_results(hard_error_results)
+    encountered_exit_code: ExitCode | None = state.exit_code or pipeline_error_code
 
     # Discovery-filtered explicit inputs are semantic probe outcomes rather than
     # hard execution errors, so append them after fatal precedence is computed.
-    results.extend(
-        build_filtered_probe_contexts(
-            selection_results=filtered_selection_results,
-            config=prepared.effective_cfg,
-            run_options=prepared.run_options,
+    filtered_results: tuple[ProcessingResult, ...] = tuple(
+        iter_processing_results(
+            build_filtered_probe_contexts(
+                selection_results=filtered_selection_results,
+                config=prepared.effective_cfg,
+                run_options=prepared.run_options,
+            ),
+            release_views=True,
         )
     )
 
+    results: tuple[ProcessingResult, ...] = hard_error_results + filtered_results
+
     logger.info("Probing %d result(s) with TopMark %s", len(results), TOPMARK_VERSION)
 
-    return ApiPipelineRun(
+    return ApiPipelineResultRun(
         effective_cfg=prepared.effective_cfg,
         file_list=prepared.file_list,
-        contexts=results,
+        results=results,
         exit_code=encountered_exit_code,
     )

--- a/src/topmark/api/types.py
+++ b/src/topmark/api/types.py
@@ -223,8 +223,8 @@ class FileResult:
     path: Path
     outcome: Outcome
     diff: str | None
-    bucket_key: str | None = None
-    bucket_label: str | None = None
+    bucket_key: str
+    bucket_label: str
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/src/topmark/api/view.py
+++ b/src/topmark/api/view.py
@@ -17,7 +17,7 @@ assemble public run-result DTOs.
 Current reduction boundary:
 - `check()` and `strip()` consume durable `ProcessingResult` snapshots.
 - `probe()` consumes durable probe snapshots carried by `ProcessingResult`,
-  matching the check/strip mutable-context to durable-result handover.
+  including synthetic results for missing or filtered explicit inputs.
 
 Why this exists:
 - `check()` and `strip()` share post-run behavior: filtering, summaries,
@@ -228,14 +228,14 @@ def count_writes(
     results: Sequence[ProcessingResult],
     *,
     apply: bool,
-    eligible: set[PlanStatus],
+    eligible: frozenset[PlanStatus],
 ) -> tuple[int, int]:
     """Return `(written, failed)` counts for the given results.
 
     Args:
         results: Durable pipeline results.
         apply: Whether the run was in apply mode (counts are zero when False).
-        eligible: Which `WriteStatus` values count as "written".
+        eligible: Which `PlanStatus` values are eligible to count as "written".
 
     Returns:
         The `(written, failed)` counts.
@@ -247,6 +247,20 @@ def count_writes(
     )
     failed: int = sum(1 for r in results if r.status.write == WriteStatus.FAILED)
     return written, failed
+
+
+def _diagnostic_entries_for_result(
+    result: ProcessingResult,
+) -> list[DiagnosticEntry]:
+    """Return public diagnostic entries for durable pipeline results.
+
+    Args:
+        result: Durable pipeline result to inspect.
+
+    Returns:
+        Public diagnostic entries in result order.
+    """
+    return [DiagnosticEntry(level=d.level.value, message=d.message) for d in result.diagnostics]
 
 
 def collect_diagnostics(
@@ -265,14 +279,9 @@ def collect_diagnostics(
     """
     diags: dict[str, list[DiagnosticEntry]] = {}
     for result in results:
-        if result.diagnostics:
-            diags[str(result.path)] = [
-                DiagnosticEntry(
-                    level=d.level.value,
-                    message=d.message,
-                )
-                for d in result.diagnostics
-            ]
+        entries: list[DiagnosticEntry] = _diagnostic_entries_for_result(result)
+        if entries:
+            diags[str(result.path)] = entries
     return diags
 
 
@@ -291,10 +300,8 @@ def collect_diagnostic_totals(
     total_warn: int = 0
     total_error: int = 0
     for result in results:
-        if not result.diagnostics:
-            continue
-        for d in result.diagnostics:
-            match d.level.value:
+        for diagnostic in _diagnostic_entries_for_result(result):
+            match diagnostic["level"]:
                 case "info":
                     total_info += 1
                 case "warning":
@@ -317,7 +324,7 @@ def finalize_run_result(
     apply: bool,
     report_scope: ReportScope,
     would_change: Callable[[ProcessingResult], bool] = would_change_result,
-    update_statuses: set[PlanStatus],
+    update_statuses: frozenset[PlanStatus],
     encountered_exit_code: ExitCode | None,
 ) -> RunResult:
     """Assemble a `RunResult` from pipeline results with consistent report filtering.
@@ -372,14 +379,7 @@ def finalize_run_result(
 
     bucket_summary: dict[str, int] = {}
     for fr in files:
-        # Each FileResult already carries bucket_key. If absent, recompute from ctx.
-        if fr.bucket_key:
-            b_key: str = fr.bucket_key
-        else:
-            # If you already track the surviving contexts in this scope as `view_ctxs`,
-            # you can recompute with map_result_bucket(ctx). Otherwise, keep it simple:
-            b_key = fr.outcome.value  # harmless fallback (shouldn't happen)
-        bucket_summary[b_key] = bucket_summary.get(b_key, 0) + 1
+        bucket_summary[fr.bucket_key] = bucket_summary.get(fr.bucket_key, 0) + 1
 
     return RunResult(
         files=files,
@@ -409,8 +409,9 @@ def finalize_probe_result(
     public DTOs and summarizes by public probe status.
 
     Args:
-        results: Raw probe pipeline results, including synthetic contexts for
-            discovery-filtered explicit inputs when supplied by the caller.
+        results: Raw probe pipeline results, including synthetic durable results
+            for missing or discovery-filtered explicit inputs when supplied by
+            the caller.
         file_list: Resolved input files for the run. Used only to preserve the
             empty-run behavior shared with other API entry points.
         encountered_exit_code: Fatal exit code if any was encountered.

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -444,7 +444,9 @@ def probe_command(
     )
 
     durable_results: tuple[ProcessingResult, ...] = reduce_processing_contexts(
-        context_results
+        context_results,
+        retain_contexts=False,
+        release_views=True,
     ).results
 
     if fmt in (OutputFormat.JSON, OutputFormat.NDJSON):

--- a/tests/api/test_api_check_and_strip.py
+++ b/tests/api/test_api_check_and_strip.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 import topmark.core.outcomes
 from tests.api.conftest import has_header
 from tests.helpers.api import api_check_dir
@@ -25,7 +27,9 @@ from topmark import api
 from topmark.api.runtime import ApiPipelineResultRun
 from topmark.api.runtime import run_pipeline_results
 from topmark.api.types import PublicPolicy
+from topmark.api.types import PublicReportScopeLiteral
 from topmark.core.constants import TOPMARK_START_MARKER
+from topmark.core.errors import InvalidReportScopeError
 from topmark.pipeline.pipelines import PipelineSelection
 from topmark.pipeline.pipelines import select_pipeline
 from topmark.runtime.model import RunOptions
@@ -33,6 +37,7 @@ from topmark.runtime.model import RunOptions
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.processors.base import HeaderProcessor
 
 
@@ -221,3 +226,63 @@ def test_run_pipeline_results_handles_empty_file_list(tmp_path: Path) -> None:
     assert result.file_list == []
     assert result.results == ()
     assert result.exit_code is None
+
+
+@pytest.mark.parametrize("cmd", ["check", "strip"])
+@pytest.mark.parametrize("scope", ["actionable", "noncompliant", "all"])
+def test_check_and_strip_accept_public_report_scopes(
+    repo_py_with_and_without_header: Path,
+    cmd: PipelineKindLiteral,
+    scope: PublicReportScopeLiteral,
+) -> None:
+    """Public check/strip entry points accept every supported report scope."""
+    path: Path = repo_py_with_and_without_header / "src" / "without_header.py"
+
+    match cmd:
+        case "check":
+            api_cmd = api.check
+        case "strip":
+            api_cmd = api.strip
+        case _:
+            pytest.fail(f"Invalid API command: {cmd}")
+
+    result: api.RunResult = api_cmd(
+        [path],
+        apply=False,
+        diff=False,
+        config=None,
+        include_file_types=["python"],
+        report=scope,
+        prune_views=True,
+    )
+
+    assert result.had_errors is False
+    assert result.bucket_summary is not None
+
+
+@pytest.mark.parametrize("cmd", ["check", "strip"])
+def test_check_and_strip_reject_invalid_report_scope(
+    repo_py_with_and_without_header: Path,
+    cmd: PipelineKindLiteral,
+) -> None:
+    """Public check/strip entry points reject unsupported report scopes."""
+    path: Path = repo_py_with_and_without_header / "src" / "without_header.py"
+
+    match cmd:
+        case "check":
+            api_cmd = api.check
+        case "strip":
+            api_cmd = api.strip
+        case _:
+            pytest.fail(f"Invalid API command: {cmd}")
+
+    with pytest.raises(InvalidReportScopeError):
+        api_cmd(
+            [path],
+            apply=False,
+            diff=False,
+            config=None,
+            include_file_types=["python"],
+            report="non-existing",  # pyright: ignore[reportArgumentType]
+            prune_views=True,
+        )

--- a/tests/api/test_api_probe.py
+++ b/tests/api/test_api_probe.py
@@ -21,11 +21,27 @@ from typing import TYPE_CHECKING
 import pytest
 
 from topmark import api
+from topmark.api.view import finalize_probe_result
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from topmark.api.types import DiagnosticTotals
+
+
+def test_finalize_probe_result_empty_run_returns_empty_public_result() -> None:
+    """Probe finalization preserves empty-run public DTO shape."""
+    result: api.ProbeRunResult = finalize_probe_result(
+        results=(),
+        file_list=[],
+        encountered_exit_code=None,
+    )
+
+    assert result.files == ()
+    assert result.summary == {}
+    assert result.had_errors is False
+    assert result.diagnostics is None
+    assert result.diagnostic_totals is None
 
 
 def test_probe_empty_explicit_dir_is_reported_as_filtered(tmp_path: Path) -> None:

--- a/tests/api/test_api_runtime_probe_results.py
+++ b/tests/api/test_api_runtime_probe_results.py
@@ -1,0 +1,126 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_api_runtime_probe_results.py
+#   file_relpath : tests/api/test_api_runtime_probe_results.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Runtime tests for durable probe-result orchestration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from topmark.api.runtime import run_probe_pipeline_results
+from topmark.core.exit_codes import ExitCode
+from topmark.pipeline.pipelines import select_pipeline
+from topmark.pipeline.status import FsStatus
+from topmark.pipeline.status import ResolveStatus
+from topmark.runtime.model import RunOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.api.runtime import ApiPipelineResultRun
+    from topmark.pipeline.pipelines import PipelineSelection
+    from topmark.pipeline.result import ProcessingResult
+
+
+def test_run_probe_pipeline_results_returns_durable_results_for_real_files(
+    tmp_path: Path,
+) -> None:
+    """Probe runtime reduces real file contexts directly to durable results."""
+    target: Path = tmp_path / "sample.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+    pipeline: PipelineSelection = select_pipeline("probe", apply=False, diff=False)
+    run_options: RunOptions = RunOptions.from_pipeline_selection(
+        selection=pipeline,
+        prune_views=True,
+    )
+
+    result: ApiPipelineResultRun = run_probe_pipeline_results(
+        pipeline=pipeline,
+        paths=[target],
+        run_options=run_options,
+        base_config=None,
+        include_file_types=["python"],
+    )
+
+    assert result.file_list == [target]
+    assert result.exit_code is None
+    assert len(result.results) == 1
+    assert result.results[0].probe is not None
+    assert result.results[0].probe.status == "resolved"
+    assert result.results[0].execution_mode.pipeline_kind == "probe"
+
+
+def test_run_probe_pipeline_results_preserves_missing_input_precedence(
+    tmp_path: Path,
+) -> None:
+    """Missing explicit inputs remain durable probe results and hard failures."""
+    missing: Path = tmp_path / "missing.py"
+    pipeline: PipelineSelection = select_pipeline("probe", apply=False, diff=False)
+    run_options: RunOptions = RunOptions.from_pipeline_selection(selection=pipeline)
+
+    result: ApiPipelineResultRun = run_probe_pipeline_results(
+        pipeline=pipeline,
+        paths=[missing],
+        run_options=run_options,
+        base_config=None,
+    )
+
+    assert result.file_list == []
+    assert result.exit_code == ExitCode.FILE_NOT_FOUND
+    assert len(result.results) == 1
+    assert result.results[0].path == missing
+    assert result.results[0].probe is None
+    assert result.results[0].status.fs == FsStatus.NOT_FOUND
+
+
+def test_run_probe_pipeline_results_preserves_filtered_explicit_inputs(
+    tmp_path: Path,
+) -> None:
+    """Explicit probe inputs excluded by file-type filters get durable results.
+
+    This validates the runtime adapter directly, not only the public `api.probe()`
+    DTO finalizer. Filtered explicit paths should remain visible as synthetic
+    durable probe results even though no real probe pipeline context is executed
+    for the excluded file.
+    """
+    python_file: Path = tmp_path / "sample.py"
+    python_file.write_text("print('hello')\n", encoding="utf-8")
+    toml_file: Path = tmp_path / "sample.toml"
+    toml_file.write_text("[test]\nfoo = 'bar'\n", encoding="utf-8")
+
+    pipeline: PipelineSelection = select_pipeline("probe", apply=False, diff=False)
+    run_options: RunOptions = RunOptions.from_pipeline_selection(pipeline)
+
+    result: ApiPipelineResultRun = run_probe_pipeline_results(
+        pipeline=pipeline,
+        paths=[python_file, toml_file],
+        run_options=run_options,
+        base_config=None,
+        include_file_types=["python"],
+    )
+
+    assert result.file_list == [python_file]
+    assert result.exit_code is None
+    assert len(result.results) == 2
+
+    by_path: dict[Path, ProcessingResult] = {item.path: item for item in result.results}
+
+    python_result: ProcessingResult = by_path[python_file]
+    toml_result: ProcessingResult = by_path[toml_file]
+
+    assert python_result.status.resolve == ResolveStatus.RESOLVED
+    assert python_result.probe is not None
+    assert python_result.probe.status == "resolved"
+
+    assert toml_result.status.resolve == ResolveStatus.PENDING
+    assert toml_result.probe is not None
+    assert toml_result.probe.status == "filtered"
+    assert toml_result.probe.reason == "excluded_by_file_type_filter"
+    assert toml_result.probe.candidates == ()

--- a/tests/api/test_result_view.py
+++ b/tests/api/test_result_view.py
@@ -47,7 +47,13 @@ def test_finalize_run_result_consumes_durable_processing_results(
         file_list=[path],
         apply=False,
         report_scope=ReportScope.ALL,
-        update_statuses={PlanStatus.INSERTED, PlanStatus.REPLACED, PlanStatus.REMOVED},
+        update_statuses=frozenset(
+            {
+                PlanStatus.INSERTED,
+                PlanStatus.REPLACED,
+                PlanStatus.REMOVED,
+            }
+        ),
         encountered_exit_code=None,
     )
 

--- a/tests/pipeline/integration/test_nested_config_e2e.py
+++ b/tests/pipeline/integration/test_nested_config_e2e.py
@@ -17,16 +17,16 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from topmark.api.runtime import run_pipeline
+from topmark.api.runtime import ApiPipelineResultRun
+from topmark.api.runtime import run_pipeline_results
 from topmark.pipeline.pipelines import select_pipeline
 from topmark.runtime.model import RunOptions
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from topmark.api.types import ApiPipelineRun
-    from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.pipelines import PipelineSelection
+    from topmark.pipeline.result import ProcessingResult
 
 
 def _write(path: Path, content: str) -> None:
@@ -37,7 +37,15 @@ def _write(path: Path, content: str) -> None:
 
 @pytest.mark.pipeline
 def test_nested_config_applies_only_within_its_subtree(tmp_path: Path) -> None:
-    """A nested config should affect only files within its own subtree."""
+    """A nested config should affect durable output for its own subtree only.
+
+    This end-to-end test intentionally observes nested configuration through
+    reduced [`ProcessingResult`][topmark.pipeline.result.ProcessingResult]
+    snapshots instead of retained mutable processing contexts. The API runtime
+    path reduces each file to durable result state and releases context-owned
+    volatile views, so output-facing behavior must be asserted via copied
+    details such as `diff_text` rather than `ProcessingContext.config`.
+    """
     root: Path = tmp_path / "repo"
     pkg: Path = root / "pkg"
     docs: Path = root / "docs"
@@ -74,12 +82,12 @@ def test_nested_config_applies_only_within_its_subtree(tmp_path: Path) -> None:
     pipeline: PipelineSelection = select_pipeline(
         "check",
         apply=False,
-        diff=False,
+        diff=True,
     )
     run_options: RunOptions = RunOptions.from_pipeline_selection(
         selection=pipeline,
     )
-    api_run: ApiPipelineRun = run_pipeline(
+    api_run: ApiPipelineResultRun = run_pipeline_results(
         pipeline=pipeline,
         paths=[pkg_file, docs_file],
         run_options=run_options,
@@ -92,19 +100,28 @@ def test_nested_config_applies_only_within_its_subtree(tmp_path: Path) -> None:
     # Limit discovery to Python files so the config files themselves are not part
     # of the processed candidate set for this end-to-end behavior check.
     assert set(api_run.file_list) == {pkg_file.resolve(), docs_file.resolve()}
-    assert len(api_run.contexts) == 2
+    assert len(api_run.results) == 2
 
-    by_path: dict[Path, ProcessingContext] = {ctx.path.resolve(): ctx for ctx in api_run.contexts}
+    by_path: dict[Path, ProcessingResult] = {
+        result.path.resolve(): result for result in api_run.results
+    }
 
-    pkg_ctx: ProcessingContext = by_path[pkg_file.resolve()]
-    docs_ctx: ProcessingContext = by_path[docs_file.resolve()]
+    pkg_result: ProcessingResult = by_path[pkg_file.resolve()]
+    docs_result: ProcessingResult = by_path[docs_file.resolve()]
 
-    assert pkg_ctx.config.header_fields == ("project", "file")
-    assert pkg_ctx.config.field_values["project"] == "TopMark"
-    assert pkg_ctx.config.field_values["license"] == "MIT"
-    assert pkg_ctx.config.field_values["file"] == "pkg/mod.py"
+    # `ProcessingResult` deliberately does not expose the per-file FrozenConfig.
+    # The nested-config contract is therefore verified through the durable diff
+    # snapshot copied across the reduction boundary.
+    pkg_diff: str | None = pkg_result.detail.diff_text
+    docs_diff: str | None = docs_result.detail.diff_text
 
-    assert docs_ctx.config.header_fields == ("project", "license")
-    assert docs_ctx.config.field_values["project"] == "TopMark"
-    assert docs_ctx.config.field_values["license"] == "MIT"
-    assert "file" not in docs_ctx.config.field_values
+    assert pkg_diff is not None
+    assert docs_diff is not None
+
+    assert "+#   project : TopMark" in pkg_diff
+    assert "+#   file    : pkg/mod.py" in pkg_diff
+    assert "+#   license : MIT" not in pkg_diff
+
+    assert "+#   project : TopMark" in docs_diff
+    assert "+#   license : MIT" in docs_diff
+    assert "+#   file" not in docs_diff


### PR DESCRIPTION
## Summary

This PR completes the issue #165 Option B follow-up by migrating probe API
orchestration onto the result-oriented runtime path.

It:

- adds `run_probe_pipeline_results()` for durable probe-result orchestration;
- removes the remaining context-oriented API runtime helpers `run_pipeline()` and
  `run_probe_pipeline()`;
- updates `api.probe()` to finalize public DTOs from durable `ProcessingResult`
  snapshots;
- keeps synthetic missing and filtered probe inputs as durable synthetic probe
  results;
- updates nested-configuration E2E coverage to assert durable diff snapshots
  instead of `ProcessingContext.config`;
- strengthens `FileResult.bucket_key` and `FileResult.bucket_label` to always be
  populated strings;
- updates architecture, pipeline, and performance-baseline documentation;
- records an informational issue #165 smoke benchmark result.

## Validation

- `1562 passed, 5 skipped`
- Coverage improved from `90.2%` to `90.3%`
- `src/topmark/api/commands/pipeline.py` now reports `100%` coverage
- issue #165 smoke benchmark remained effectively flat/informational

## Related issues / PRs

- Addresses GitHub issue #165
- Builds on the durable-result boundary completed in #148 / PR #164
- Follows the explicit pipeline-selection model from PR #168

## Compatibility

CLI behavior, public API result contents, presentation output, exit-code behavior,
and machine-output schemas are preserved.

Potential Python API compatibility note: direct manual construction of
`FileResult` now requires `bucket_key` and `bucket_label`, matching the values
already produced by TopMark result finalization.