### PR TITLE
Prefer structured diff for single-edit patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,6 +430,9 @@ ______________________________________________________________________
 - Added focused regression coverage for structured diff rendering, planned-edit inference,
   planner/stripper edit metadata generation, patcher shadow-validation behavior, and unified-diff
   formatter line-number rendering.
+- Made structured unified-diff rendering the primary patch-generation backend for valid single-edit
+  pipeline mutations, with `difflib.unified_diff()` retained as a fallback for missing, invalid, or
+  future multi-edit metadata.
 
 ### Notes - Unreleased
 

--- a/docs/dev/performance-baselines.md
+++ b/docs/dev/performance-baselines.md
@@ -482,6 +482,43 @@ Follow-up:
 - stdout presentation outside writer-owned updated-content emission, which remains the focus of
   GitHub issue 139;
 
+### Structured diff backend follow-up (GitHub issue 167)
+
+GitHub issue 167 evaluated whether structured edit metadata can become the primary diff-generation
+backend for current TopMark pipeline mutations. The current planner and stripper mutation paths emit
+exactly one contiguous `PlannedEdit` for the implemented update operations: header replacement,
+header insertion, and header removal. `EditView` keeps a tuple of edits as deliberate
+future-proofing, but current processors do not produce multiple independent file mutations from one
+pipeline action.
+
+Patch generation now prefers the structured unified-diff renderer when `EditView` contains exactly
+one edit and applying that edit to the original image reproduces the already-computed updated image.
+`difflib.unified_diff()` remains available as a fallback for missing, invalid, or future multi-edit
+metadata. This preserves the existing unified-diff output contract while avoiding generic sequence
+diffing on the common single-splice paths.
+
+Representative pathological measurements after the change were:
+
+| Scenario             | Mode                | Peak traced |  Max RSS |
+| -------------------- | ------------------- | ----------: | -------: |
+| `huge_diff`          | `strip_diff_pruned` |     4.35 MB | 46.90 MB |
+| `strip_large_header` | `strip_diff_pruned` |     6.37 MB | 52.80 MB |
+| `huge_header`        | `check_diff_pruned` |     3.21 MB | 47.12 MB |
+| `strip_large_header` | `check_diff_pruned` |     7.26 MB | 54.00 MB |
+
+The structured backend reduces the algorithmic work needed to produce patch lines for common
+single-splice mutations, but it does not remove the larger ownership boundaries that still dominate
+these workloads: comparison materializes current and updated lines before patching, and patch views
+still retain unified diff text for downstream reporting. The benchmark impact should therefore be
+interpreted as modest and workload-sensitive rather than as a broad memory step-change.
+
+The benchmark tool remains adequate for this class of change because the pathological
+`*_diff_pruned` modes exercise context retention, view pruning, diff retention, and repository-scale
+execution through the same durable-result pipeline used by the CLI and API. Its main limitation is
+that it measures retained process allocations and RSS around complete per-file processing; it does
+not isolate the diff algorithm's short-lived internal allocations from earlier comparison and
+updated image materialization.
+
 ### Stdout rendering and end-to-end output architecture audits (GitHub issues 139 and 147)
 
 GitHub issue 139 audited stdout rendering after the writer-owned streaming work. The audit found

--- a/docs/dev/pipelines.md
+++ b/docs/dev/pipelines.md
@@ -338,9 +338,12 @@ remaining consumer has run, while preserving requested output such as retained d
 Updated-file views may be represented either as materialized line sequences or as repeatable
 updated-content abstractions. This allows replacement planning to compose updated content lazily.
 Pipeline-generated lazy updated content must remain repeatable because comparison, patch generation,
-and writing may consume the same updated view. Writer file sinks and STDOUT emission stream through
-the context's updated-line iterator; comparison and patch generation still materialize updated lines
-where required by their current algorithms.
+and writing may consume the same updated view. Planner and stripper steps may also attach structured
+edit metadata describing the contiguous splice that produced the updated image. Patch generation
+uses that metadata as the preferred structured diff source for supported single-edit changes, while
+retaining generic diff generation as a fallback. Writer file sinks and STDOUT emission stream
+through the context's updated-line iterator; comparison and patch generation still materialize
+updated lines where required by their current algorithms.
 
 For filesystem inputs, the processing context path is the selected processing path. It may differ
 from the path spelling supplied on the command line or in configuration when symlinks or equivalent
