### PR TITLE
Harden Rich-aware output assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -493,6 +493,15 @@ ______________________________________________________________________
   future multi-edit metadata.
 - Added focused CLI regression coverage for empty check/strip diff-output composition across TEXT
   and Markdown summary and per-file report modes.
+- Audited CLI human-output regression tests, introduced reusable semantic assertion helpers for
+  strict file-type overlap diagnostics, and reduced duplication while preserving output-contract
+  coverage.
+- Added focused regression coverage for Rich-aware CLI output assertion helpers, including
+  layout-independent verification of strict file-type overlap diagnostics across ANSI styling, panel
+  rendering, and wrapped terminal output.
+- Hardened CLI human-output regression tests against Rich styling, panel borders, terminal-width
+  wrapping, and other layout differences by replacing brittle raw output assertions with semantic
+  Rich-aware assertion helpers.
 
 ### Notes - Unreleased
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -557,6 +557,53 @@ def assert_human_output_contains_if(
     )
 
 
+# Domain-specific human-output assertions ----------------------------------
+
+
+FILE_TYPE_OVERLAP_WARNING_PREFIX: Final[str] = (
+    "File types specified in both include and exclude filters; exclusion wins:"
+)
+"""Stable prefix for strict include/exclude file-type overlap diagnostics."""
+
+
+def assert_strict_file_type_overlap_warning(
+    result: Result,
+    *,
+    output_format: OutputFormat | None,
+    expected_removed_file_types: tuple[str, ...],
+) -> None:
+    """Assert strict file-type overlap output includes actionable diagnostics.
+
+    This helper verifies the semantic contract for strict include/exclude
+    file-type overlap handling without depending on incidental Rich or Markdown
+    layout. The diagnostic prefix and each removed file type are asserted
+    separately so line wrapping, panel borders, and punctuation around the
+    rendered list do not make the test brittle.
+
+    Args:
+        result: CLI result returned by `run_cli` or `run_cli_in`.
+        output_format: Human output format requested by the test. `None` means
+            the CLI default, currently equivalent to `OutputFormat.TEXT`.
+        expected_removed_file_types: File-type labels expected to be removed
+            from the include filter because the exclude filter wins.
+    """
+    assert_CONFIG_ERROR(result)
+    assert_human_output_contains(
+        output_format=output_format,
+        output=result.output,
+        expected=FILE_TYPE_OVERLAP_WARNING_PREFIX,
+    )
+    for expected_removed_file_type in expected_removed_file_types:
+        assert_human_output_contains(
+            output_format=output_format,
+            output=result.output,
+            expected=expected_removed_file_type,
+        )
+
+
+# Parser-level Rich Click assertions ---------------------------------------
+
+
 CLICK_USAGE_ERROR_EXIT_CODE: Final[int] = 2
 """Raw exit code used by Click for parser-level usage errors."""
 

--- a/tests/cli/test_apply_write_guard.py
+++ b/tests/cli/test_apply_write_guard.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 import pytest
 from click.testing import Result
 
+from tests.cli.conftest import assert_human_output_contains
 from tests.cli.conftest import assert_rich_output_contains
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
@@ -134,7 +135,11 @@ def test_apply_does_not_write_skipped_known_no_headers(tmp_path: Path) -> None:
     assert_SUCCESS(result)
 
     # Output should indicate no changes; content must remain intact.
-    assert "no changes to apply." in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="no changes to apply.",
+    )
     assert lic.read_text("utf-8") == original  # content intact
 
 

--- a/tests/cli/test_config_human_output.py
+++ b/tests/cli/test_config_human_output.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 import pytest
 from click.testing import Result
 
+from tests.cli.conftest import assert_human_output_contains
 from tests.cli.conftest import assert_rich_output_no_such_option
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
@@ -197,7 +198,11 @@ def test_config_dump_text_verbose_adds_progressive_disclosure_details() -> None:
     assert_SUCCESS(base)
     assert_SUCCESS(verbose)
     assert verbose.output != base.output
-    assert "Config files processed" in verbose.output
+    assert_human_output_contains(
+        output_format=None,
+        output=verbose.output,
+        expected="Config files processed",
+    )
 
 
 # --- Markdown document content ---
