### PR TITLE
Adopt pytest importlib mode and package the test hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,6 +408,8 @@ ______________________________________________________________________
   tooling imports explicit for the test suite.
 - Packaged all test subdirectories consistently and relocated remaining generic unit tests into
   source-aligned test packages.
+- Added dedicated developer-validation tests for registry integrity, processor strategy usage, and
+  test package layout invariants.
 - Updated pre-commit dependencies, including TopMark itself.
 - Raised the minimum supported runtime dependency version for `click` to 8.4.2 to align with the
   current validated compatibility baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,8 @@ ______________________________________________________________________
 ### Internal - Unreleased
 
 - Removed stale tox references.
+- Migrated pytest collection to `--import-mode=importlib` and made repository-local developer
+  tooling imports explicit for the test suite.
 - Updated pre-commit dependencies, including TopMark itself.
 - Raised the minimum supported runtime dependency version for `click` to 8.4.2 to align with the
   current validated compatibility baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,6 +406,8 @@ ______________________________________________________________________
 - Removed stale tox references.
 - Migrated pytest collection to `--import-mode=importlib` and made repository-local developer
   tooling imports explicit for the test suite.
+- Packaged all test subdirectories consistently and relocated remaining generic unit tests into
+  source-aligned test packages.
 - Updated pre-commit dependencies, including TopMark itself.
 - Raised the minimum supported runtime dependency version for `click` to 8.4.2 to align with the
   current validated compatibility baseline.