@@ -710,9 +713,9 @@ Current consumer declarations are:
 | \[`BuilderStep`\][topmark.pipeline.steps.builder.BuilderStep]    | none                                            |
 | \[`RendererStep`\][topmark.pipeline.steps.renderer.RendererStep] | `image`, `header`, `build`                      |
 | \[`ComparerStep`\][topmark.pipeline.steps.comparer.ComparerStep] | `image`, `header`, `build`, `render`, `updated` |
-| \[`StripperStep`\][topmark.pipeline.steps.stripper.StripperStep] | `image`, `header`                               |
-| \[`PlannerStep`\][topmark.pipeline.steps.planner.PlannerStep]    | `image`, `header`, `render`, `updated`          |
-| \[`PatcherStep`\][topmark.pipeline.steps.patcher.PatcherStep]    | `image`, `updated`                              |
+| \[`StripperStep`\][topmark.pipeline.steps.stripper.StripperStep] | `image`, `header`, `edit`                       |
+| \[`PlannerStep`\][topmark.pipeline.steps.planner.PlannerStep]    | `image`, `header`, `render`, `updated`, `edit`  |
+| \[`PatcherStep`\][topmark.pipeline.steps.patcher.PatcherStep]    | `image`, `updated`, `edit`                      |
 | \[`WriterStep`\][topmark.pipeline.steps.writer.WriterStep]       | `updated`                                       |
 
 `ReaderStep` and `BuilderStep` produce views but do not consume existing view slots. `RendererStep`

--- a/src/topmark/pipeline/steps/patcher.py
+++ b/src/topmark/pipeline/steps/patcher.py
@@ -49,11 +49,138 @@ from topmark.presentation.shared.paths import get_display_path
 from topmark.utils.timestamp import format_gnu_diff_timestamp
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from topmark.core.logging import TopmarkLogger
     from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.views import PlannedEdit
 
 
 logger: TopmarkLogger = get_logger(__name__)