@@ -214,4 +219,8 @@ def test_config_dump_markdown_includes_document_sections_by_default() -> None:
     )
 
     assert_SUCCESS(result)
-    assert "Config files processed" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="Config files processed",
+    )

--- a/tests/cli/test_config_overrides.py
+++ b/tests/cli/test_config_overrides.py
@@ -29,6 +29,7 @@ import pytest
 from click.testing import Result
 
 from tests.cli.conftest import assert_CONFIG_ERROR
+from tests.cli.conftest import assert_strict_file_type_overlap_warning
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli_in
 from topmark.cli.keys import CliCmd
@@ -246,8 +247,8 @@ def test_strict_config_warning_renders_actionable_diagnostic_for_processing_comm
         ],
     )
 
-    assert_CONFIG_ERROR(result)
-    out: str = result.output.lower()
-    assert "file types specified in both include and exclude filters" in out
-    assert "exclusion wins" in out
-    assert "topmark:python" in out
+    assert_strict_file_type_overlap_warning(
+        result,
+        output_format=None,
+        expected_removed_file_types=("topmark:python",),
+    )

--- a/tests/cli/test_file_type_and_skip_flags.py
+++ b/tests/cli/test_file_type_and_skip_flags.py
@@ -31,6 +31,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from tests.cli.conftest import assert_CONFIG_ERROR
+from tests.cli.conftest import assert_human_output_contains
+from tests.cli.conftest import assert_human_output_does_not_contain
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
 from tests.cli.conftest import run_cli
@@ -175,7 +177,11 @@ def test_report_actionable_hides_unsupported_per_file_but_summary_counts_it(tmp_
 
     # Nothing to do, and the unsupported file is hidden from per-file output.
     assert_SUCCESS(result_normal)
-    assert ResolveStatus.UNSUPPORTED.value not in result_normal.output.lower()
+    assert_human_output_does_not_contain(
+        output_format=None,
+        output=result_normal.output.lower(),
+        expected=ResolveStatus.UNSUPPORTED.value,
+    )
 
     # Summary mode should still count the unsupported bucket.
     result_summary: Result = run_cli(
@@ -189,7 +195,11 @@ def test_report_actionable_hides_unsupported_per_file_but_summary_counts_it(tmp_
     )
 
     assert_SUCCESS(result_summary)
-    assert ResolveStatus.UNSUPPORTED.value in result_summary.output.lower()
+    assert_human_output_contains(
+        output_format=None,
+        output=result_summary.output.lower(),
+        expected=ResolveStatus.UNSUPPORTED.value,
+    )
 
 
 # ---- Test hidden singular option aliases ----
@@ -351,11 +361,22 @@ def test_strict_file_type_filter_overlap_reports_actionable_warning(
     )
 
     assert_CONFIG_ERROR(result)
-    out: str = result.output.lower()
-    assert "file types specified in both include and exclude filters" in out
-    assert "exclusion wins" in out
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output.lower(),
+        expected="file types specified in both include and exclude filters",
+    )
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output.lower(),
+        expected="exclusion wins",
+    )
     for expected_removed_file_type in expected_removed_file_types:
-        assert expected_removed_file_type in out
+        assert_human_output_contains(
+            output_format=None,
+            output=result.output.lower(),
+            expected=expected_removed_file_type,
+        )
 
 
 @pytest.mark.parametrize("command", [CliCmd.CHECK, CliCmd.STRIP, CliCmd.PROBE])

--- a/tests/cli/test_filetypes.py
+++ b/tests/cli/test_filetypes.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tests.cli.conftest import assert_human_output_contains
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
 from topmark.cli.keys import CliCmd
@@ -46,4 +47,8 @@ def test_registry_filetypes_lists_supported_types() -> None:
 
     # Default TEXT output is compact and does not include the verbose heading.
     assert result.output.strip() != ""
-    assert "topmark:" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="topmark:",
+    )

