### PR TITLE
Suppress empty diff sections in human reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,8 @@ ______________________________________________________________________
   semantics and default report scope to both entry points.
 - Fixed Markdown pipeline output so report scopes with no visible per-file results no longer render
   an empty `## Files` section.
+- Fixed check/strip human diff output so TEXT and Markdown summary or per-file reports no longer
+  render empty diff sections when `--diff` is requested but no file has diff content.
 
 ### Documentation - Unreleased
 
@@ -460,6 +462,8 @@ ______________________________________________________________________
 - Made structured unified-diff rendering the primary patch-generation backend for valid single-edit
   pipeline mutations, with `difflib.unified_diff()` retained as a fallback for missing, invalid, or
   future multi-edit metadata.
+- Added focused CLI regression coverage for empty check/strip diff-output composition across TEXT
+  and Markdown summary and per-file report modes.
 
 ### Notes - Unreleased
 

--- a/src/topmark/presentation/markdown/pipeline.py
+++ b/src/topmark/presentation/markdown/pipeline.py
@@ -435,8 +435,7 @@ def _render_pipeline_diffs_markdown(
     Returns:
         Markdown diff section.
     """
-    # Keep Markdown diffs readable and copyable.
-    blocks: list[str] = ["## Diffs", ""]
+    diff_blocks: list[str] = []
     for result in results:
         patch: str | None = _render_diff_markdown(
             result.detail.diff_text,
@@ -444,17 +443,23 @@ def _render_pipeline_diffs_markdown(
         )
 
         if patch:
-            blocks.append(f"### {render_path_display_markdown(result)}")
-            blocks.append("")
-            blocks.append(
+            diff_blocks.append(f"### {render_path_display_markdown(result)}")
+            diff_blocks.append("")
+            diff_blocks.append(
                 render_fenced_code_block_markdown(
                     text=patch.rstrip("\n"),
                     language="diff",
                 )
             )
-            blocks.append("")
-    if len(blocks) > 2:
-        blocks.append("")
+            diff_blocks.append("")
+
+    if not diff_blocks:
+        return ""
+
+    # Keep Markdown diffs readable and copyable.
+    blocks: list[str] = ["## Diffs", ""]
+    blocks.extend(diff_blocks)
+    blocks.append("")
     return "\n".join(blocks).rstrip()
 
 

--- a/src/topmark/presentation/text/pipeline.py
+++ b/src/topmark/presentation/text/pipeline.py
@@ -582,6 +582,20 @@ def _render_pipeline_diffs_text(
     Returns:
         TEXT diff section.
     """
+    rendered_patches: list[str] = []
+    for result in results:
+        patch: str | None = _render_diff_text(
+            result.detail.diff_text,
+            styled=styled,
+            show_line_numbers=show_line_numbers,
+        )
+
+        if patch:
+            rendered_patches.append(patch)
+
+    if not rendered_patches:
+        return ""
+
     line_width: Final[int] = get_console_line_width()
 
     parts: list[str] = []
@@ -599,15 +613,7 @@ def _render_pipeline_diffs_text(
         )
     )
 