+
+
+def _apply_single_edit(
+    *,
+    original_lines: Sequence[str],
+    edit: PlannedEdit,
+) -> list[str] | None:
+    """Apply one planned edit to original lines for metadata validation.
+
+    Args:
+        original_lines: Original file image lines.
+        edit: Planned edit to apply.
+
+    Returns:
+        list[str] | None: Updated lines when the edit span is valid, otherwise
+        ``None``.
+    """
+    if edit.old_start < 0 or edit.old_end < edit.old_start:
+        return None
+    if edit.old_end > len(original_lines):
+        return None
+
+    return [
+        *original_lines[: edit.old_start],
+        *edit.new_lines,
+        *original_lines[edit.old_end :],
+    ]
+
+
+def _render_difflib_unified_diff(
+    *,
+    current_lines: Sequence[str],
+    updated_lines: Sequence[str],
+    fromfile: str,
+    tofile: str,
+    fromfiledate: str,
+    tofiledate: str,
+    lineterm: str,
+) -> list[str]:
+    """Render the generic difflib unified diff fallback.
+
+    Args:
+        current_lines: Original file image lines.
+        updated_lines: Updated file image lines.
+        fromfile: Diff label for the original file.
+        tofile: Diff label for the updated file.
+        fromfiledate: Timestamp label for the original file.
+        tofiledate: Timestamp label for the updated file.
+        lineterm: Diff control-line terminator.
+
+    Returns:
+        list[str]: Unified diff lines.
+    """
+    return list(
+        difflib.unified_diff(
+            current_lines,
+            updated_lines,
+            fromfile=fromfile,
+            tofile=tofile,
+            fromfiledate=fromfiledate,
+            n=3,
+            lineterm=lineterm,
+            tofiledate=tofiledate,
+        )
+    )
+
+
+def _render_patch_lines(
+    *,
+    current_lines: Sequence[str],
+    updated_lines: Sequence[str],
+    edit_view: EditView | None,
+    fromfile: str,
+    tofile: str,
+    fromfiledate: str,
+    tofiledate: str,
+    lineterm: str,
+) -> list[str]:
+    """Render patch lines, preferring structured single-edit metadata.
+
+    Args:
+        current_lines: Original file image lines.
+        updated_lines: Updated file image lines.
+        edit_view: Structured planned edits, when available.
+        fromfile: Diff label for the original file.
+        tofile: Diff label for the updated file.
+        fromfiledate: Timestamp label for the original file.
+        tofiledate: Timestamp label for the updated file.
+        lineterm: Diff control-line terminator.
+
+    Returns:
+        list[str]: Unified diff lines.
+    """
+    if edit_view is not None and len(edit_view.edits) == 1:
+        edit: PlannedEdit = edit_view.edits[0]
+        applied_lines: list[str] | None = _apply_single_edit(
+            original_lines=current_lines,
+            edit=edit,
+        )
+        if applied_lines == list(updated_lines):
+            structured_patch_lines: list[str] | None = render_structured_unified_diff(
+                original_lines=current_lines,
+                edit=edit,
+                fromfile=fromfile,
+                tofile=tofile,
+                fromfiledate=fromfiledate,
+                tofiledate=tofiledate,
+                lineterm=lineterm,
+                context=3,
+            )
+            if structured_patch_lines is not None:
+                return structured_patch_lines
+
+        logger.debug("structured diff unavailable for single edit; falling back to difflib")
+
+    return _render_difflib_unified_diff(
+        current_lines=current_lines,
+        updated_lines=updated_lines,
+        fromfile=fromfile,
+        tofile=tofile,
+        fromfiledate=fromfiledate,
+        tofiledate=tofiledate,
+        lineterm=lineterm,
+    )
 
 
 class PatcherStep(BaseStep):
@@ -131,13 +258,6 @@ class PatcherStep(BaseStep):
             ProcessingContext: The same context with ``ctx.views.diff`` set when a change is
                 detected, and with comparison status normalized when applicable.
 