--- a/tests/cli/test_output_assertion_helpers.py
+++ b/tests/cli/test_output_assertion_helpers.py
@@ -1,0 +1,124 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_output_assertion_helpers.py
+#   file_relpath : tests/cli/test_output_assertion_helpers.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for CLI human-output assertion helpers.
+
+The helpers intentionally normalize incidental Rich and Markdown rendering so
+CLI regression tests can assert semantic output contracts without depending on
+terminal width, ANSI styling, or panel borders.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+from click.testing import Result
+
+from tests.cli.conftest import assert_human_output_contains
+from tests.cli.conftest import assert_human_output_does_not_contain
+from tests.cli.conftest import assert_markdown_output_contains
+from tests.cli.conftest import assert_rich_output_contains
+from tests.cli.conftest import assert_rich_output_does_not_contain
+from tests.cli.conftest import assert_strict_file_type_overlap_warning
+from tests.cli.conftest import normalize_rich_cli_output
+from topmark.core.exit_codes import ExitCode
+from topmark.core.formats import OutputFormat
+
+pytestmark: pytest.MarkDecorator = pytest.mark.cli
+
+
+def test_normalize_rich_cli_output_strips_ansi_panels_and_soft_wraps() -> None:
+    """Rich normalization should preserve content while removing layout noise."""
+    output: str = (
+        "\x1b[31m╭─ Error ─╮\x1b[0m\n"
+        "│ No such option '--include-file- │\n"
+        "│ types'.                         │\n"
+        "╰────────────╯\n"
+    )
+
+    assert normalize_rich_cli_output(output) == "No such option '--include-file-types'."
+
+
+def test_rich_output_assertions_ignore_borders_wrapping_and_ansi() -> None:
+    """Rich semantic assertions should tolerate terminal rendering differences."""
+    output: str = (
+        "\x1b[33m╭─ Warning ─╮\x1b[0m\n"
+        "│ File types specified in both include and │\n"
+        "│ exclude filters; exclusion wins.         │\n"
+        "╰────────────╯\n"
+    )
+
+    assert_rich_output_contains(
+        output,
+        expected="File types specified in both include and exclude filters; exclusion wins.",
+    )
+    assert_rich_output_does_not_contain(output, expected="unrelated diagnostic")
+
+
+def test_markdown_output_assertion_ignores_hard_line_break_markers() -> None:
+    """Markdown semantic assertions should ignore layout-only hard breaks."""
+    output: str = "# TopMark\\\n\nConfig files\\\nprocessed\n"
+
+    assert_markdown_output_contains(output, expected="# TopMark Config files processed")
+
+
+def test_human_output_facade_dispatches_by_format() -> None:
+    """The format-aware helper should normalize TEXT and Markdown appropriately."""
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output="│ selected file │\n│ type          │\n",
+        expected="selected file type",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output="## Files\\\n\nexample.py\n",
+        expected="## Files example.py",
+    )
+    assert_human_output_does_not_contain(
+        output_format=OutputFormat.TEXT,
+        output="│ selected processor │\n",
+        expected="selected file type",
+    )
+
+
+def test_strict_file_type_overlap_warning_assertion_is_layout_independent() -> None:
+    """The strict overlap helper should tolerate Rich layout differences."""
+    result = Result(
+        runner=CliRunner(),
+        output_bytes=(
+            "\x1b[33m╭─ Warning ─╮\x1b[0m\n"
+            "│ File types specified in both include and │\n"
+            "│ exclude filters; exclusion wins:         │\n"
+            "│ python, markdown                         │\n"
+            "╰────────────╯\n"
+        ).encode(),
+        stdout_bytes=b"",
+        stderr_bytes=b"",
+        return_value=None,
+        exit_code=ExitCode.CONFIG_ERROR,
+        exception=None,
+        exc_info=None,
+    )
+
+    assert_strict_file_type_overlap_warning(
+        result,
+        output_format=OutputFormat.TEXT,
+        expected_removed_file_types=("python", "markdown"),
+    )
+
+
+def test_human_output_facade_rejects_machine_format() -> None:
+    """The human-output facade should reject machine-readable formats."""
+    with pytest.raises(ValueError, match="Invalid human output format"):
+        assert_human_output_contains(
+            output_format=OutputFormat.JSON,
+            output='{"kind":"meta"}\n',
+            expected="meta",
+        )

--- a/tests/cli/test_pipeline_human_output.py
+++ b/tests/cli/test_pipeline_human_output.py
@@ -27,9 +27,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_human_output_contains
 from tests.cli.conftest import assert_human_output_does_not_contain
+from tests.cli.conftest import assert_strict_file_type_overlap_warning
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_WOULD_CHANGE
 from tests.cli.conftest import run_cli
