### PR TITLE
Omit empty Markdown files section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,8 @@ ______________________________________________________________________
   as compliant rather than actionable.
 - Fixed report-scope parity between the CLI and public API by applying the same actionable-filtering
   semantics and default report scope to both entry points.
+- Fixed Markdown pipeline output so report scopes with no visible per-file results no longer render
+  an empty `## Files` section.
 
 ### Documentation - Unreleased
 

--- a/src/topmark/presentation/markdown/pipeline.py
+++ b/src/topmark/presentation/markdown/pipeline.py
@@ -325,6 +325,10 @@ def _render_per_file_guidance_markdown(
         Markdown fragment containing all rendered file sections.
     """
     blocks: list[str] = []
+
+    if not results:
+        return ""
+
     blocks.append("## Files")
     blocks.append("")
 

--- a/tests/cli/test_pipeline_human_output.py
+++ b/tests/cli/test_pipeline_human_output.py
@@ -28,6 +28,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from tests.cli.conftest import assert_CONFIG_ERROR
+from tests.cli.conftest import assert_human_output_contains
+from tests.cli.conftest import assert_human_output_does_not_contain
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_WOULD_CHANGE
 from tests.cli.conftest import run_cli
@@ -36,6 +38,7 @@ from topmark.cli.keys import CliOpt
 from topmark.core.constants import TOPMARK_END_MARKER
 from topmark.core.constants import TOPMARK_START_MARKER
 from topmark.core.formats import OutputFormat
+from topmark.pipeline.reporting import ReportScope
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -63,6 +66,13 @@ def _write_file_requiring_strip(tmp_path: Path) -> Path:
         "print('has header')\n",
         encoding="utf-8",
     )
+    return path
+
+
+def _write_supported_headerless_file(tmp_path: Path) -> Path:
+    """Create a supported Python file without a TopMark header."""
+    path: Path = tmp_path / "without_header.py"
+    path.write_text("print('without header')\n", encoding="utf-8")
     return path
 
 
@@ -288,6 +298,69 @@ def test_check_markdown_output_shows_hints_without_text_verbosity(tmp_path: Path
     assert_WOULD_CHANGE(result)
     assert "Hints:" in result.output
     assert "header:missing" in result.output
+
+
+@pytest.mark.parametrize(
+    ("cmd", "report_scope"),
+    [
+        (CliCmd.CHECK, None),
+        (CliCmd.CHECK, ReportScope.ACTIONABLE),
+        (CliCmd.CHECK, ReportScope.NONCOMPLIANT),
+        (CliCmd.STRIP, None),
+        (CliCmd.STRIP, ReportScope.ACTIONABLE),
+        (CliCmd.STRIP, ReportScope.NONCOMPLIANT),
+    ],
+)
+def test_pipeline_markdown_output_omits_empty_files_section(
+    tmp_path: Path,
+    cmd: str,
+    report_scope: ReportScope | None,
+) -> None:
+    """Markdown output should not render an empty `## Files` section.
+
+    The default/actionable and noncompliant report scopes may legitimately hide
+    every per-file result. Markdown should mirror TEXT behavior by omitting the
+    per-file section instead of rendering a heading with no file entries.
+    """
+    path: Path = _write_supported_headerless_file(tmp_path)
+
+    if cmd == CliCmd.CHECK:
+        apply_result: Result = run_cli(
+            [
+                CliCmd.CHECK,
+                CliOpt.APPLY_CHANGES,
+                str(path),
+            ]
+        )
+        assert_SUCCESS(apply_result)
+
+    args: list[str] = [
+        cmd,
+        CliOpt.OUTPUT_FORMAT,
+        OutputFormat.MARKDOWN.value,
+    ]
+    if report_scope is not None:
+        args.extend(
+            [
+                CliOpt.REPORT,
+                report_scope.value,
+            ]
+        )
+    args.append(str(path))
+
+    result: Result = run_cli(args)
+
+    assert_SUCCESS(result)
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="# TopMark",
+    )
+    assert_human_output_does_not_contain(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="## Files",
+    )
 
 
 # --- TEXT verbosity ---


### PR DESCRIPTION
## Summary

Fixes Markdown pipeline output so report scopes with no visible per-file results no longer render an empty `## Files` section.

Fixes #196  
Refs #190  
Refs #193

## Changes

- Return an empty Markdown fragment from per-file guidance rendering when there are no visible file results.
- Add CLI regression coverage for Markdown output across:
  - `check`
  - `strip`
  - default report scope
  - `--report actionable`
  - `--report noncompliant`
- Update the Unreleased changelog.

## Validation

- `1685 passed, 5 skipped`
- Markdown pipeline coverage improved from `82.7%` to `83.0%`.