-        Raises:
-            RuntimeError: During the GitHub issue #167 shadow-validation phase,
-                when the structured single-edit diff renderer produces output
-                that differs from the current `difflib.unified_diff()` result.
-                This temporary assertion protects the existing diff-output
-                contract while validating parity before any future backend
-                switch.
         """
         logger.debug(
             "File '%s' : header status %s, header comparison status: %s",
@@ -179,58 +299,17 @@ class PatcherStep(BaseStep):
         fromfiledate: str = format_gnu_diff_timestamp(dt=ctx.timestamp)
         tofiledate: str = format_gnu_diff_timestamp(dt=ctx.run_options.started_at)
 
-        patch_lines: list[str] = list(
-            difflib.unified_diff(
-                current_lines,
-                updated_lines,
-                fromfile=fromfile,
-                tofile=tofile,
-                fromfiledate=fromfiledate,
-                n=3,
-                lineterm=ctx.newline_style,
-                tofiledate=tofiledate,
-            )
+        patch_lines: list[str] = _render_patch_lines(
+            current_lines=current_lines,
+            updated_lines=updated_lines,
+            edit_view=ctx.views.edit,
+            fromfile=fromfile,
+            tofile=tofile,
+            fromfiledate=fromfiledate,
+            tofiledate=tofiledate,
+            lineterm=ctx.newline_style,
         )
 
-        # Transitional shadow-diff validation for GitHub issue #167.
-        #
-        # `difflib.unified_diff()` remains the production source of truth in this
-        # PR so the public diff contract stays unchanged. When the planner or
-        # stripper records exactly one structured edit, we also render the new
-        # structured diff and compare it with the difflib result. This intentionally
-        # duplicates diff work for now: the goal is to prove parity across the full
-        # test suite before a later PR can make the structured renderer the primary
-        # backend for single-splice edits.
-        #
-        # A mismatch is treated as a hard failure during this transitional phase.
-        # Silent fallback would hide cases where EditView metadata or structured
-        # rendering diverges from the existing output contract.
-        edit_view: EditView | None = ctx.views.edit
-        if edit_view is not None and len(edit_view.edits) == 1:
-            structured_patch_lines: list[str] | None = render_structured_unified_diff(
-                original_lines=current_lines,
-                edit=edit_view.edits[0],
-                fromfile=fromfile,
-                tofile=tofile,
-                fromfiledate=fromfiledate,
-                tofiledate=tofiledate,
-                lineterm=ctx.newline_style,
-                context=3,
-            )
-            if structured_patch_lines is not None and structured_patch_lines != patch_lines:
-                logger.debug(
-                    "structured diff shadow mismatch for %s: structured=%r difflib=%r",
-                    ctx.path,
-                    structured_patch_lines,
-                    patch_lines,
-                )
-                # Keep this as a temporary assertion until the structured renderer
-                # becomes the primary single-edit backend or this validation phase is
-                # explicitly retired.
-                raise RuntimeError(
-                    f"structured diff shadow mismatch for {ctx.path}: "
-                    f"structured={structured_patch_lines!r} difflib={patch_lines!r}"
-                )
         if len(patch_lines) == 0:
             ctx.status.comparison = ComparisonStatus.UNCHANGED
             ctx.status.patch = PatchStatus.SKIPPED
@@ -246,7 +325,7 @@ class PatcherStep(BaseStep):
                 ),
             )
 
-        # Join exactly as produced by difflib. Do not introduce CRLF conversions.
+        # Join exactly as produced by the selected backend. Do not introduce CRLF conversions.
         ctx.views.diff = DiffView(text="".join(patch_lines))
         if not ctx.views.diff or not ctx.views.diff.text:
             logger.error("ComparisonStatus == CHANGED but no diff generated: PatchStatus == FAILED")
@@ -291,4 +370,7 @@ class PatcherStep(BaseStep):
             )
         elif st == PatchStatus.PENDING:
             # patcher did not complete
-            ctx.request_halt(reason=f"{self.__class__.__name__} did not set state.", at_step=self)
+            ctx.request_halt(
+                reason=f"{self.__class__.__name__} did not set state.",
+                at_step=self,
+            )

--- a/tests/pipeline/steps/test_patcher.py
+++ b/tests/pipeline/steps/test_patcher.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import topmark.pipeline.steps.patcher as patcher_module
 from tests.helpers.pipeline import make_pipeline_context
 from tests.helpers.pipeline import materialize_updated_lines
 from tests.helpers.pipeline import run_builder
@@ -56,6 +57,7 @@ from topmark.presentation.formatters.unified_diff import format_patch_plain
 from topmark.runtime.model import RunOptions
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from topmark.config.model import FrozenConfig
@@ -313,8 +315,11 @@ def test_patcher_uses_stdin_filename_in_unified_diff_labels(tmp_path: Path) -> N
     assert "materialized-stdin.py" not in diff_text
 
 
-def test_patcher_accepts_matching_structured_shadow_diff(tmp_path: Path) -> None:
-    """Matching structured edit metadata should preserve normal diff generation."""
+def test_patcher_uses_structured_diff_for_valid_single_edit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid single-edit metadata should avoid the generic difflib fallback."""
     ctx: ProcessingContext = _make_patcher_context(
         tmp_path / "structured_match.py",
         image_lines=["old\n", "body\n"],
@@ -332,6 +337,15 @@ def test_patcher_accepts_matching_structured_shadow_diff(tmp_path: Path) -> None
         )
     )
 
+    def fail_difflib_fallback(**kwargs: object) -> list[str]:
+        raise AssertionError("difflib fallback should not be used")
+
+    monkeypatch.setattr(
+        patcher_module,
+        "_render_difflib_unified_diff",
+        fail_difflib_fallback,
+    )
+
     ctx = run_patcher(ctx)
 
     diff_text: str = ctx.views.diff.text if ctx.views.diff and ctx.views.diff.text else ""