@@ -88,19 +88,6 @@ def _write_file_requiring_pipeline_change(tmp_path: Path, cmd: str) -> Path:
 # --- Strict config diagnostics ---
 
 
-def _assert_strict_file_type_overlap_warning(
-    result: Result,
-    expected_removed_file_types: tuple[str, ...],
-) -> None:
-    """Assert strict file-type overlap output includes actionable diagnostics."""
-    assert_CONFIG_ERROR(result)
-    out: str = result.output.lower()
-    assert "file types specified in both include and exclude filters" in out
-    assert "exclusion wins" in out
-    for expected_removed_file_type in expected_removed_file_types:
-        assert expected_removed_file_type in out
-
-
 @pytest.mark.parametrize("cmd", [CliCmd.CHECK, CliCmd.STRIP])
 @pytest.mark.parametrize(
     ("include_file_types", "exclude_file_types", "expected_removed_file_types"),
@@ -145,7 +132,11 @@ def test_pipeline_text_output_reports_strict_file_type_overlap_warning(
         ]
     )
 
-    _assert_strict_file_type_overlap_warning(result, expected_removed_file_types)
+    assert_strict_file_type_overlap_warning(
+        result,
+        output_format=None,
+        expected_removed_file_types=expected_removed_file_types,
+    )
 
 
 @pytest.mark.parametrize("cmd", [CliCmd.CHECK, CliCmd.STRIP])
@@ -171,9 +162,14 @@ def test_pipeline_markdown_output_reports_strict_file_type_overlap_warning(
         ]
     )
 
-    _assert_strict_file_type_overlap_warning(
+    expected_removed_file_types = (
+        "topmark:python",
+        "topmark:markdown",
+    )
+    assert_strict_file_type_overlap_warning(
         result,
-        ("topmark:python", "topmark:markdown"),
+        output_format=OutputFormat.MARKDOWN,
+        expected_removed_file_types=expected_removed_file_types,
     )
 
 
@@ -278,7 +274,11 @@ def test_pipeline_markdown_output_always_renders_document_banner(
     )
 
     assert_WOULD_CHANGE(result)
-    assert "# TopMark" in result.output
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="# TopMark",
+    )
 
 
 def test_check_markdown_output_shows_hints_without_text_verbosity(tmp_path: Path) -> None:
@@ -296,8 +296,16 @@ def test_check_markdown_output_shows_hints_without_text_verbosity(tmp_path: Path
     )
 
     assert_WOULD_CHANGE(result)
-    assert "Hints:" in result.output
-    assert "header:missing" in result.output
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="Hints:",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="header:missing",
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_probe_human_output.py
+++ b/tests/cli/test_probe_human_output.py
@@ -26,8 +26,10 @@ import pytest
 from click.testing import CliRunner
 from click.testing import Result
 
-from tests.cli.conftest import assert_CONFIG_ERROR
 from tests.cli.conftest import assert_FILE_NOT_FOUND
+from tests.cli.conftest import assert_human_output_contains
+from tests.cli.conftest import assert_human_output_does_not_contain
+from tests.cli.conftest import assert_strict_file_type_overlap_warning
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import assert_UNSUPPORTED_FILE_TYPE
 from topmark.cli.keys import CliCmd
@@ -79,16 +81,40 @@ def test_probe_text_output_progressively_expands_with_verbosity(tmp_path: Path) 
     assert_SUCCESS(result_vv)
 
     # Default TEXT output is a compact one-line summary.
-    assert "resolved" in result_default.output
-    assert "processor=" in result_default.output
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result_default.output,
+        expected="resolved",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result_default.output,
+        expected="processor=",
+    )
 
     # `-v` adds selected file type and processor details.
-    assert "selected file type" in result_v.output
-    assert "selected processor" in result_v.output
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result_v.output,
+        expected="selected file type",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result_v.output,
+        expected="selected processor",
+    )
 
     # `-vv` adds candidate and match details.
-    assert "candidates:" in result_vv.output
-    assert "match:" in result_vv.output
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result_vv.output,
+        expected="candidates:",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result_vv.output,
+        expected="match:",
+    )
 
     # Each verbosity level should provide a distinct TEXT rendering.
     assert result_default.output != result_v.output
