### PR TITLE
Clarify PipelineSelection and RunOptions ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,11 @@ ______________________________________________________________________
   165, including iterator-based engine/reduction seams, check/strip and probe durable-result runtime
   adapters, synthetic probe-result ownership, and the rationale for preserving batch-oriented public
   contracts.
+- Documented the ownership boundary between `PipelineSelection` and `RunOptions`, clarifying
+  executable pipeline selection versus invocation-specific runtime state, the
+  `RunOptions.from_pipeline_selection(...)` derivation boundary, and the durable ownership chain
+  from pipeline selection through runtime options, processing contexts, and processing results
+  (GitHub issue 169).
 
 ### Internal - Unreleased
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -207,6 +207,8 @@ See also:
 - [`Discovery & Precedence`](../configuration/discovery.md)
 - [`Configuration overview`](../configuration/index.md)
 - [`Configuration schema`](configuration-schema.md)
+- [`Pipelines (Concepts)`](pipelines.md#selection-and-runtime-ownership) - selection/runtime
+  ownership boundary between `PipelineSelection` and `RunOptions`
 
 ______________________________________________________________________
 

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -46,6 +46,44 @@ documented in [`Architecture`](architecture.md) and
 steps are executable for the invocation; runtime options capture execution-wide state that must be
 copied onto processing contexts and durable results.
 
+______________________________________________________________________
+
+## Selection and runtime ownership
+
+Pipeline selection and runtime options deliberately model different ownership boundaries:
+
+- \[`PipelineSelection`\][topmark.pipeline.pipelines.PipelineSelection] owns the executable
+  catalogue choice for one invocation. It records the selected pipeline family, invocation flags
+  that affect variant selection, the concrete
+  \[`PipelineDefinition`\][topmark.pipeline.pipelines.PipelineDefinition], and the immutable step
+  sequence exposed by that definition.
+- \[`RunOptions`\][topmark.runtime.model.RunOptions] owns invocation-specific runtime state. It
+  carries execution metadata and policy such as mutation mode, diff-view preservation, STDIN
+  handling, writer behavior, view-pruning policy, and run-scoped timestamp state onto processing
+  contexts and reduced results.
+
+The intentional ownership chain is:
+
+```text
+PipelineSelection
+        ↓
+RunOptions
+        ↓
+ProcessingContext
+        ↓
+ProcessingResult
+```
+
+`RunOptions.from_pipeline_selection(...)` is therefore an explicit derivation boundary, not a sign
+that callers should configure pipeline intent twice. Overlapping values such as pipeline family,
+apply mode, and diff-view preservation are selected once through the pipeline catalogue, then copied
+into durable runtime options so downstream context, result, reporting, and future streaming/event
+layers do not depend on executable catalogue objects.
+
+This split keeps catalogue evolution separate from runtime execution evolution: new pipeline
+variants and selection metadata belong with `PipelineDefinition` and `PipelineSelection`, while
+invocation behavior that must be visible during execution or reduction belongs with `RunOptions`.
+
 Pipeline execution is streaming-capable internally, even though public CLI, API, presentation, and
 machine-output surfaces remain batch-oriented. The engine can yield per-file
 \[`ProcessingContext`\][topmark.pipeline.context.model.ProcessingContext] instances through
@@ -78,6 +116,8 @@ execution. They influence configuration discovery and staged config-loading vali
 do not become layered configuration fields.
 
 {% include-markdown "\_snippets/config-strictness.md" %}
+
+______________________________________________________________________
 
 ## Concepts vs Reference
 


### PR DESCRIPTION
# Document PipelineSelection and RunOptions ownership boundaries

Closes #169

## Summary

This PR documents the ownership-boundary review completed for
GitHub issue #169.

The review concluded that the existing architecture should be
retained:

```text
PipelineSelection
        ↓
RunOptions
        ↓
ProcessingContext
        ↓
ProcessingResult
```

No implementation changes were required.

## Changes

### Pipeline documentation

Add a dedicated "Selection and runtime ownership" section to:

- `docs/dev/pipelines.md`

The new section explains:

- ownership responsibilities of `PipelineSelection`
- ownership responsibilities of `RunOptions`
- the purpose of `RunOptions.from_pipeline_selection(...)`
- why the current overlap is intentional derivation rather than
  accidental duplication
- how the boundary supports future catalogue, runtime, and
  streaming-oriented evolution

### Architecture cross-reference

Add a cross-reference from:

- `docs/dev/architecture.md`

to the new pipeline ownership documentation.

## Architectural conclusion

The review found that:

- `PipelineSelection` owns executable pipeline catalogue choice
- `RunOptions` owns invocation-specific execution state and policy
- the current derivation boundary is intentional
- no DTO consolidation or redesign is justified
- the existing separation supports future work tracked in:
  - #170 (pipeline catalogue guidance)
  - #174 (future streaming/event APIs)

## Compatibility

No functional changes.

No CLI changes.

No API changes.

No machine-readable output changes.

No breaking changes.