@@ -340,8 +354,8 @@ def test_patcher_accepts_matching_structured_shadow_diff(tmp_path: Path) -> None
     assert "+new\n" in diff_text
 
 
-def test_patcher_rejects_mismatching_structured_shadow_diff(tmp_path: Path) -> None:
-    """Mismatching structured edit metadata should fail the shadow comparison."""
+def test_patcher_falls_back_for_mismatching_structured_edit(tmp_path: Path) -> None:
+    """Mismatching structured edit metadata should use the difflib fallback."""
     ctx: ProcessingContext = _make_patcher_context(
         tmp_path / "structured_mismatch.py",
         image_lines=["old\n", "body\n"],
@@ -359,8 +373,13 @@ def test_patcher_rejects_mismatching_structured_shadow_diff(tmp_path: Path) -> N
         )
     )
 
-    with pytest.raises(RuntimeError, match="structured diff"):
-        run_patcher(ctx)
+    ctx = run_patcher(ctx)
+
+    diff_text: str = ctx.views.diff.text if ctx.views.diff and ctx.views.diff.text else ""
+    assert ctx.status.patch is PatchStatus.GENERATED
+    assert "-old\n" in diff_text
+    assert "+new\n" in diff_text
+    assert "different" not in diff_text
 
 
 def test_patcher_falls_back_when_structured_shadow_diff_is_unavailable(
@@ -390,6 +409,169 @@ def test_patcher_falls_back_when_structured_shadow_diff_is_unavailable(
     assert ctx.status.patch is PatchStatus.GENERATED
     assert "-old\n" in diff_text
     assert "+new\n" in diff_text
+
+
+@pytest.mark.parametrize(
+    "edit",
+    [
+        pytest.param(
+            PlannedEdit(
+                kind=PlanEditKind.REPLACE,
+                old_start=-1,
+                old_end=1,
+                new_lines=("new\n",),
+            ),
+            id="negative-start",
+        ),
+        pytest.param(
+            PlannedEdit(
+                kind=PlanEditKind.REPLACE,
+                old_start=1,
+                old_end=0,
+                new_lines=("new\n",),
+            ),
+            id="reversed-span",
+        ),
+        pytest.param(
+            PlannedEdit(
+                kind=PlanEditKind.REPLACE,
+                old_start=0,
+                old_end=3,
+                new_lines=("new\n",),
+            ),
+            id="span-past-end",
+        ),
+    ],
+)
+def test_patcher_falls_back_for_invalid_single_edit_spans(
+    tmp_path: Path,
+    edit: PlannedEdit,
+) -> None:
+    """Invalid single-edit spans should be rejected before structured rendering."""
+    ctx: ProcessingContext = _make_patcher_context(
+        tmp_path / "invalid_span.py",
+        image_lines=["old\n", "body\n"],
+        updated_lines=["new\n", "body\n"],
+        comparison_status=ComparisonStatus.CHANGED,
+    )
+    ctx.views.edit = EditView(edits=(edit,))
+
+    ctx = run_patcher(ctx)
+
+    diff_text: str = ctx.views.diff.text if ctx.views.diff and ctx.views.diff.text else ""
+    assert ctx.status.patch is PatchStatus.GENERATED
+    assert "-old\n" in diff_text
+    assert "+new\n" in diff_text
+
+
+def test_patcher_falls_back_when_structured_renderer_returns_no_patch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid edit metadata should still fall back if structured rendering declines it."""
+    ctx: ProcessingContext = _make_patcher_context(
+        tmp_path / "structured_none.py",
+        image_lines=["old\n", "body\n"],
+        updated_lines=["new\n", "body\n"],
+        comparison_status=ComparisonStatus.CHANGED,
+    )
+    ctx.views.edit = EditView(
+        edits=(
+            PlannedEdit(
+                kind=PlanEditKind.REPLACE,
+                old_start=0,
+                old_end=1,
+                new_lines=("new\n",),
+            ),
+        )
+    )
+
+    def _render_no_patch(
+        *,
+        original_lines: Sequence[str],
+        edit: PlannedEdit,
+        fromfile: str,
+        tofile: str,
+        fromfiledate: str,
+        tofiledate: str,
+        lineterm: str,
+        context: int = 3,
+    ) -> list[str] | None:
+        """Test double that forces structured rendering fallback.
+
+        Returns:
+            None: Always returns ``None`` to simulate a structured renderer that
+            declines to render the supplied edit.
+        """
+        del original_lines, edit, fromfile, tofile, fromfiledate, tofiledate, lineterm, context
+        return None
+
+    monkeypatch.setattr(
+        patcher_module,
+        "render_structured_unified_diff",
+        _render_no_patch,
+    )
+
+    ctx = run_patcher(ctx)
+
+    diff_text: str = ctx.views.diff.text if ctx.views.diff and ctx.views.diff.text else ""
+    assert ctx.status.patch is PatchStatus.GENERATED
+    assert "-old\n" in diff_text
+    assert "+new\n" in diff_text
+
+
+def test_patcher_marks_failed_when_backend_returns_empty_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-empty patch lines that join to empty text should mark patch generation failed."""
+    ctx: ProcessingContext = _make_patcher_context(
+        tmp_path / "empty_text.py",
+        image_lines=["old\n"],
+        updated_lines=["new\n"],
+        comparison_status=ComparisonStatus.CHANGED,
+    )
+
+    def _render_empty_text_patch(
+        *,
+        current_lines: Sequence[str],
+        updated_lines: Sequence[str],
+        edit_view: EditView | None,
+        fromfile: str,
+        tofile: str,
+        fromfiledate: str,
+        tofiledate: str,
+        lineterm: str,
+    ) -> list[str]:
+        """Test double that produces an empty rendered diff payload.
+
+        Returns:
+            list[str]: A single empty string element, causing the joined diff text
+            to be empty while the rendered patch line collection remains non-empty.
+        """
+        del (
+            current_lines,
+            updated_lines,
+            edit_view,
+            fromfile,
+            tofile,
+            fromfiledate,
+            tofiledate,
+            lineterm,
+        )
+        return [""]
+
+    monkeypatch.setattr(
+        patcher_module,
+        "_render_patch_lines",
+        _render_empty_text_patch,
+    )
+
+    ctx = run_patcher(ctx)
+
+    assert ctx.status.comparison is ComparisonStatus.CHANGED
+    assert ctx.status.patch is PatchStatus.FAILED
+    assert ctx.views.diff == DiffView(text="")
 
 
 # Additional tests for PatcherStep.hint


### PR DESCRIPTION
## Summary

This completes the second phase of #167.

Changes:

- make structured unified-diff rendering the primary backend for valid single-edit pipeline mutations;
- keep `difflib.unified_diff()` as a safe fallback for missing, invalid, mismatching, or future multi-edit metadata;
- remove the temporary shadow-validation `RuntimeError` path from `PatcherStep`;
- add focused patcher tests for structured rendering, fallback behavior, invalid edit spans, and failed patch payload handling;
- update `docs/dev/pipelines.md` to document `edit` view consumption and structured edit metadata;
- update `docs/dev/performance-baselines.md` with the #167 benchmark interpretation;
- update `CHANGELOG.md`.

## Findings

Current TopMark planner and stripper mutation paths are representable as one contiguous `PlannedEdit`:

- header insertion;
- header replacement;
- header removal.

`EditView.edits` remains tuple-based for future multi-edit support, but current pipeline behavior does not require multi-hunk structured rendering before using the structured backend on common paths.

Benchmarks show that replacing generic diff generation has modest, workload-sensitive memory impact because comparison still materializes current and updated lines, and diff text is still retained for reporting.

## Follow-up

The remaining memory opportunity should be tracked separately: avoid full-image materialization during comparison and structured patch generation.

## Closes

Closes #167.