@@ -123,8 +149,16 @@ def test_probe_text_output_reports_explicitly_filtered_input(
 
     assert_UNSUPPORTED_FILE_TYPE(result)
 
-    assert "<filtered>" in result.output
-    assert "filtered: excluded_by_path_filter" in result.output
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result.output,
+        expected="<filtered>",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result.output,
+        expected="filtered: excluded_by_path_filter",
+    )
 
 
 def test_probe_text_output_omits_directory_filtered_result_when_children_selected(
@@ -160,9 +194,21 @@ def test_probe_text_output_omits_directory_filtered_result_when_children_selecte
 
     assert_SUCCESS(result)
 
-    assert "example.py" in result.output
-    assert "README.md" in result.output
-    assert "<filtered>" not in result.output
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result.output,
+        expected="example.py",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result.output,
+        expected="README.md",
+    )
+    assert_human_output_does_not_contain(
+        output_format=OutputFormat.TEXT,
+        output=result.output,
+        expected="<filtered>",
+    )
 
 
 def test_probe_text_output_reports_missing_input_only_once(
@@ -182,8 +228,16 @@ def test_probe_text_output_reports_missing_input_only_once(
 
     assert_FILE_NOT_FOUND(result)
 
-    assert "probe-missing" in result.output
-    assert "<filtered>" not in result.output
+    assert_human_output_contains(
+        output_format=OutputFormat.TEXT,
+        output=result.output,
+        expected="probe-missing",
+    )
+    assert_human_output_does_not_contain(
+        output_format=OutputFormat.TEXT,
+        output=result.output,
+        expected="<filtered>",
+    )
 
 
 # --- TEXT output: strict config diagnostics ---
@@ -233,12 +287,11 @@ def test_probe_text_output_reports_strict_file_type_overlap_warning(
         ],
     )
 
-    assert_CONFIG_ERROR(result)
-    out: str = result.output.lower()
-    assert "file types specified in both include and exclude filters" in out
-    assert "exclusion wins" in out
-    for expected_removed_file_type in expected_removed_file_types:
-        assert expected_removed_file_type in out
+    assert_strict_file_type_overlap_warning(
+        result,
+        output_format=None,
+        expected_removed_file_types=expected_removed_file_types,
+    )
 
 
 # --- Markdown output: strict config diagnostics ---
@@ -267,12 +320,15 @@ def test_probe_markdown_output_reports_strict_file_type_overlap_warning(
         ],
     )
 
-    assert_CONFIG_ERROR(result)
-    out: str = result.output.lower()
-    assert "file types specified in both include and exclude filters" in out
-    assert "exclusion wins" in out
-    assert "topmark:python" in out
-    assert "topmark:markdown" in out
+    expected_removed_file_types = (
+        "topmark:python",
+        "topmark:markdown",
+    )
+    assert_strict_file_type_overlap_warning(
+        result,
+        output_format=None,
+        expected_removed_file_types=expected_removed_file_types,
+    )
 
 
 # --- Markdown output: verbosity and quiet controls ---
@@ -312,9 +368,21 @@ def test_probe_markdown_output_ignores_text_verbosity(tmp_path: Path) -> None:
     assert result_default.output == result_v.output
 
     # Basic Markdown structure checks.
-    assert "TopMark Resolution Probe Results" in result_default.output
-    assert "## Files" in result_default.output
-    assert "###" in result_default.output
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result_default.output,
+        expected="TopMark Resolution Probe Results",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result_default.output,
+        expected="## Files",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result_default.output,
+        expected="###",
+    )
 
 
 def test_probe_markdown_output_ignores_text_quiet(tmp_path: Path) -> None:
@@ -339,4 +407,8 @@ def test_probe_markdown_output_ignores_text_quiet(tmp_path: Path) -> None:
 
     # Markdown should still render full document output.
     assert result.output.strip() != ""
-    assert "TopMark Resolution Probe Results" in result.output
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="TopMark Resolution Probe Results",
+    )

--- a/tests/cli/test_processing_case_insensitive_fs.py
+++ b/tests/cli/test_processing_case_insensitive_fs.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.cli.conftest import assert_human_output_does_not_contain
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli_in
 from topmark.cli.keys import CliCmd