--- a/docs/ci/test-validation.md
+++ b/docs/ci/test-validation.md
@@ -87,7 +87,7 @@ Pytest markers are declared in `pyproject.toml` under `[tool.pytest.ini_options]
 | `case_insensitive_fs` | Tests for behavior that depends on case-insensitive filesystem semantics.                          | Run where the host filesystem can exercise them.     |
 | `cli`                 | Tests that exercise the command-line interface.                                                    | Included in normal test runs.                        |
 | `config`              | Tests for configuration deserialization, path normalization, strictness, and layer merge behavior. | Included in normal test runs.                        |
-| `dev_validation`      | Developer validation tests for internal invariants such as registry consistency.                   | Included in normal test runs.                        |
+| `dev_validation`      | Developer validation tests for internal invariants such as registry and test-layout consistency.   | Included in normal test runs.                        |
 | `exit_code`           | Tests that validate the CLI exit-code contract.                                                    | Included in normal test runs.                        |
 | `hypothesis_slow`     | Long-running property tests.                                                                       | Skipped in CI unless explicitly selected.            |
 | `integration`         | Environment-dependent integration checks, such as shell completion.                                | Run selectively where the environment supports them. |
@@ -101,11 +101,12 @@ ______________________________________________________________________
 The `dev_validation` marker identifies tests that check internal invariants rather than user-facing
 behavior.
 
-Typical examples include:
+Typical examples live under `tests/dev_validation/` and include:
 
 - registry consistency between processors and file types;
 - sanity checks for internal plugin mappings;
-- placement-strategy checks for XML/HTML-like processors.
+- placement-strategy checks for XML/HTML-like processors;
+- test-package layout checks that keep Python test directories importable by absolute package name.
 
 Example:
 
@@ -193,9 +194,12 @@ Developer-validation checks include:
   identity.
 - **Placement strategy for XML/HTML**: processors based on `XmlHeaderProcessor` must signal the
   character-offset strategy by returning `NO_LINE_ANCHOR` from `get_header_insertion_index()`.
+- **Test package layout**: every directory under `tests/` that contains Python modules must include
+  an `__init__.py` marker so test modules have stable absolute package names.
 
-These checks avoid accidental miswiring, such as registering a processor under a typo key, and help
-prevent XML/HTML-like processors from regressing into line-based insertion behavior.
+These checks avoid accidental miswiring, such as registering a processor under a typo key, help
+prevent XML/HTML-like processors from regressing into line-based insertion behavior, and keep the
+test suite aligned with TopMark's absolute-import convention.
 
 ______________________________________________________________________
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,6 +303,10 @@ norecursedirs = [
 ]
 python_files = ["test_*.py", "*_test.py"]
 filterwarnings = ["default::DeprecationWarning"]
+addopts = ["--import-mode=importlib"]
+# Keep repository-local developer tooling importable without relying on pytest's
+# legacy prepend/append import modes.
+pythonpath = ["."]
 
 [tool.ruff]
 # Shared formatter/linter line length.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,7 @@ markers = [
   "case_insensitive_fs: tests for case-insensitive file systems",
   "cli: tests that exercise the CLI",
   "config: tests for config deserialization, path normalization, strictness, and layer merge behavior",
-  "dev_validation: developer validation tests (e.g., registry validation)",
+  "dev_validation: developer validation tests for repository and internal invariants",
   "exit_code: tests that validate the CLI exit-code contract",
   "hypothesis_slow: long-running property tests (skipped in CI)",
   "integration: environment-dependent integration checks (e.g., shell completion)",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,6 +8,6 @@
 #
 # topmark:header:end
 
-"""TopMark Test Framework."""
+"""TopMark test package for repository-local validation of the topmark package."""
 
 from __future__ import annotations

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/api/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Public API tests for topmark.api and topmark.api.commands."""
 
 from __future__ import annotations

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -8,6 +8,6 @@
 #
 # topmark:header:end
 
-"""TopMark Test Framework: CLI."""
+"""CLI tests for topmark.cli and command-line behavior."""
 
 from __future__ import annotations

--- a/tests/cli/machine/__init__.py
+++ b/tests/cli/machine/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/cli/machine/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Machine-output CLI tests for topmark.cli JSON and NDJSON contracts."""
 
 from __future__ import annotations

--- a/tests/config/__init__.py
+++ b/tests/config/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/config/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Configuration tests for topmark.config."""
 
 from __future__ import annotations

--- a/tests/config/machine/__init__.py
+++ b/tests/config/machine/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/config/machine/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Machine-output configuration tests for topmark.config.machine."""
 
 from __future__ import annotations

--- a/tests/config/resolution/__init__.py
+++ b/tests/config/resolution/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/config/resolution/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Configuration-resolution tests for topmark.config.resolution."""
 
 from __future__ import annotations

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/core/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Core utility tests for topmark.core."""
 
 from __future__ import annotations

--- a/tests/core/test_enum_mixins.py
+++ b/tests/core/test_enum_mixins.py
@@ -2,7 +2,7 @@
 #
 #   project      : TopMark
 #   file         : test_enum_mixins.py
-#   file_relpath : tests/unit/test_enum_mixins.py
+#   file_relpath : tests/core/test_enum_mixins.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #

--- a/tests/dev_validation/__init__.py
+++ b/tests/dev_validation/__init__.py
@@ -1,0 +1,13 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : __init__.py
+#   file_relpath : tests/dev_validation/__init__.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Developer-validation tests for repository and internal TopMark invariants."""
+
+from __future__ import annotations

--- a/tests/dev_validation/test_registry_validation.py
+++ b/tests/dev_validation/test_registry_validation.py
@@ -2,13 +2,13 @@
 #
 #   project      : TopMark
 #   file         : test_registry_validation.py
-#   file_relpath : tests/pipeline/test_registry_validation.py
+#   file_relpath : tests/dev_validation/test_registry_validation.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""CI guardrails for processor↔filetype registry integrity and strategy usage."""
+"""Developer-validation checks for registry integrity and processor strategy usage."""
 
 from __future__ import annotations
 

--- a/tests/dev_validation/test_test_package_layout.py
+++ b/tests/dev_validation/test_test_package_layout.py
@@ -1,0 +1,40 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_test_package_layout.py
+#   file_relpath : tests/dev_validation/test_test_package_layout.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Developer-validation checks for the test package layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_TESTS_ROOT: Path = Path(__file__).resolve().parents[1]
+_IGNORED_DIR_NAMES: frozenset[str] = frozenset({".pytest_cache", "__pycache__"})
+
+
+def _contains_python_file(path: Path) -> bool:
+    """Return whether the directory contains at least one Python source file."""
+    return any(child.is_file() and child.suffix == ".py" for child in path.iterdir())
+
+
+@pytest.mark.dev_validation
+def test_python_test_directories_are_packages() -> None:
+    """Every test directory containing Python modules has an ``__init__.py`` marker."""
+    missing: list[str] = [
+        path.relative_to(_TESTS_ROOT).as_posix() or "."
+        for path in [_TESTS_ROOT, *sorted(_TESTS_ROOT.rglob("*"))]
+        if path.is_dir()
+        and path.name not in _IGNORED_DIR_NAMES
+        and _contains_python_file(path)
+        and not (path / "__init__.py").is_file()
+    ]
+
+    assert missing == [], f"Test directories without __init__.py: {missing!r}"

--- a/tests/filetypes/__init__.py
+++ b/tests/filetypes/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/filetypes/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""File-type model and registry tests for topmark.filetypes."""
 
 from __future__ import annotations

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/helpers/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Shared test helpers used by TopMark test packages."""
 
 from __future__ import annotations

--- a/tests/pipeline/__init__.py
+++ b/tests/pipeline/__init__.py
@@ -8,6 +8,6 @@
 #
 # topmark:header:end
 
-"""TopMark Test Framework: Pipeline."""
+"""Pipeline tests for topmark.pipeline."""
 
 from __future__ import annotations

--- a/tests/pipeline/integration/__init__.py
+++ b/tests/pipeline/integration/__init__.py
@@ -8,6 +8,6 @@
 #
 # topmark:header:end
 
-"""TopMark Test Framework: Pipeline - Integration."""
+"""End-to-end pipeline integration tests for topmark.pipeline."""
 
 from __future__ import annotations

--- a/tests/pipeline/machine/__init__.py
+++ b/tests/pipeline/machine/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/pipeline/machine/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Machine-output pipeline tests for topmark.pipeline.machine."""
 
 from __future__ import annotations

--- a/tests/pipeline/steps/__init__.py
+++ b/tests/pipeline/steps/__init__.py
@@ -8,6 +8,6 @@
 #
 # topmark:header:end
 
-"""TopMark Test Framework: Pipeline - Steps."""
+"""Pipeline-step tests for topmark.pipeline.steps."""
 
 from __future__ import annotations

--- a/tests/presentation/__init__.py
+++ b/tests/presentation/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/presentation/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Presentation-layer tests for topmark.presentation."""
 
 from __future__ import annotations

--- a/tests/processors/__init__.py
+++ b/tests/processors/__init__.py
@@ -8,6 +8,6 @@
 #
 # topmark:header:end
 
-"""TopMark Test Framework: Pipeline - Processors."""
+"""Header-processor tests for topmark.processors."""
 
 from __future__ import annotations

--- a/tests/processors/test_processor_key_token.py
+++ b/tests/processors/test_processor_key_token.py
@@ -2,7 +2,7 @@
 #
 #   project      : TopMark
 #   file         : test_processor_key_token.py
-#   file_relpath : tests/unit/test_processor_key_token.py
+#   file_relpath : tests/processors/test_processor_key_token.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #

--- a/tests/registry/__init__.py
+++ b/tests/registry/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/registry/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Registry tests for topmark.registry."""
 
 from __future__ import annotations

--- a/tests/resolver/test_resolve_file_list.py
+++ b/tests/resolver/test_resolve_file_list.py
@@ -2,7 +2,7 @@
 #
 #   project      : TopMark
 #   file         : test_resolve_file_list.py
-#   file_relpath : tests/unit/test_resolve_file_list.py
+#   file_relpath : tests/resolver/test_resolve_file_list.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #

--- a/tests/toml/__init__.py
+++ b/tests/toml/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/toml/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""TOML parsing, validation, and surgery tests for topmark.toml."""
 
 from __future__ import annotations

--- a/tests/toml/machine/__init__.py
+++ b/tests/toml/machine/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/unit/__init__.py
+#   file_relpath : tests/toml/machine/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""TopMark Test Framework: Unit tests."""
+"""Machine-output TOML tests for topmark.toml.machine."""
 
 from __future__ import annotations

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -2,12 +2,12 @@
 #
 #   project      : TopMark
 #   file         : __init__.py
-#   file_relpath : tests/resolver/__init__.py
+#   file_relpath : tests/utils/__init__.py
 #   license      : MIT
 #   copyright    : (c) 2025 Olivier Biot
 #
 # topmark:header:end
 
-"""File-resolution tests for topmark.resolution."""
+"""Utility tests for topmark.utils."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Completes GitHub issue #213 by migrating the test suite to pytest's recommended `importlib` import mode while preserving existing behavior and making the test package structure explicit and self-validating.

This PR consists of three focused commits:

1. Enable pytest `importlib` collection mode and replace reliance on legacy import semantics with an explicit repository-root import path for developer tooling.
2. Normalize the test hierarchy by making all Python test directories packages and aligning the layout with the `src/topmark` package structure.
3. Introduce a dedicated `tests/dev_validation` package and add an invariant test that prevents regressions of the new package-layout convention.

Closes #213.

## Changes

### Pytest import mode

- enable `--import-mode=importlib`
- explicitly expose the repository root via `pythonpath = ["."]`
- preserve imports from repository-local developer tooling (such as `tools.api_snapshot`) without relying on pytest's legacy `prepend`/`append` import behavior

### Test package consistency

- add missing `__init__.py` files throughout `tests/`
- refresh package docstrings describing each test package and its relationship to the corresponding `src/topmark` subsystem
- relocate a small number of generic unit tests into subsystem-specific test packages to better mirror the source tree
- establish a consistent absolute-import structure for the test suite

### Developer validation

- create a dedicated `tests/dev_validation/` package for repository invariant tests
- move existing developer-validation tests into the new package
- add a developer-validation test ensuring every Python-bearing directory under `tests/` contains an `__init__.py` marker
- update developer documentation describing the `dev_validation` marker and the new repository invariant

## Validation

Verified locally:

- all tests collect successfully using `--import-mode=importlib`
- full test suite passes
- developer-validation test suite passes
- coverage baseline maintained

The new package-layout invariant ensures future additions to the test suite remain compatible with TopMark's absolute-import convention and pytest's `importlib` collection mode.