-    for result in results:
-        patch: str | None = _render_diff_text(
-            result.detail.diff_text,
-            styled=styled,
-            show_line_numbers=show_line_numbers,
-        )
-
-        if patch:
-            parts.append(patch)
+    parts.extend(rendered_patches)
 
     parts.append(
         diff_fence_style(

--- a/tests/cli/test_diff_output.py
+++ b/tests/cli/test_diff_output.py
@@ -20,6 +20,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
+from tests.cli.conftest import assert_markdown_output_does_not_contain
+from tests.cli.conftest import assert_rich_output_does_not_contain
+from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_WOULD_CHANGE
 from tests.cli.conftest import run_cli_in
 from topmark.cli.keys import CliCmd
@@ -45,6 +50,35 @@ def _write_plain_python_file(tmp_path: Path) -> Path:
     """
     path: Path = tmp_path / "example.py"
     path.write_text('print("hello")\n', encoding="utf-8")
+    return path
+
+
+def _write_python_file_with_topmark_header(tmp_path: Path) -> Path:
+    """Write a Python file containing a compliant TopMark header.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        Path to the created file.
+    """
+    path: Path = tmp_path / "example.py"
+    path.write_text(
+        "\n".join(
+            [
+                f"# {TOPMARK_START_MARKER}",
+                "#",
+                "#   file         : example.py",
+                "#   file_relpath : example.py",
+                "#",
+                f"# {TOPMARK_END_MARKER}",
+                "",
+                'print("hello")',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
     return path
 
 
@@ -90,6 +124,41 @@ def _assert_unified_diff_rendered(output: str, *, path_name: str) -> None:
     assert f"--- {path_name}" in output
     assert f"+++ {path_name}" in output
     assert "@@" in output
+
+
+def _assert_text_diff_output_absent(output: str) -> None:
+    """Assert that TEXT CLI output does not contain diff markers.
+
+    Args:
+        output: Captured CLI output.
+    """
+    assert_rich_output_does_not_contain(
+        output=output,
+        expected="diffs - start",
+    )
+    assert_rich_output_does_not_contain(
+        output=output,
+        expected="diffs - end",
+    )
+    assert_rich_output_does_not_contain(output=output, expected="--- example.py")
+    assert_rich_output_does_not_contain(output=output, expected="+++ example.py")
+    assert_rich_output_does_not_contain(output=output, expected="@@")
+
+
+def _assert_markdown_diff_output_absent(output: str) -> None:
+    """Assert that Markdown CLI output does not contain diff markers.
+
+    Args:
+        output: Captured CLI output.
+    """
+    assert_markdown_output_does_not_contain(
+        output=output,
+        expected="## Diffs",
+    )
+    assert_markdown_output_does_not_contain(output=output, expected="```diff")
+    assert_markdown_output_does_not_contain(output=output, expected="--- example.py")
+    assert_markdown_output_does_not_contain(output=output, expected="+++ example.py")
+    assert_markdown_output_does_not_contain(output=output, expected="@@")
 
 
 def test_check_diff_text_per_file_output_renders_patch(tmp_path: Path) -> None:
@@ -177,6 +246,115 @@ def test_check_diff_markdown_summary_output_renders_patch(tmp_path: Path) -> Non
     assert f"+# {TOPMARK_START_MARKER}" in result.output
 
 
+def test_check_diff_summary_output_suppresses_empty_diff_section(tmp_path: Path) -> None:
+    """TEXT summary output should omit diff fences when no check diff exists."""
+    path: Path = _write_plain_python_file(tmp_path)
+    run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.APPLY_CHANGES,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_SUCCESS(result)
+    assert_rich_output_does_not_contain(
+        output=result.output,
+        expected="diffs - start",
+    )
+    assert_rich_output_does_not_contain(
+        output=result.output,
+        expected="diffs - end",
+    )
+
+
+def test_check_diff_markdown_summary_output_suppresses_empty_diff_section(
+    tmp_path: Path,
+) -> None:
+    """Markdown summary output should omit `## Diffs` when no check diff exists."""
+    path: Path = _write_plain_python_file(tmp_path)
+    run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.APPLY_CHANGES,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_SUCCESS(result)
+    assert_markdown_output_does_not_contain(
+        output=result.output,
+        expected="## Diffs",
+    )
+    assert_markdown_output_does_not_contain(
+        output=result.output,
+        expected="```diff",
+    )
+
+
+@pytest.mark.parametrize(
+    "output_format",
+    [
+        OutputFormat.TEXT,
+        OutputFormat.MARKDOWN,
+    ],
+)
+def test_check_diff_per_file_output_suppresses_empty_diff_section(
+    tmp_path: Path,
+    output_format: OutputFormat,
+) -> None:
+    """`check --diff` per-file output should omit diff sections without a diff."""
+    path: Path = _write_python_file_with_topmark_header(tmp_path)
+
+    args: list[str] = [
+        CliCmd.CHECK,
+        CliOpt.RENDER_DIFF,
+        CliOpt.REPORT,
+        "all",
+    ]
+    if output_format is OutputFormat.MARKDOWN:
+        args.extend([CliOpt.OUTPUT_FORMAT, output_format.value])
+    args.append(str(path))
+
+    result: Result = run_cli_in(tmp_path, args, prune_views=True)
+
+    assert_SUCCESS(result)
+    if output_format is OutputFormat.MARKDOWN:
+        assert "# TopMark" in result.output
+        _assert_markdown_diff_output_absent(result.output)
+    else:
+        assert path.name in result.output
+        _assert_text_diff_output_absent(result.output)
+
+
 def test_strip_diff_text_per_file_output_renders_patch(tmp_path: Path) -> None:
     """`strip --diff` should render a patch in TEXT per-file output."""
     path: Path = _write_markdown_file_with_topmark_header(tmp_path)
@@ -216,6 +394,32 @@ def test_strip_diff_text_summary_output_renders_patch(tmp_path: Path) -> None:
     _assert_unified_diff_rendered(result.output, path_name=path.name)
     assert f"-{TOPMARK_START_MARKER}" in result.output
     assert "-<!--" in result.output
+
+
+def test_strip_diff_summary_output_suppresses_empty_diff_section(tmp_path: Path) -> None:
+    """TEXT summary output should omit diff fences when no strip diff exists."""
+    path: Path = _write_plain_python_file(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.STRIP,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_SUCCESS(result)
+    assert_rich_output_does_not_contain(
+        output=result.output,
+        expected="diffs - start",
+    )
+    assert_rich_output_does_not_contain(
+        output=result.output,
+        expected="diffs - end",
+    )
 
 
 def test_strip_diff_markdown_per_file_output_renders_patch(tmp_path: Path) -> None:
@@ -264,3 +468,68 @@ def test_strip_diff_markdown_summary_output_renders_patch(tmp_path: Path) -> Non
     _assert_unified_diff_rendered(result.output, path_name=path.name)
     assert f"-{TOPMARK_START_MARKER}" in result.output
     assert "-<!--" in result.output
+
+
+def test_strip_diff_markdown_summary_output_suppresses_empty_diff_section(
+    tmp_path: Path,
+) -> None:
+    """Markdown summary output should omit `## Diffs` when no strip diff exists."""
+    path: Path = _write_plain_python_file(tmp_path)
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.STRIP,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.MARKDOWN.value,
+            str(path),
+        ],
+        prune_views=True,
+    )
+
+    assert_SUCCESS(result)
+    assert_markdown_output_does_not_contain(
+        output=result.output,
+        expected="## Diffs",
+    )
+    assert_markdown_output_does_not_contain(
+        output=result.output,
+        expected="```diff",
+    )
+
+
+@pytest.mark.parametrize(
+    "output_format",
+    [
+        OutputFormat.TEXT,
+        OutputFormat.MARKDOWN,
+    ],
+)
+def test_strip_diff_per_file_output_suppresses_empty_diff_section(
+    tmp_path: Path,
+    output_format: OutputFormat,
+) -> None:
+    """`strip --diff` per-file output should omit diff sections without a diff."""
+    path: Path = _write_plain_python_file(tmp_path)
+
+    args: list[str] = [
+        CliCmd.STRIP,
+        CliOpt.RENDER_DIFF,
+        CliOpt.REPORT,
+        "all",
+    ]
+    if output_format is OutputFormat.MARKDOWN:
+        args.extend([CliOpt.OUTPUT_FORMAT, output_format.value])
+    args.append(str(path))
+
+    result: Result = run_cli_in(tmp_path, args, prune_views=True)
+
+    assert_SUCCESS(result)
+    if output_format is OutputFormat.MARKDOWN:
+        assert "# TopMark" in result.output
+        _assert_markdown_diff_output_absent(result.output)
+    else:
+        assert path.name in result.output
+        _assert_text_diff_output_absent(result.output)


### PR DESCRIPTION
## Summary

- Suppresses empty human diff sections for `check --diff` and `strip --diff`
  when no file has rendered diff content.
- Aligns TEXT and Markdown behavior for empty summary/per-file diff output.
- Adds focused CLI regression coverage for TEXT and Markdown summary and
  per-file report modes.
- Updates the Unreleased changelog entry.

## Validation

- Full local suite reported green:
  - `1693 passed, 5 skipped`
- Coverage improved from `90.6%` to `90.7%`.
- Markdown pipeline coverage improved from `83.0%` to `85.0%`.
- TEXT pipeline coverage improved from `92.1%` to `93.5%`.

## Notes

- Closes #192
- Broader diff stream separation remains appropriate for #189
- Broader Markdown/Rich rendering architecture remains appropriate for #193