@@ -102,8 +103,16 @@ def test_check_uses_canonical_path_fields_for_mismatched_invocation_casing(
 
     assert_SUCCESS(result)
     assert readme_path.read_text(encoding="utf-8") == before
-    assert "would update" not in result.output.lower()
-    assert "changes found" not in result.output.lower()
+    assert_human_output_does_not_contain(
+        output_format=None,
+        output=result.output,
+        expected="would update",
+    )
+    assert_human_output_does_not_contain(
+        output_format=None,
+        output=result.output,
+        expected="changes found",
+    )
 
 
 def test_check_apply_preserves_file_for_mismatched_invocation_casing_when_unchanged(
@@ -150,5 +159,13 @@ def test_check_uses_canonical_path_fields_for_absolute_mismatched_invocation_cas
 
     assert_SUCCESS(result)
     assert readme_path.read_text(encoding="utf-8") == before
-    assert "would update" not in result.output.lower()
-    assert "changes found" not in result.output.lower()
+    assert_human_output_does_not_contain(
+        output_format=None,
+        output=result.output,
+        expected="would update",
+    )
+    assert_human_output_does_not_contain(
+        output_format=None,
+        output=result.output,
+        expected="changes found",
+    )

--- a/tests/cli/test_processing_case_sensitive_fs.py
+++ b/tests/cli/test_processing_case_sensitive_fs.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from tests.cli.conftest import assert_FILE_NOT_FOUND
+from tests.cli.conftest import assert_human_output_contains
 from tests.cli.conftest import run_cli_in
 from topmark.cli.keys import CliCmd
 
@@ -54,4 +55,8 @@ def test_check_does_not_resolve_mismatched_invocation_casing_on_case_sensitive_f
     )
 
     assert_FILE_NOT_FOUND(result)
-    assert "REadme.md" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="REadme.md",
+    )

--- a/tests/cli/test_registry_human_output.py
+++ b/tests/cli/test_registry_human_output.py
@@ -27,6 +27,8 @@ from typing import ClassVar
 
 import pytest
 
+from tests.cli.conftest import assert_human_output_contains
+from tests.cli.conftest import assert_human_output_does_not_contain
 from tests.cli.conftest import assert_rich_output_no_such_option
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
@@ -34,6 +36,7 @@ from tests.helpers.registry import make_file_type
 from tests.helpers.registry import patched_effective_registries
 from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
+from topmark.core.formats import OutputFormat
 from topmark.processors.base import HeaderProcessor
 
 if TYPE_CHECKING:
@@ -122,9 +125,21 @@ def test_registry_filetypes_text_output_is_compact_by_default(
     )
 
     assert_SUCCESS(result)
-    assert "pytest:bound_ft" in result.output
-    assert "pytest:unbound_ft" in result.output
-    assert "Extensions:" not in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="pytest:bound_ft",
+    )
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="pytest:unbound_ft",
+    )
+    assert_human_output_does_not_contain(
+        output_format=None,
+        output=result.output,
+        expected="Extensions:",
+    )
 
 
 def test_registry_filetypes_text_verbose_shows_console_heading(
@@ -141,8 +156,16 @@ def test_registry_filetypes_text_verbose_shows_console_heading(
     )
 
     assert_SUCCESS(result)
-    assert "Supported file types (canonical identities):" in result.output
-    assert "pytest:bound_ft" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="Supported file types (canonical identities):",
+    )
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="pytest:bound_ft",
+    )
 
 
 def test_registry_filetypes_text_long_shows_details(
@@ -159,8 +182,16 @@ def test_registry_filetypes_text_long_shows_details(
     )
 
     assert_SUCCESS(result)
-    assert "pytest:bound_ft" in result.output
-    assert ".bound" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="pytest:bound_ft",
+    )
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected=".bound",
+    )
 
 
 # --- Unsupported quiet mode ---
@@ -263,10 +294,26 @@ def test_registry_filetypes_markdown_long_shows_details(
     )
 
     assert_SUCCESS(result)
-    assert "# Supported File Types" in result.output
-    assert "pytest:bound_ft" in result.output
-    assert "Bound registry test file type." in result.output
-    assert ".bound" in result.output
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="# Supported File Types",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="pytest:bound_ft",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="Bound registry test file type.",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected=".bound",
+    )
 
 
 # --- Markdown output: processors and bindings ---
