### PR TITLE
Align CLI errors with Click exit code typing

### DIFF
--- a/src/topmark/cli/errors.py
+++ b/src/topmark/cli/errors.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from typing import IO
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import ClassVar
 
 import click
 
@@ -44,16 +45,7 @@ logger: TopmarkLogger = get_logger(__name__)
 class TopmarkCliError(click.ClickException):
     """Base class for all TopMark CLI errors."""
 
-    exit_code: int
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        exit_code: ExitCode = ExitCode.USAGE_ERROR,
-    ) -> None:
-        super().__init__(message)
-        self.exit_code = int(exit_code)
+    exit_code: ClassVar[int] = int(ExitCode.FAILURE)
 
     def format_message(self) -> str:  # pragma: no cover - trivial
         """Return the plain error message text.
@@ -97,58 +89,58 @@ class TopmarkCliError(click.ClickException):
 class TopmarkCliUsageError(TopmarkCliError):
     """Error for command-line invocation errors (invalid flags/args)."""
 
-    exit_code = ExitCode.USAGE_ERROR
+    exit_code: ClassVar[int] = int(ExitCode.USAGE_ERROR)
 
 
 class TopmarkCliConfigError(TopmarkCliError):
     """Error for configuration errors (missing/invalid/malformed config)."""
 
-    exit_code = ExitCode.CONFIG_ERROR
+    exit_code: ClassVar[int] = int(ExitCode.CONFIG_ERROR)
 
 
 class TopmarkCliFileNotFoundError(TopmarkCliError):
     """Error when input path does not exist."""
 
-    exit_code = ExitCode.FILE_NOT_FOUND
+    exit_code: ClassVar[int] = int(ExitCode.FILE_NOT_FOUND)
 
 
 class TopmarkCliPermissionDeniedError(TopmarkCliError):
     """Error for insufficient permissions (read/write)."""
 
-    exit_code = ExitCode.PERMISSION_DENIED
+    exit_code: ClassVar[int] = int(ExitCode.PERMISSION_DENIED)
 
 
 class TopmarkCliIOError(TopmarkCliError):
     """Error for I/O errors reading/writing files."""
 
-    exit_code = ExitCode.IO_ERROR
+    exit_code: ClassVar[int] = int(ExitCode.IO_ERROR)
 
 
 class TopmarkCliEncodingError(TopmarkCliError):
     """Error for text decoding/encoding errors (e.g., UnicodeDecodeError)."""
 
-    exit_code = ExitCode.ENCODING_ERROR
+    exit_code: ClassVar[int] = int(ExitCode.ENCODING_ERROR)
 
 
 class TopmarkCliUnsupportedFileTypeError(TopmarkCliError):
     """Error for known/unsupported file types (skipped as per policy)."""
 
-    exit_code = ExitCode.UNSUPPORTED_FILE_TYPE
+    exit_code: ClassVar[int] = int(ExitCode.UNSUPPORTED_FILE_TYPE)
 
 
 class TopmarkCliPipelineError(TopmarkCliError):
     """Error for internal pipeline failures (processor/step contract violation)."""
 
-    exit_code = ExitCode.PIPELINE_ERROR
+    exit_code: ClassVar[int] = int(ExitCode.PIPELINE_ERROR)
 
 
 class TopmarkCliVersionConversionError(TopmarkCliError):
     """Error for PEP440-to-SemVer version conversion."""
 
-    exit_code = ExitCode.VERSION_CONVERSION_ERROR
+    exit_code: ClassVar[int] = int(ExitCode.VERSION_CONVERSION_ERROR)
 
 
 class TopmarkCliUnexpectedError(TopmarkCliError):
     """Error for unhandled/unknown errors (last-resort)."""
 
-    exit_code = ExitCode.UNEXPECTED_ERROR
+    exit_code: ClassVar[int] = int(ExitCode.UNEXPECTED_ERROR)

--- a/uv.lock
+++ b/uv.lock
@@ -251,14 +251,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update the lockfile to Click 8.4.2 and adjust TopMark's custom Click exceptions to match Click's `exit_code` contract.

Click exposes `ClickException.exit_code` as an `int` class variable, so TopMark subclasses now declare `exit_code` as `ClassVar[int]` and convert `ExitCode` enum values at the class boundary. This avoids instance-variable overrides and satisfies newer Pyright checks while preserving the CLI exit codes emitted by TopMark-specific errors.