@@ -346,7 +393,23 @@ def test_registry_bindings_markdown_long_shows_binding_details(
     )
 
     assert_SUCCESS(result)
-    assert "# Effective File-Type-to-Processor Bindings" in result.output
-    assert "pytest:bound_ft" in result.output
-    assert "pytest:bound_processor" in result.output
-    assert "Bound registry test file type." in result.output
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="# Effective File-Type-to-Processor Bindings",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="pytest:bound_ft",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="pytest:bound_processor",
+    )
+    assert_human_output_contains(
+        output_format=OutputFormat.MARKDOWN,
+        output=result.output,
+        expected="Bound registry test file type.",
+    )

--- a/tests/cli/test_smoke.py
+++ b/tests/cli/test_smoke.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tests.cli.conftest import assert_human_output_contains
 from tests.cli.conftest import assert_SUCCESS
 from tests.cli.conftest import run_cli
 from topmark.cli.keys import CliCmd
@@ -39,7 +40,11 @@ def test_cli_help_outputs_usage_and_exits_success() -> None:
 
     assert_SUCCESS(result)
 
-    assert "usage" in result.output.lower()
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="Usage",
+    )
 
 
 # --- Version command ---
@@ -51,4 +56,8 @@ def test_cli_version_outputs_project_version() -> None:
 
     assert_SUCCESS(result)
 
-    assert TOPMARK_VERSION in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected=TOPMARK_VERSION,
+    )

--- a/tests/cli/test_stdin_errors.py
+++ b/tests/cli/test_stdin_errors.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 import pytest
 from click.testing import Result
 
+from tests.cli.conftest import assert_human_output_contains
 from tests.cli.conftest import assert_USAGE_ERROR
 from tests.cli.conftest import run_cli
 from tests.cli.conftest import run_cli_in
@@ -72,7 +73,11 @@ def test_check_rejects_content_stdin_with_file(tmp_path: Path) -> None:
 
     assert_USAGE_ERROR(result)
     # Diagnostic should point users toward the STDIN/path conflict.
-    assert "-" in result.output or "STDIN" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="-",
+    )
 
 
 def test_strip_rejects_content_stdin_with_file(tmp_path: Path) -> None:
@@ -86,7 +91,11 @@ def test_strip_rejects_content_stdin_with_file(tmp_path: Path) -> None:
     )
 
     assert_USAGE_ERROR(result)
-    assert "-" in result.output or "STDIN" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="-",
+    )
 
 
 def test_check_rejects_content_stdin_with_directory(tmp_path: Path) -> None:
@@ -101,7 +110,11 @@ def test_check_rejects_content_stdin_with_directory(tmp_path: Path) -> None:
     )
 
     assert_USAGE_ERROR(result)
-    assert "-" in result.output or "STDIN" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="-",
+    )
 
 
 def test_strip_rejects_content_stdin_with_directory(tmp_path: Path) -> None:
@@ -114,7 +127,11 @@ def test_strip_rejects_content_stdin_with_directory(tmp_path: Path) -> None:
         input_text="<!-- topmark:header:start -->\n",
     )
     assert_USAGE_ERROR(result)
-    assert "-" in result.output or "STDIN" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="-",
+    )
 
 
 # --- List/pattern-list STDIN modes: single consumer rule ---
@@ -129,4 +146,8 @@ def test_only_one_list_mode_option_may_consume_stdin(tmp_path: Path) -> None:
     )
 
     assert_USAGE_ERROR(result)
-    assert "-" in result.output or "STDIN" in result.output
+    assert_human_output_contains(
+        output_format=None,
+        output=result.output,
+        expected="-",
+    )


### PR DESCRIPTION
## Summary

- Audits CLI human-output regression tests for brittle raw output assertions.
- Replaces semantic human-output checks with Rich-aware assertion helpers where appropriate.
- Centralizes strict file-type overlap warning assertions in shared CLI test helpers.
- Adds focused helper coverage for ANSI styling, Rich panel borders, and wrapped terminal output.

## Validation

- `uv run pytest tests -q`
- `uv run pyright --pythonversion 3.10`
- `uv run pyright --pythonversion 3.13`

Closes #203.