### PR TITLE
Normalize pytest marker usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,9 @@ ______________________________________________________________________
   maintenance work, including the later completion of the Rich and `rich-click` migration.
 - Clarified pytest marker documentation by restoring the `case_insensitive_fs` marker entry and
   fixing the malformed `pipeline` marker table row in CI test-validation guidance.
+- Documented the normalized pytest marker taxonomy, including the shift to cross-cutting semantic
+  markers, path-based package or subsystem test selection, marker-expression hygiene expectations,
+  and the reduced marker set used by CI and local validation tooling.
 - Clarified the report-scope contract, including the distinction between actionable and noncompliant
   results and the applicability of report filtering across human-readable output formats.
 - Added dedicated performance-baseline documentation covering subprocess-isolated RSS measurement,
@@ -409,7 +412,11 @@ ______________________________________________________________________
 - Packaged all test subdirectories consistently and relocated remaining generic unit tests into
   source-aligned test packages.
 - Added dedicated developer-validation tests for registry integrity, processor strategy usage, and
-  test package layout invariants.
+- Audited and normalized pytest marker usage by removing package-only subsystem markers, retaining
+  only cross-cutting semantic markers, and aligning Nox and Makefile marker expressions with the
+  declared marker set.
+- Added developer-validation coverage for pytest marker hygiene so undeclared marker usage, stale
+  marker declarations, and stale Nox marker expressions are detected during repository validation.
 - Updated pre-commit dependencies, including TopMark itself.
 - Raised the minimum supported runtime dependency version for `click` to 8.4.2 to align with the
   current validated compatibility baseline.

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ help:
 	@echo "  hygiene         Run all prose/documentation hygiene checks"
 	@echo "Tests:"
 	@echo "  test            Run the test suite (nox: qa)"
-	@echo "  pytest          Run tests with current interpreter (no nox), skipping slow tests; supports PYTEST_PAR=-n auto"
+	@echo "  pytest          Run tests with current interpreter (no nox), skipping Hypothesis slow tests; supports PYTEST_PAR=-n auto"
 	@echo "  pytest-full     Run all tests with current interpreter (no nox); supports PYTEST_PAR=-n auto"
 	@echo "  coverage        Run coverage testing"
 	@echo "  coverage-erase  Erase coverage testing output (.coverage coverage.xml coverage.json htmlcov .coverage.*)"
@@ -178,11 +178,11 @@ hygiene: docs-hygiene code-hygiene
 
 # Run pytest directly (no nox) with the current interpreter
 pytest:
-	@echo "Running pytest locally -- skipping slow tests"
-	pytest $(PYTEST_PAR) -m "not slow and not hypothesis_slow" -q
+	@echo "Running pytest locally -- skipping Hypothesis slow tests"
+	pytest $(PYTEST_PAR) -m "not hypothesis_slow" -q
 
 pytest-full:
-	@echo "Running all pytest locally -- including slow tests"
+	@echo "Running all pytest locally -- including Hypothesis slow tests"
 	pytest $(PYTEST_PAR) -q
 
 property-test: check-venv

--- a/docs/ci/test-validation.md
+++ b/docs/ci/test-validation.md
@@ -81,18 +81,18 @@ ______________________________________________________________________
 
 Pytest markers are declared in `pyproject.toml` under `[tool.pytest.ini_options]`.
 
-| Marker                | Purpose                                                                                            | CI expectation                                       |
-| --------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `api`                 | Tests that exercise the public API.                                                                | Included in normal test runs.                        |
-| `case_insensitive_fs` | Tests for behavior that depends on case-insensitive filesystem semantics.                          | Run where the host filesystem can exercise them.     |
-| `cli`                 | Tests that exercise the command-line interface.                                                    | Included in normal test runs.                        |
-| `config`              | Tests for configuration deserialization, path normalization, strictness, and layer merge behavior. | Included in normal test runs.                        |
-| `dev_validation`      | Developer validation tests for internal invariants such as registry and test-layout consistency.   | Included in normal test runs.                        |
-| `exit_code`           | Tests that validate the CLI exit-code contract.                                                    | Included in normal test runs.                        |
-| `hypothesis_slow`     | Long-running property tests.                                                                       | Skipped in CI unless explicitly selected.            |
-| `integration`         | Environment-dependent integration checks, such as shell completion.                                | Run selectively where the environment supports them. |
-| `pipeline`            | Tests that exercise the processing pipeline, including filesystem-identity and target eligibility. | Included in normal test runs.                        |
-| `toml`                | Tests for TopMark TOML loading, extraction, schema validation, and source resolution.              | Included in normal test runs.                        |
+Pytest markers are reserved for cross-cutting test semantics rather than package membership.
+Package- or subsystem-specific test selection should normally use test paths (for example,
+`pytest tests/cli`) instead of markers. Nox marker expressions should reference only declared
+markers so exclusions remain visible in the central pytest configuration.
+
+| Marker                | Purpose                                                                                                                                                             | CI expectation                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `case_insensitive_fs` | Tests for behavior that depends on case-insensitive filesystem semantics.                                                                                           | Run where the host filesystem can exercise them.     |
+| `dev_validation`      | Developer validation tests for internal invariants such as registry integrity, test-layout consistency, and pytest marker hygiene.                                  | Included in normal test runs.                        |
+| `exit_code`           | Tests that validate the CLI exit-code contract.                                                                                                                     | Included in normal test runs.                        |
+| `hypothesis_slow`     | Long-running property tests.                                                                                                                                        | Skipped in CI unless explicitly selected.            |
+| `integration`         | Environment-dependent integration checks that exercise interactions with external tooling, the operating system, or shell features (for example, shell completion). | Run selectively where the environment supports them. |
 
 ______________________________________________________________________
 
@@ -107,6 +107,7 @@ Typical examples live under `tests/dev_validation/` and include:
 - sanity checks for internal plugin mappings;
 - placement-strategy checks for XML/HTML-like processors;
 - test-package layout checks that keep Python test directories importable by absolute package name.
+- pytest marker declarations and marker-expression consistency.
 
 Example:
 
@@ -196,6 +197,9 @@ Developer-validation checks include:
   character-offset strategy by returning `NO_LINE_ANCHOR` from `get_header_insertion_index()`.
 - **Test package layout**: every directory under `tests/` that contains Python modules must include
   an `__init__.py` marker so test modules have stable absolute package names.
+- **Pytest marker hygiene**: every custom marker used by the test suite is declared in
+  `pyproject.toml`, and marker expressions referenced by project tooling remain aligned with the
+  declared marker set.
 
 These checks avoid accidental miswiring, such as registering a processor under a typo key, help
 prevent XML/HTML-like processors from regressing into line-based insertion behavior, and keep the
@@ -266,7 +270,9 @@ Slow and environment-dependent tests should be marked explicitly.
   environment-specific assumptions.
 
 These markers make CI exclusions visible and intentional instead of relying on hidden filename or
-directory-selection conventions.
+directory-selection conventions. Marker expressions used by Nox and other project tooling (such as
+the `Makefile`) should remain aligned with the declarations in `pyproject.toml`;
+developer-validation tests help detect stale references.
 
 ______________________________________________________________________
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -236,7 +236,7 @@ def qa(session: nox.Session) -> None:
         "-q",
         "tests",
         "-m",
-        "not slow and not hypothesis_slow",
+        "not hypothesis_slow",
         *session.posargs,
     )
 
@@ -272,7 +272,7 @@ def qa_api(session: nox.Session) -> None:
         "-q",
         "tests",
         "-m",
-        "not slow and not hypothesis_slow",
+        "not hypothesis_slow",
         *session.posargs,
     )
 
@@ -354,7 +354,7 @@ def coverage(session: nox.Session) -> None:
         "-q",
         "tests",
         "-m",
-        "not slow and not hypothesis_slow",
+        "not hypothesis_slow",
         "--cov=topmark",
         "--cov-branch",
         "--cov-report=term-missing",
@@ -750,7 +750,7 @@ def release_check(session: nox.Session) -> None:
         "-q",
         "tests",
         "-m",
-        "not slow and not hypothesis_slow",
+        "not hypothesis_slow",
         *session.posargs,
     )
     # Entry point check -- We call it as a function to reuse the current session environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,8 @@ dependencies = [
     "pytest-cov>=7.1.0,<8.0.0",
     # Parallel test execution:
     "pytest-xdist>=3.8.0,<4.0.0",
+    # TOML configuration file manipulation:
+    "tomlkit>=0.15.0,<0.16.0",
   ]
   typing = []
 
@@ -275,16 +277,11 @@ reportUnusedVariable               = true
 
 [tool.pytest.ini_options]
 markers = [
-  "api: tests that exercise the API",
   "case_insensitive_fs: tests for case-insensitive file systems",
-  "cli: tests that exercise the CLI",
-  "config: tests for config deserialization, path normalization, strictness, and layer merge behavior",
   "dev_validation: developer validation tests for repository and internal invariants",
   "exit_code: tests that validate the CLI exit-code contract",
   "hypothesis_slow: long-running property tests (skipped in CI)",
   "integration: environment-dependent integration checks (e.g., shell completion)",
-  "pipeline: tests that exercise the processing pipeline",
-  "toml: tests for TopMark TOML loading, extraction, schema validation, and source resolution",
 ]
 testpaths = ["tests"]
 norecursedirs = [

--- a/tests/api/test_api_discovery_parity.py
+++ b/tests/api/test_api_discovery_parity.py
@@ -60,8 +60,6 @@ def _contains_unaligned_fields(diff: str) -> bool:
     return ("file:" in diff) and ("file         :" not in diff)
 
 
-@pytest.mark.api
-@pytest.mark.cli
 @pytest.mark.integration
 def test_same_dir_precedence_topmark_over_pyproject(tmp_path: Path) -> None:
     """Nearest directory: topmark.toml should override pyproject.toml in the same dir."""
@@ -125,8 +123,6 @@ def test_same_dir_precedence_topmark_over_pyproject(tmp_path: Path) -> None:
     assert _contains_aligned_fields(cli_diff), "CLI-like did not reflect topmark.toml override"
 
 
-@pytest.mark.api
-@pytest.mark.cli
 @pytest.mark.integration
 def test_discovery_anchor_subdir_nearest_wins(tmp_path: Path) -> None:
     """Anchor in subdir: parent pyproject.toml, child topmark.toml - child wins."""
@@ -187,8 +183,6 @@ def test_discovery_anchor_subdir_nearest_wins(tmp_path: Path) -> None:
     assert _contains_aligned_fields(cli_diff), "CLI-like did not honor nearest (child) config"
 
 
-@pytest.mark.api
-@pytest.mark.cli
 @pytest.mark.integration
 def test_root_true_stops_traversal(tmp_path: Path) -> None:
     """root=true in parent prevents overrides from ancestors."""
@@ -254,8 +248,6 @@ def test_root_true_stops_traversal(tmp_path: Path) -> None:
     assert _contains_unaligned_fields(cli_diff), "CLI-like did not stop at root=true boundary"
 
 
-@pytest.mark.api
-@pytest.mark.cli
 @pytest.mark.integration
 def test_cli_like_positional_paths_preserve_discovered_exclude_from_gitignore(
     tmp_path: Path,

--- a/tests/cli/machine/test_registry_machine.py
+++ b/tests/cli/machine/test_registry_machine.py
@@ -57,9 +57,6 @@ class UnusedRegistryProcessor(HeaderProcessor):
     description: ClassVar[str] = "Processor left intentionally unused in registry tests."
 
 
-pytestmark: pytest.MarkDecorator = pytest.mark.cli
-
-
 FILETYPE_BRIEF_KEYS: frozenset[str] = frozenset(
     {"local_key", "namespace", "qualified_key", "description"}
 )

--- a/tests/cli/test_completion.py
+++ b/tests/cli/test_completion.py
@@ -79,7 +79,6 @@ def test_output_format_completion_lists_all_values() -> None:
 
 
 # adapt if enum values change
-@pytest.mark.cli
 @pytest.mark.parametrize("prefix", ["t", "m", "j", "n"])
 # adapt if enum values change
 def test_output_format_completion_filters_by_prefix(prefix: str) -> None:
@@ -96,14 +95,12 @@ def test_output_format_completion_filters_by_prefix(prefix: str) -> None:
         assert expected & values
 
 
-@pytest.mark.cli
 def test_output_format_completion_handles_nonmatching_prefix() -> None:
     """Non-matching prefixes should yield an empty suggestion list."""
     items: list[CompletionItem] = _complete("zzz")
     assert _values(items) == set()
 
 
-@pytest.mark.cli
 def test_output_format_completion_works_across_commands() -> None:
     """The same option type should complete in other commands that accept it."""
     # If another command (e.g., check) exposes --header-format, it should complete too.

--- a/tests/cli/test_config_human_output.py
+++ b/tests/cli/test_config_human_output.py
@@ -38,9 +38,6 @@ if TYPE_CHECKING:
     from click.testing import Result
 
 
-pytestmark: pytest.MarkDecorator = pytest.mark.cli
-
-
 # --- Quiet mode: TEXT output ---
 @pytest.mark.parametrize(
     "cmd",

--- a/tests/cli/test_output_assertion_helpers.py
+++ b/tests/cli/test_output_assertion_helpers.py
@@ -31,8 +31,6 @@ from tests.cli.conftest import normalize_rich_cli_output
 from topmark.core.exit_codes import ExitCode
 from topmark.core.formats import OutputFormat
 
-pytestmark: pytest.MarkDecorator = pytest.mark.cli
-
 
 def test_normalize_rich_cli_output_strips_ansi_panels_and_soft_wraps() -> None:
     """Rich normalization should preserve content while removing layout noise."""

--- a/tests/cli/test_pipeline_human_output.py
+++ b/tests/cli/test_pipeline_human_output.py
@@ -46,9 +46,6 @@ if TYPE_CHECKING:
     from click.testing import Result
 
 
-pytestmark: pytest.MarkDecorator = pytest.mark.cli
-
-
 def _write_file_requiring_check_update(tmp_path: Path) -> Path:
     """Create a Python file that requires header insertion by `check`."""
     path: Path = tmp_path / "needs_header.py"

--- a/tests/cli/test_processing_case_insensitive_fs.py
+++ b/tests/cli/test_processing_case_insensitive_fs.py
@@ -33,10 +33,7 @@ if TYPE_CHECKING:
     from click.testing import Result
 
 
-pytestmark: list[pytest.MarkDecorator] = [
-    pytest.mark.cli,
-    pytest.mark.case_insensitive_fs,
-]
+pytestmark: pytest.MarkDecorator = pytest.mark.case_insensitive_fs
 
 
 def _write_readme_without_header(root: Path) -> Path:

--- a/tests/cli/test_processing_case_sensitive_fs.py
+++ b/tests/cli/test_processing_case_sensitive_fs.py
@@ -32,9 +32,6 @@ if TYPE_CHECKING:
     from click.testing import Result
 
 
-pytestmark: list[pytest.MarkDecorator] = [pytest.mark.cli]
-
-
 def test_check_does_not_resolve_mismatched_invocation_casing_on_case_sensitive_fs(
     tmp_path: Path,
 ) -> None:

--- a/tests/cli/test_registry_human_output.py
+++ b/tests/cli/test_registry_human_output.py
@@ -63,9 +63,6 @@ class UnusedHumanRegistryProcessor(HeaderProcessor):
     description: ClassVar[str] = "Processor left intentionally unused."
 
 
-pytestmark: pytest.MarkDecorator = pytest.mark.cli
-
-
 @pytest.fixture
 def registry_snapshot() -> Iterator[None]:
     """Patch a small deterministic registry for output rendering tests."""

--- a/tests/config/machine/test_config_machine_payloads.py
+++ b/tests/config/machine/test_config_machine_payloads.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.config.machine.payloads import build_config_check_summary_payload
 from topmark.config.machine.schemas import ConfigDiagnosticsPayload
@@ -29,7 +27,6 @@ if TYPE_CHECKING:
     from topmark.config.model import MutableConfig
 
 
-@pytest.mark.pipeline
 def test_config_check_summary_reuses_precomputed_diagnostic_counts(
     tmp_path: Path,
 ) -> None:
@@ -62,7 +59,6 @@ def test_config_check_summary_reuses_precomputed_diagnostic_counts(
     assert summary.config_files == [config_file.as_posix()]
 
 
-@pytest.mark.pipeline
 def test_config_check_summary_builds_diagnostic_counts_when_missing() -> None:
     """Config-check summaries should compute diagnostic counts when not precomputed."""
     config: FrozenConfig = mutable_config_from_defaults().freeze()

--- a/tests/config/test_config_deserializers.py
+++ b/tests/config/test_config_deserializers.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
 # --- Layered-config deserialization tests (remain in topmark.config) ---
 
 
-@pytest.mark.config
 def test_header_fields_wrong_type_is_treated_as_empty() -> None:
     """Wrong-type [header].fields is treated as empty (must not crash)."""
     draft: MutableConfig = mutable_config_from_layered_toml_table(
@@ -58,7 +57,6 @@ def test_header_fields_wrong_type_is_treated_as_empty() -> None:
     assert draft.header_fields == []
 
 
-@pytest.mark.config
 def test_header_fields_mixed_types_ignores_non_strings(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -97,7 +95,6 @@ def test_header_fields_mixed_types_ignores_non_strings(
     )
 
 
-@pytest.mark.config
 def test_policy_by_type_section_wrong_type_is_ignored() -> None:
     """Non-table [policy_by_type] values are ignored (must not crash)."""
     draft: MutableConfig = mutable_config_from_layered_toml_table(
@@ -114,7 +111,6 @@ _empty_str_list: list[str] = []
 _empty_str_set: set[str] = set()
 
 
-@pytest.mark.config
 @pytest.mark.parametrize(
     "key,_kind,expect_empty",
     [
@@ -156,7 +152,6 @@ def test_files_list_valued_keys_wrong_type_is_treated_as_empty(
         assert draft.exclude_file_types == expect_empty
 
 
-@pytest.mark.config
 def test_include_from_mixed_types_ignores_non_strings(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -200,7 +195,6 @@ def test_include_from_mixed_types_ignores_non_strings(
     )
 
 
-@pytest.mark.config
 @pytest.mark.parametrize(
     "key,is_include",
     [
@@ -250,7 +244,6 @@ def test_glob_patterns_mixed_types_ignores_non_strings(
     )
 
 
-@pytest.mark.config
 @pytest.mark.parametrize(
     "key,is_include",
     [
@@ -303,7 +296,6 @@ def test_glob_patterns_all_non_strings_results_in_empty_list(
     )
 
 
-@pytest.mark.config
 def test_fields_scalar_values_are_stringified_and_unsupported_are_ignored(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -362,7 +354,6 @@ def test_fields_scalar_values_are_stringified_and_unsupported_are_ignored(
     )
 
 
-@pytest.mark.config
 def test_header_fields_can_reference_missing_custom_fields_without_error() -> None:
     """header.fields may reference names not present in [fields] and should not crash."""
     draft: MutableConfig = mutable_config_from_layered_toml_table(
@@ -383,7 +374,6 @@ def test_header_fields_can_reference_missing_custom_fields_without_error() -> No
     assert draft.field_values["project"] == "TopMark"
 
 
-@pytest.mark.config
 @pytest.mark.parametrize("bad_val", ["x", 123, {"a": 1}, None])
 def test_header_fields_wrong_type_falls_back_to_empty_list(
     bad_val: TomlValue,
@@ -402,7 +392,6 @@ def test_header_fields_wrong_type_falls_back_to_empty_list(
     assert draft.header_fields == []
 
 
-@pytest.mark.config
 def test_duplicate_include_file_types_warns_and_is_recorded(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -436,7 +425,6 @@ def test_duplicate_include_file_types_warns_and_is_recorded(
     )
 
 
-@pytest.mark.config
 def test_duplicate_exclude_file_types_warns_and_is_recorded(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -470,7 +458,6 @@ def test_duplicate_exclude_file_types_warns_and_is_recorded(
     )
 
 
-@pytest.mark.config
 def test_extend_pattern_sources_resolves_relative_paths_against_base(
     tmp_path: Path,
 ) -> None:

--- a/tests/config/test_config_resolution_discovery.py
+++ b/tests/config/test_config_resolution_discovery.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from tests.helpers.paths import symlink_or_skip
 from tests.toml.conftest import write_toml_document
 from topmark.config.resolution.bridge import ResolvedConfigDraft
@@ -31,11 +29,11 @@ from topmark.config.resolution.bridge import resolve_toml_sources_and_build_muta
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
     from topmark.config.resolution.bridge import ResolvedConfigDraft
 
 
-@pytest.mark.config
-@pytest.mark.toml
 def test_same_dir_precedence_topmark_over_pyproject(
     tmp_path: Path,
 ) -> None:
@@ -65,8 +63,6 @@ def test_same_dir_precedence_topmark_over_pyproject(
     assert resolved_config.draft.align_fields is True
 
 
-@pytest.mark.config
-@pytest.mark.toml
 def test_root_true_stops_traversal(
     tmp_path: Path,
 ) -> None:
@@ -104,8 +100,6 @@ def test_root_true_stops_traversal(
     assert resolved_config.draft.align_fields is True
 
 
-@pytest.mark.config
-@pytest.mark.toml
 def test_symlinked_discovery_anchor_uses_resolved_project_chain(
     tmp_path: Path,
 ) -> None:
@@ -134,8 +128,6 @@ def test_symlinked_discovery_anchor_uses_resolved_project_chain(
     assert resolved_config.draft.config_files == [repo.resolve() / "topmark.toml"]
 
 
-@pytest.mark.config
-@pytest.mark.toml
 def test_symlinked_cwd_discovery_uses_resolved_project_chain(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -164,8 +156,6 @@ def test_symlinked_cwd_discovery_uses_resolved_project_chain(
     assert resolved_config.draft.config_files == [repo.resolve() / "topmark.toml"]
 
 
-@pytest.mark.config
-@pytest.mark.toml
 def test_repo_below_symlinked_parent_discovers_real_project_chain(
     tmp_path: Path,
 ) -> None:
@@ -196,8 +186,6 @@ def test_repo_below_symlinked_parent_discovers_real_project_chain(
     assert resolved_config.draft.config_files == [repo.resolve() / "topmark.toml"]
 
 
-@pytest.mark.config
-@pytest.mark.toml
 def test_malformed_toml_in_discovered_config_is_ignored(
     tmp_path: Path,
 ) -> None:

--- a/tests/config/test_config_resolution_merge.py
+++ b/tests/config/test_config_resolution_merge.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from tests.helpers.diagnostics import NON_EMPTY
 from tests.helpers.diagnostics import assert_diagnostic_level_stats
 from tests.helpers.diagnostics import assert_validation_stage_totals
@@ -50,7 +48,6 @@ if TYPE_CHECKING:
     from topmark.diagnostic.model import MutableDiagnosticLog
 
 
-@pytest.mark.config
 def test_include_from_accumulates_across_multiple_applicable_layers(
     tmp_path: Path,
 ) -> None:
@@ -93,7 +90,6 @@ def test_include_from_accumulates_across_multiple_applicable_layers(
     ]
 
 
-@pytest.mark.config
 def test_files_nearest_non_empty_list_wins_across_layers(
     tmp_path: Path,
 ) -> None:
@@ -123,7 +119,6 @@ def test_files_nearest_non_empty_list_wins_across_layers(
     assert resolved_config.draft.files == [str((child / "module.py").resolve())]
 
 
-@pytest.mark.config
 def test_include_file_types_nearest_non_empty_set_wins_across_layers(
     tmp_path: Path,
 ) -> None:
@@ -153,7 +148,6 @@ def test_include_file_types_nearest_non_empty_set_wins_across_layers(
     assert resolved_config.draft.include_file_types == {"markdown"}
 
 
-@pytest.mark.config
 def test_select_applicable_layers_filters_child_scoped_layer(
     tmp_path: Path,
 ) -> None:
@@ -194,7 +188,6 @@ def test_select_applicable_layers_filters_child_scoped_layer(
     assert not any(layer.scope_root == child.resolve() for layer in sibling_layers)
 
 
-@pytest.mark.config
 def test_build_effective_config_for_path_merges_only_applicable_layers(
     tmp_path: Path,
 ) -> None:
@@ -247,7 +240,6 @@ def test_build_effective_config_for_path_merges_only_applicable_layers(
     assert "file" not in sibling_cfg.field_values
 
 
-@pytest.mark.config
 def test_merge_layers_globally_empty_returns_defaults() -> None:
     """Merging an empty layer sequence should fall back to defaults."""
     draft: MutableConfig = merge_layers_globally(())
@@ -258,7 +250,6 @@ def test_merge_layers_globally_empty_returns_defaults() -> None:
     assert draft.include_pattern_groups == default_draft.include_pattern_groups
 
 
-@pytest.mark.config
 def test_cli_overrides_merge_last(
     tmp_path: Path,
 ) -> None:
@@ -288,7 +279,6 @@ def test_cli_overrides_merge_last(
     assert resolved_config.draft.align_fields is True
 
 
-@pytest.mark.config
 def test_override_diagnostics_land_in_merged_config(tmp_path: Path) -> None:
     """Override application diagnostics should land in the merged-config stage."""
     proj: Path = tmp_path / "proj"

--- a/tests/config/test_config_resolution_paths.py
+++ b/tests/config/test_config_resolution_paths.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     from topmark.resolution.files import FileListResolution
 
 
-@pytest.mark.config
 def test_relative_to_resolves_against_config_dir(
     tmp_path: Path,
 ) -> None:
@@ -68,7 +67,6 @@ def test_relative_to_resolves_against_config_dir(
     assert resolved_config.draft.relative_to == proj.resolve()
 
 
-@pytest.mark.config
 def test_include_from_normalized_to_patternsources(
     tmp_path: Path,
 ) -> None:
@@ -95,7 +93,6 @@ def test_include_from_normalized_to_patternsources(
     assert ps.base == proj.resolve()
 
 
-@pytest.mark.config
 def test_cli_path_options_resolve_from_cwd(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -124,7 +121,6 @@ def test_cli_path_options_resolve_from_cwd(
     assert ps.base == cwd.resolve()
 
 
-@pytest.mark.config
 def test_globs_evaluated_relative_to_relative_to(
     tmp_path: Path,
 ) -> None:
@@ -156,7 +152,6 @@ def test_globs_evaluated_relative_to_relative_to(
     assert py.resolve() in paths
 
 
-@pytest.mark.config
 def test_relative_to_inheritance_across_multiple_discovered_configs(
     tmp_path: Path,
 ) -> None:
@@ -189,7 +184,6 @@ def test_relative_to_inheritance_across_multiple_discovered_configs(
     assert resolved_config.draft.relative_to == root.resolve()
 
 
-@pytest.mark.config
 def test_child_overrides_relative_to_with_its_own_dir(
     tmp_path: Path,
 ) -> None:
@@ -221,7 +215,6 @@ def test_child_overrides_relative_to_with_its_own_dir(
     assert resolved_config.draft.relative_to == sub.resolve()
 
 
-@pytest.mark.config
 def test_parent_include_from_and_child_exclude_from_normalized_with_proper_bases(
     tmp_path: Path,
 ) -> None:
@@ -264,7 +257,6 @@ def test_parent_include_from_and_child_exclude_from_normalized_with_proper_bases
     assert resolved_config.draft.exclude_from[0].base == child.resolve()
 
 
-@pytest.mark.config
 def test_config_seeding_globs_when_no_inputs_and_cwd_differs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -301,7 +293,6 @@ def test_config_seeding_globs_when_no_inputs_and_cwd_differs(
     assert rel == ["proj/src/mod.py"]
 
 
-@pytest.mark.config
 def test_include_patterns_seed_candidates_when_no_files_are_configured(
     tmp_path: Path,
 ) -> None:
@@ -339,7 +330,6 @@ def test_include_patterns_seed_candidates_when_no_files_are_configured(
     assert list(resolution.selected) == [py.resolve()]
 
 
-@pytest.mark.config
 def test_files_from_declared_in_config_normalizes_to_patternsource(
     tmp_path: Path,
 ) -> None:
@@ -364,7 +354,6 @@ def test_files_from_declared_in_config_normalizes_to_patternsource(
     assert ps.base == proj.resolve()
 
 
-@pytest.mark.config
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows drive semantics only")
 def test_cli_path_options_resolve_from_windows_drive_cwd(
     tmp_path: Path,
@@ -395,7 +384,6 @@ def test_cli_path_options_resolve_from_windows_drive_cwd(
         assert pattern_source.path.drive == cwd.resolve().drive
 
 
-@pytest.mark.config
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows drive semantics only")
 def test_relative_to_resolves_against_windows_config_drive(
     tmp_path: Path,
@@ -420,7 +408,6 @@ def test_relative_to_resolves_against_windows_config_drive(
     assert draft.relative_to.drive == workspace.resolve().drive
 
 
-@pytest.mark.config
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows drive semantics only")
 def test_config_file_discovery_accepts_windows_absolute_input_path(
     tmp_path: Path,
@@ -447,7 +434,6 @@ def test_config_file_discovery_accepts_windows_absolute_input_path(
     assert resolved_config.draft.relative_to.drive == proj.resolve().drive
 
 
-@pytest.mark.config
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows absolute path semantics only")
 def test_config_resolution_preserves_absolute_cli_path(
     tmp_path: Path,

--- a/tests/config/test_config_strictness_and_validity.py
+++ b/tests/config/test_config_strictness_and_validity.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from tests.helpers.config import make_mutable_config
 from tests.helpers.diagnostics import NON_EMPTY
 from tests.helpers.diagnostics import assert_diagnostic_level_stats
@@ -42,7 +40,6 @@ if TYPE_CHECKING:
     from topmark.diagnostic.model import FrozenDiagnosticLog
 
 
-@pytest.mark.config
 def test_load_resolved_config_applies_strictness_from_config_table(
     tmp_path: Path,
 ) -> None:
@@ -64,7 +61,6 @@ def test_load_resolved_config_applies_strictness_from_config_table(
     assert resolved_config.resolved.strict is True
 
 
-@pytest.mark.config
 def test_explicit_strictness_override_false_wins_over_resolved_true(
     tmp_path: Path,
 ) -> None:
@@ -87,7 +83,6 @@ def test_explicit_strictness_override_false_wins_over_resolved_true(
     assert resolved_config.resolved.strict is False
 
 
-@pytest.mark.config
 def test_explicit_strictness_override_true_wins_over_resolved_false(
     tmp_path: Path,
 ) -> None:
@@ -110,7 +105,6 @@ def test_explicit_strictness_override_true_wins_over_resolved_false(
     assert resolved_config.resolved.strict is True
 
 
-@pytest.mark.config
 def test_replayed_toml_warning_is_non_strict_valid_but_strict_invalid(
     tmp_path: Path,
 ) -> None:
@@ -155,7 +149,6 @@ def test_replayed_toml_warning_is_non_strict_valid_but_strict_invalid(
     assert frozen.is_valid(strict=True) is False
 
 
-@pytest.mark.config
 def test_missing_section_info_does_not_fail_even_when_strict(
     tmp_path: Path,
 ) -> None:
@@ -203,7 +196,6 @@ def test_missing_section_info_does_not_fail_even_when_strict(
     )
 
 
-@pytest.mark.config
 def test_sanitization_warning_is_non_strict_valid_but_strict_invalid() -> None:
     """Sanitization warnings participate in strict validity but not non-strict validity."""
     draft: MutableConfig = make_mutable_config(include_from=["patterns/*.txt"])
@@ -241,7 +233,6 @@ def test_sanitization_warning_is_non_strict_valid_but_strict_invalid() -> None:
     )
 
 
-@pytest.mark.config
 def test_is_valid_false_on_errors() -> None:
     """Merged-config errors always make the config invalid."""
     draft: MutableConfig = mutable_config_from_defaults()
@@ -252,7 +243,6 @@ def test_is_valid_false_on_errors() -> None:
     assert c.is_valid() is False
 
 
-@pytest.mark.config
 def test_is_valid_true_on_warnings() -> None:
     """Merged-config warnings do not make the config invalid by default."""
     draft: MutableConfig = mutable_config_from_defaults()
@@ -263,7 +253,6 @@ def test_is_valid_true_on_warnings() -> None:
     assert c.is_valid() is True
 
 
-@pytest.mark.config
 def test_is_valid_false_on_warnings_when_strict() -> None:
     """Merged-config warnings make the config invalid when strict mode is enabled."""
     draft: MutableConfig = mutable_config_from_defaults()
@@ -274,7 +263,6 @@ def test_is_valid_false_on_warnings_when_strict() -> None:
     assert c.is_valid(strict=True) is False
 
 
-@pytest.mark.config
 def test_freeze_preserves_diagnostics() -> None:
     """freeze() must preserve staged diagnostics and their flattened view."""
     draft: MutableConfig = mutable_config_from_defaults()

--- a/tests/config/test_merge_semantics_invariants.py
+++ b/tests/config/test_merge_semantics_invariants.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pytest
-
 from tests.helpers.diagnostics import assert_diagnostic_level_stats
 from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.config.policy import HeaderMutationMode
@@ -38,7 +36,6 @@ if TYPE_CHECKING:
     from topmark.diagnostic.model import MutableDiagnosticLog
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_provenance_and_diagnostics_accumulate() -> None:
     """config_files and merged-config diagnostics should always accumulate."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -79,7 +76,6 @@ def test_merge_invariant_provenance_and_diagnostics_accumulate() -> None:
     assert list(merged.validation_logs.runtime_applicability.items) == []
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_header_fields_nearest_non_empty_wins() -> None:
     """header_fields uses nearest-wins semantics for non-empty child lists."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -93,7 +89,6 @@ def test_merge_invariant_header_fields_nearest_non_empty_wins() -> None:
     assert merged.header_fields == ["project", "file"]
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_empty_header_fields_do_not_clear_parent() -> None:
     """An empty child header_fields list is treated as not-set in merge_with()."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -107,7 +102,6 @@ def test_merge_invariant_empty_header_fields_do_not_clear_parent() -> None:
     assert merged.header_fields == ["project", "license"]
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_field_values_overlay_by_key() -> None:
     """field_values should merge by key, with child keys overriding parent keys."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -131,7 +125,6 @@ def test_merge_invariant_field_values_overlay_by_key() -> None:
     }
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_pattern_groups_accumulate() -> None:
     """include/exclude pattern groups should append across layers."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -162,7 +155,6 @@ def test_merge_invariant_pattern_groups_accumulate() -> None:
     ]
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_pattern_sources_accumulate() -> None:
     """include_from/exclude_from/files_from should append across layers."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -203,7 +195,6 @@ def test_merge_invariant_pattern_sources_accumulate() -> None:
     ]
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_explicit_files_nearest_non_empty_wins() -> None:
     """Files uses nearest-wins semantics for non-empty child lists."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -217,7 +208,6 @@ def test_merge_invariant_explicit_files_nearest_non_empty_wins() -> None:
     assert merged.files == ["/repo/pkg/module.py"]
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_empty_files_do_not_clear_parent() -> None:
     """An empty child files list is treated as not-set in merge_with()."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -231,7 +221,6 @@ def test_merge_invariant_empty_files_do_not_clear_parent() -> None:
     assert merged.files == ["/repo/README.md"]
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_file_type_filters_nearest_non_empty_wins() -> None:
     """include/exclude file type filters should replace, not union."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -248,7 +237,6 @@ def test_merge_invariant_file_type_filters_nearest_non_empty_wins() -> None:
     assert merged.exclude_file_types == {"xml"}
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_policy_by_type_merges_by_key() -> None:
     """policy_by_type should preserve unrelated parent keys and merge shared keys."""
     base: MutableConfig = mutable_config_from_defaults()
@@ -275,7 +263,6 @@ def test_merge_invariant_policy_by_type_merges_by_key() -> None:
 # --- Additional three-layer invariants ---
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_three_layer_field_values_and_policy_overlay() -> None:
     """Three-layer merges should preserve ordering for mappings and per-type policies."""
     root: MutableConfig = mutable_config_from_defaults()
@@ -323,7 +310,6 @@ def test_merge_invariant_three_layer_field_values_and_policy_overlay() -> None:
     assert merged.policy_by_type["html"].allow_content_probe is True
 
 
-@pytest.mark.pipeline
 def test_merge_invariant_three_layer_include_from_accumulates_in_order() -> None:
     """Three-layer merges should accumulate include_from sources in precedence order."""
     root: MutableConfig = mutable_config_from_defaults()

--- a/tests/config/test_model_export.py
+++ b/tests/config/test_model_export.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
     from topmark.toml.types import TomlTable
 
 
-@pytest.mark.pipeline
 def test_to_toml_strips_none_entries() -> None:
     """to_toml() rejects None by stripping (regression guard).
 
@@ -62,7 +61,6 @@ def test_to_toml_strips_none_entries() -> None:
     assert ArgKey.ALIGN_FIELDS not in s  # or whatever your stripper does
 
 
-@pytest.mark.pipeline
 def test_config_to_toml_dict_origin_mode_preserves_pattern_group_and_source_tables(
     tmp_path: Path,
 ) -> None:
@@ -147,7 +145,6 @@ def test_config_to_toml_dict_origin_mode_preserves_pattern_group_and_source_tabl
     assert first_files_from_source[Toml.KEY_PATH] == files_txt_path.as_posix()
 
 
-@pytest.mark.pipeline
 def test_config_to_toml_dict_rebased_mode_flattens_pattern_groups(
     tmp_path: Path,
 ) -> None:
@@ -187,7 +184,6 @@ def test_config_to_toml_dict_rebased_mode_flattens_pattern_groups(
     assert exclude_pattern.endswith("build/**")
 
 
-@pytest.mark.pipeline
 def test_config_to_toml_dict_includes_file_list_when_requested() -> None:
     """Explicit file-list export should include discovered files when requested."""
     draft: MutableConfig = mutable_config_from_defaults()
@@ -210,7 +206,6 @@ def test_config_to_toml_dict_includes_file_list_when_requested() -> None:
     ]
 
 
-@pytest.mark.pipeline
 @pytest.mark.parametrize(
     ("mode", "expected_keys", "unexpected_keys"),
     [

--- a/tests/dev_validation/test_pytest_markers.py
+++ b/tests/dev_validation/test_pytest_markers.py
@@ -1,0 +1,242 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_pytest_markers.py
+#   file_relpath : tests/dev_validation/test_pytest_markers.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Developer-validation checks for pytest marker hygiene."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import cast
+
+import pytest
+import tomlkit
+
+_REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+_TESTS_ROOT: Path = _REPO_ROOT / "tests"
+_PYPROJECT_PATH: Path = _REPO_ROOT / "pyproject.toml"
+_NOXFILE_PATH: Path = _REPO_ROOT / "noxfile.py"
+_MAKEFILE_PATH: Path = _REPO_ROOT / "Makefile"
+_MARKER_TOKEN_RE: re.Pattern[str] = re.compile(r"\b[A-Za-z_]\w*\b")
+_MARK_EXPRESSION_KEYWORDS: frozenset[str] = frozenset({"and", "not", "or"})
+_BUILTIN_MARKERS: frozenset[str] = frozenset(
+    {
+        "filterwarnings",
+        "parametrize",
+        "skip",
+        "skipif",
+        "usefixtures",
+        "xfail",
+    }
+)
+
+
+def _string_key_mapping(value: object, label: str) -> dict[str, object]:
+    """Return ``value`` as a string-keyed mapping for TOML table traversal."""
+    assert isinstance(value, dict), f"{label} must be a TOML table"
+
+    # Validate the parsed TOML table shape before traversing it.
+    raw_mapping: dict[object, object] = cast("dict[object, object]", value)
+    mapping: dict[str, object] = {}
+    for key, item in raw_mapping.items():
+        assert isinstance(key, str), f"{label} contains a non-string key: {key!r}"
+        mapping[key] = item
+    return mapping
+
+
+def _string_list(value: object, label: str) -> list[str]:
+    """Return ``value`` as a list of strings."""
+    assert isinstance(value, list), f"{label} must be a list"
+    # Validate the parsed TOML array shape before traversing it.
+    raw_items: list[object] = cast("list[object]", value)
+    strings: list[str] = []
+    for item in raw_items:
+        assert isinstance(item, str), f"{label} contains a non-string item: {item!r}"
+        strings.append(item)
+    return strings
+
+
+def _declared_pytest_markers() -> frozenset[str]:
+    """Return custom pytest markers declared in ``pyproject.toml``."""
+    document: tomlkit.TOMLDocument = tomlkit.loads(
+        _PYPROJECT_PATH.read_text(
+            encoding="utf-8",
+        )
+    )
+
+    data: dict[str, object] = _string_key_mapping(
+        document.unwrap(),
+        "pyproject.toml",
+    )
+    tool: dict[str, object] = _string_key_mapping(data.get("tool"), "[tool]")
+    pytest_config: dict[str, object] = _string_key_mapping(
+        tool.get("pytest"),
+        "[tool.pytest]",
+    )
+    ini_options: dict[str, object] = _string_key_mapping(
+        pytest_config.get("ini_options"),
+        "[tool.pytest.ini_options]",
+    )
+    marker_entries: list[str] = _string_list(
+        ini_options.get("markers"),
+        "[tool.pytest.ini_options].markers",
+    )
+
+    return frozenset(entry.split(":", maxsplit=1)[0].strip() for entry in marker_entries)
+
+
+def _python_test_files() -> list[Path]:
+    """Return Python test files, excluding interpreter and pytest cache directories."""
+    return [
+        path
+        for path in sorted(_TESTS_ROOT.rglob("*.py"))
+        if not path.name.startswith("._")
+        and "__pycache__" not in path.parts
+        and ".pytest_cache" not in path.parts
+    ]
+
+
+def _pytest_mark_names_from_file(path: Path) -> set[str]:
+    """Return names used through ``pytest.mark.<name>`` in a Python file."""
+    tree: ast.Module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+        if not isinstance(node.value, ast.Attribute) or node.value.attr != "mark":
+            continue
+        if not isinstance(node.value.value, ast.Name) or node.value.value.id != "pytest":
+            continue
+        names.add(node.attr)
+    return names
+
+
+def _marker_tokens(expression: str) -> set[str]:
+    """Extract marker names from a pytest ``-m`` expression string."""
+    return {
+        token
+        for token in _MARKER_TOKEN_RE.findall(expression)
+        if token not in _MARK_EXPRESSION_KEYWORDS
+    }
+
+
+def _nox_marker_expressions() -> list[str]:
+    """Return pytest marker expressions passed through nox ``session.run`` calls."""
+    tree: ast.Module = ast.parse(
+        _NOXFILE_PATH.read_text(encoding="utf-8"), filename=str(_NOXFILE_PATH)
+    )
+    expressions: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        arguments: list[ast.expr] = list(node.args)
+        command_parts: list[str] = [
+            argument.value
+            for argument in arguments
+            if isinstance(argument, ast.Constant) and isinstance(argument.value, str)
+        ]
+        if "pytest" not in command_parts:
+            continue
+
+        for index, argument in enumerate(arguments[:-1]):
+            next_argument: ast.expr = arguments[index + 1]
+            if not isinstance(argument, ast.Constant) or argument.value != "-m":
+                continue
+            if not isinstance(next_argument, ast.Constant) or not isinstance(
+                next_argument.value, str
+            ):
+                continue
+            expressions.append(next_argument.value)
+    return expressions
+
+
+def _makefile_marker_expressions() -> list[str]:
+    """Return pytest marker expressions passed through Makefile recipes."""
+    expressions: list[str] = []
+    lines: list[str] = _MAKEFILE_PATH.read_text(encoding="utf-8").splitlines()
+    for line in lines:
+        if "pytest" not in line or " -m " not in line:
+            continue
+        match: re.Match[str] | None = re.search(
+            r"\s-m\s+(?P<quote>[\"'])(?P<expression>.+?)(?P=quote)",
+            line,
+        )
+        if match is None:
+            continue
+        expressions.append(match.group("expression"))
+    return expressions
+
+
+def _tool_marker_expressions() -> dict[str, list[str]]:
+    """Return pytest marker expressions grouped by project tooling source."""
+    return {
+        "Makefile": _makefile_marker_expressions(),
+        "noxfile.py": _nox_marker_expressions(),
+    }
+
+
+@pytest.mark.dev_validation
+def test_used_custom_pytest_markers_are_declared() -> None:
+    """Every custom marker used in tests is declared in pytest configuration."""
+    declared_markers: frozenset[str] = _declared_pytest_markers()
+    used_markers: set[str] = set()
+    for path in _python_test_files():
+        used_markers.update(_pytest_mark_names_from_file(path))
+
+    custom_markers: set[str] = used_markers - _BUILTIN_MARKERS
+    undeclared_markers: list[str] = sorted(custom_markers - declared_markers)
+
+    assert undeclared_markers == [], f"Undeclared custom pytest markers: {undeclared_markers!r}"
+
+
+@pytest.mark.dev_validation
+def test_declared_pytest_markers_are_used_or_referenced_by_tooling() -> None:
+    """Declared custom markers should be used or referenced by project tooling."""
+    declared_markers: frozenset[str] = _declared_pytest_markers()
+
+    used_markers: set[str] = set()
+    for path in _python_test_files():
+        used_markers.update(_pytest_mark_names_from_file(path))
+
+    custom_markers: set[str] = used_markers - _BUILTIN_MARKERS
+
+    referenced_markers: set[str] = set()
+    for expressions in _tool_marker_expressions().values():
+        for expression in expressions:
+            referenced_markers.update(_marker_tokens(expression))
+
+    unused: list[str] = sorted(
+        marker
+        for marker in declared_markers
+        if marker not in custom_markers and marker not in referenced_markers
+    )
+
+    assert unused == [], f"Declared pytest markers are unused: {unused!r}"
+
+
+@pytest.mark.dev_validation
+def test_tool_pytest_marker_expressions_reference_declared_markers() -> None:
+    """Project tooling pytest marker selections reference declared custom markers."""
+    declared_markers: frozenset[str] = _declared_pytest_markers()
+    unknown_by_source: dict[str, dict[str, list[str]]] = {}
+    for source, expressions in _tool_marker_expressions().items():
+        unknown_by_expression: dict[str, list[str]] = {
+            expression: sorted(_marker_tokens(expression) - declared_markers)
+            for expression in expressions
+            if _marker_tokens(expression) - declared_markers
+        }
+        if unknown_by_expression:
+            unknown_by_source[source] = unknown_by_expression
+
+    assert unknown_by_source == {}, (
+        "Project tooling pytest marker expressions reference undeclared markers: "
+        f"{unknown_by_source!r}"
+    )

--- a/tests/pipeline/integration/test_comparer_e2e.py
+++ b/tests/pipeline/integration/test_comparer_e2e.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from tests.helpers.pipeline import make_pipeline_context
 from tests.helpers.pipeline import run_insert
 from tests.helpers.pipeline import run_steps
@@ -37,6 +39,8 @@ from topmark.pipeline.steps import resolver
 from topmark.pipeline.steps import scanner
 from topmark.pipeline.views import BuilderView
 from topmark.pipeline.views import RenderView
+
+pytestmark: pytest.MarkDecorator = pytest.mark.integration
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/pipeline/integration/test_nested_config_e2e.py
+++ b/tests/pipeline/integration/test_nested_config_e2e.py
@@ -22,6 +22,8 @@ from topmark.api.runtime import run_pipeline_results
 from topmark.pipeline.pipelines import select_pipeline
 from topmark.runtime.model import RunOptions
 
+pytestmark: pytest.MarkDecorator = pytest.mark.integration
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -35,7 +37,6 @@ def _write(path: Path, content: str) -> None:
     path.write_text(textwrap.dedent(content).lstrip("\n"), encoding="utf-8")
 
 
-@pytest.mark.pipeline
 def test_nested_config_applies_only_within_its_subtree(tmp_path: Path) -> None:
     """A nested config should affect durable output for its own subtree only.
 

--- a/tests/pipeline/test_engine_path_configs.py
+++ b/tests/pipeline/test_engine_path_configs.py
@@ -26,8 +26,6 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from typing import Any
 
-import pytest
-
 from tests.helpers.config import make_frozen_config
 from tests.helpers.pipeline import TEST_NOOP_PIPELINE_SELECTION
 from topmark.pipeline import engine
@@ -36,6 +34,8 @@ from topmark.runtime.model import RunOptions
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
+
+    import pytest
 
     from topmark.config.model import FrozenConfig
     from topmark.config.policy import PolicyRegistry
@@ -52,7 +52,6 @@ def _fake_runner_run(
     return ctx
 
 
-@pytest.mark.pipeline
 def test_run_steps_for_files_uses_path_specific_configs_when_provided(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -128,7 +127,6 @@ def test_run_steps_for_files_uses_path_specific_configs_when_provided(
     assert bootstrap_calls[1][3] == {"header_fields": ("license",)}
 
 
-@pytest.mark.pipeline
 def test_run_steps_for_files_falls_back_to_shared_config_without_path_configs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -193,7 +191,6 @@ def test_run_steps_for_files_falls_back_to_shared_config_without_path_configs(
     assert bootstrap_calls[1][3] == {"header_fields": ("project", "file")}
 
 
-@pytest.mark.pipeline
 def test_iter_steps_for_files_yields_contexts_before_later_files_are_bootstrapped(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -247,7 +244,6 @@ def test_iter_steps_for_files_yields_contexts_before_later_files_are_bootstrappe
     assert bootstrapped_paths == [file_a, file_b]
 
 
-@pytest.mark.pipeline
 def test_iter_steps_for_files_records_engine_exit_code_in_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/pipeline/test_view_pruning.py
+++ b/tests/pipeline/test_view_pruning.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from topmark.pipeline.pipelines import Pipeline
 from topmark.pipeline.views import BuilderView
 from topmark.pipeline.views import DiffView
@@ -33,7 +31,6 @@ if TYPE_CHECKING:
     from topmark.pipeline.protocols import Step
 
 
-@pytest.mark.pipeline
 def test_release_consumed_keeps_views_needed_by_remaining_steps() -> None:
     """The lifecycle helper must not release payloads with downstream consumers."""
     header_mapping: Mapping[str, str] = {
@@ -95,7 +92,6 @@ def test_release_consumed_keeps_views_needed_by_remaining_steps() -> None:
     assert views.diff.text is not None
 
 
-@pytest.mark.pipeline
 def test_release_consumed_releases_payloads_not_needed_before_writer() -> None:
     """Only the updated image and requested diff need to survive before the writer."""
     header_mapping: Mapping[str, str] = {"project": "TopMark"}
@@ -147,7 +143,6 @@ def test_release_consumed_releases_payloads_not_needed_before_writer() -> None:
     assert views.diff.text is not None
 
 
-@pytest.mark.pipeline
 def test_release_consumed_releases_diff_unless_caller_keeps_it() -> None:
     """Diff payloads are retained only when explicitly requested."""
     views = Views(diff=DiffView(text="--- current\n+++ updated\n"))
@@ -161,7 +156,6 @@ def test_release_consumed_releases_diff_unless_caller_keeps_it() -> None:
     assert views.diff.text is None
 
 
-@pytest.mark.pipeline
 def test_pipeline_steps_declare_expected_view_consumers() -> None:
     """Verify the expected consumes_views declarations used by lifecycle pruning.
 

--- a/tests/processors/test_bom_newline_matrix.py
+++ b/tests/processors/test_bom_newline_matrix.py
@@ -21,8 +21,8 @@ Notes:
 * The strip tests build a header+body fixture with the requested newline style
   and exercise `strip_header_block`, asserting preserved newlines in the result.
 
-These tests are marked with `@pytest.mark.pipeline` and are parameterized across
-extensions and newline styles for broad coverage.
+These tests are parameterized across extensions and newline styles for broad
+coverage.
 """
 
 from __future__ import annotations
@@ -46,8 +46,6 @@ if TYPE_CHECKING:
     from topmark.processors.base import HeaderProcessor
     from topmark.processors.types import StripHeaderResult
 
-mark_pipeline: pytest.MarkDecorator = pytest.mark.pipeline
-
 
 @pytest.mark.parametrize(
     "ext, pre, post",
@@ -58,7 +56,6 @@ mark_pipeline: pytest.MarkDecorator = pytest.mark.pipeline
     ],
 )
 @pytest.mark.parametrize("newline", ["\n", "\r\n"])  # LF and CRLF
-@pytest.mark.pipeline
 def test_insert_preserves_newline_style(
     tmp_path: Path, ext: str, pre: str, post: str, newline: str
 ) -> None:
@@ -106,7 +103,6 @@ def test_insert_preserves_newline_style(
     ],
 )
 @pytest.mark.parametrize("newline", ["\n", "\r\n"])  # LF and CRLF
-@pytest.mark.pipeline
 def test_strip_preserves_newline_style(
     tmp_path: Path,
     ext: str,

--- a/tests/processors/test_bounds_inclusive.py
+++ b/tests/processors/test_bounds_inclusive.py
@@ -19,9 +19,6 @@ that explicitly covers the *start directive*, a *single payload line*, and the
 
 * return the same span `(0, 2)`, and
 * remove the entire header block, leaving only the body content intact.
-
-These tests are marked with `@pytest.mark.pipeline` to indicate they exercise
-pipeline-level processor behavior.
 """
 
 from __future__ import annotations
@@ -40,8 +37,6 @@ if TYPE_CHECKING:
 
     from topmark.processors.base import HeaderProcessor
     from topmark.processors.types import StripHeaderResult
-
-mark_pipeline: pytest.MarkDecorator = pytest.mark.pipeline
 
 
 @pytest.mark.parametrize(
@@ -70,7 +65,6 @@ mark_pipeline: pytest.MarkDecorator = pytest.mark.pipeline
         ),
     ],
 )
-@pytest.mark.pipeline
 def test_strip_bounds_are_inclusive(
     tmp_path: Path, ext: str, header_open: str, header_line: str, header_close: str, body: str
 ) -> None:

--- a/tests/processors/test_cblock.py
+++ b/tests/processors/test_cblock.py
@@ -53,7 +53,6 @@ if TYPE_CHECKING:
     from topmark.processors.types import StripHeaderResult
 
 
-@pytest.mark.pipeline
 def test_cblock_processor_basics(tmp_path: Path) -> None:
     """Basics: resolve to a C-block style processor and no pre-existing header."""
     path: Path = tmp_path / "styles.css"
@@ -82,7 +81,6 @@ def test_cblock_processor_basics(tmp_path: Path) -> None:
     assert ctx.status.header.name == "MISSING"
 
 
-@pytest.mark.pipeline
 @pytest.mark.parametrize(
     "ext,body",
     [
@@ -117,7 +115,6 @@ def test_cblock_all_registrations_insert_and_trailing_blank(
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_cblock_detect_existing_header_with_star_prefix(tmp_path: Path) -> None:
     """Detect an existing C-block header that was produced by TopMark itself."""
     path: Path = tmp_path / "existing.css"
@@ -160,7 +157,6 @@ def test_cblock_detect_existing_header_with_star_prefix(tmp_path: Path) -> None:
     ctx_check.views.release_all()  # Release the views
 
 
-@pytest.mark.pipeline
 def test_cblock_detect_existing_header_without_star_on_directives(tmp_path: Path) -> None:
     """Scanner tolerates directives without '*' inside the block."""
     path: Path = tmp_path / "nostar.css"
@@ -211,7 +207,6 @@ def test_cblock_detect_existing_header_without_star_on_directives(tmp_path: Path
     assert ctx2.views.header.range is not None
 
 
-@pytest.mark.pipeline
 def test_cblock_crlf_preserves_newlines(tmp_path: Path) -> None:
     """Preserve CRLF newlines on Windows-style CSS inputs."""
     file: Path = tmp_path / "win.less"
@@ -227,7 +222,6 @@ def test_cblock_crlf_preserves_newlines(tmp_path: Path) -> None:
         assert ln.endswith("\r\n"), f"line {i} not CRLF: {ln!r}"
 
 
-@pytest.mark.pipeline
 def test_cblock_strip_header_block_with_and_without_span(tmp_path: Path) -> None:
     """`strip_header_block` removes the block with or without explicit bounds."""
     file: Path = tmp_path / "strip_me.css"
@@ -254,7 +248,6 @@ def test_cblock_strip_header_block_with_and_without_span(tmp_path: Path) -> None
     assert strip_result_2.removed_span == (0, 4)
 
 
-@pytest.mark.pipeline
 def test_cblock_banner_comment_after_header(tmp_path: Path) -> None:
     """Header must precede any pre-existing banner comment."""
     file: Path = tmp_path / "banner.css"
@@ -278,7 +271,6 @@ def test_cblock_banner_comment_after_header(tmp_path: Path) -> None:
         assert banner_idx > close_idx
 
 
-@pytest.mark.pipeline
 def test_cblock_strip_header_block_generated(tmp_path: Path) -> None:
     """strip_header_block removes a canonical TopMark C-block header."""
     file: Path = tmp_path / "strip_me.css"
@@ -302,7 +294,6 @@ def test_cblock_strip_header_block_generated(tmp_path: Path) -> None:
     assert TOPMARK_START_MARKER not in "".join(strip_result.lines)
 
 
-@pytest.mark.pipeline
 def test_cblock_not_at_top_insertion_single_leading_blank(tmp_path: Path) -> None:
     """When inserting *not* at the top, ensure exactly one leading blank is added.
 

--- a/tests/processors/test_markdown.py
+++ b/tests/processors/test_markdown.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from tests.helpers.pipeline import BlockSignatures
 from tests.helpers.pipeline import expected_block_lines_for
 from tests.helpers.pipeline import find_line
@@ -34,7 +32,6 @@ if TYPE_CHECKING:
     from topmark.pipeline.context.model import ProcessingContext
 
 
-@pytest.mark.pipeline
 def test_markdown_fenced_code_no_insertion_inside(tmp_path: Path) -> None:
     """Do not insert inside Markdown fenced code blocks.
 
@@ -58,7 +55,6 @@ def test_markdown_fenced_code_no_insertion_inside(tmp_path: Path) -> None:
     )
 
 
-@pytest.mark.pipeline
 def test_markdown_top_of_file_with_trailing_blank(tmp_path: Path) -> None:
     """Markdown supports HTML comments; insert at top with trailing blank.
 
@@ -82,7 +78,6 @@ def test_markdown_top_of_file_with_trailing_blank(tmp_path: Path) -> None:
         assert lines[close_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_markdown_with_existing_banner_comment(tmp_path: Path) -> None:
     """Markdown: header precedes any existing banner comment.
 

--- a/tests/processors/test_pound.py
+++ b/tests/processors/test_pound.py
@@ -54,7 +54,6 @@ if TYPE_CHECKING:
 logger: TopmarkLogger = get_logger(__name__)
 
 
-@pytest.mark.pipeline
 def test_pound_processor_basics(tmp_path: Path) -> None:
     """Basic detection and scan.
 
@@ -84,7 +83,6 @@ def test_pound_processor_basics(tmp_path: Path) -> None:
     assert ctx.views.header is None
 
 
-@pytest.mark.pipeline
 def test_pound_processor_detects_existing_header(tmp_path: Path) -> None:
     """Test that PoundHeaderProcessor correctly detects an existing TopMark header.
 
@@ -135,7 +133,6 @@ def test_pound_processor_detects_existing_header(tmp_path: Path) -> None:
     ctx.views.release_all()  # Release the views
 
 
-@pytest.mark.pipeline
 def test_pound_processor_missing_header(tmp_path: Path) -> None:
     """Test that PoundHeaderProcessor handles files with no TopMark header.
 
@@ -168,7 +165,6 @@ def test_pound_processor_missing_header(tmp_path: Path) -> None:
     assert ctx.status.header.name == "MISSING"
 
 
-@pytest.mark.pipeline
 @pytest.mark.parametrize(
     "header_fields, expected_status",
     [
@@ -225,7 +221,6 @@ def test_pound_malformed_header_fields(
     assert ctx.status.header == expected_status
 
 
-@pytest.mark.pipeline
 def test_insert_with_shebang_adds_single_blank_line(tmp_path: Path) -> None:
     """Insert after shebang with exactly one blank line.
 
@@ -264,7 +259,6 @@ def test_insert_with_shebang_adds_single_blank_line(tmp_path: Path) -> None:
     assert lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_insert_with_shebang_existing_blank_not_duplicated(tmp_path: Path) -> None:
     """Do not duplicate an existing blank line after the shebang.
 
@@ -289,7 +283,6 @@ def test_insert_with_shebang_existing_blank_not_duplicated(tmp_path: Path) -> No
     assert start_idx == 2, f"expected header at index 2, got {start_idx}"
 
 
-@pytest.mark.pipeline
 def test_insert_with_shebang_and_encoding(tmp_path: Path) -> None:
     """Insert after shebang + encoding with one blank.
 
@@ -314,7 +307,6 @@ def test_insert_with_shebang_and_encoding(tmp_path: Path) -> None:
     assert start_idx == 3, f"expected header at index 3 after shebang+encoding, got {start_idx}"
 
 
-@pytest.mark.pipeline
 def test_insert_without_shebang_starts_at_top_and_blank_after(tmp_path: Path) -> None:
     """Insert at top of file when there is no shebang, with a trailing blank.
 
@@ -340,7 +332,6 @@ def test_insert_without_shebang_starts_at_top_and_blank_after(tmp_path: Path) ->
     assert lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_insert_trailing_blank_not_added_if_next_line_is_blank(tmp_path: Path) -> None:
     """Avoid adding an extra trailing blank when the next line is already blank.
 
@@ -375,7 +366,8 @@ def test_insert_trailing_blank_not_added_if_next_line_is_blank(tmp_path: Path) -
 
 
 # Additional tests for more file types and scenarios
-@pytest.mark.pipeline
+
+
 def test_shell_with_shebang_spacing(tmp_path: Path) -> None:
     """Shell: exactly one blank between shebang and header; trailing blank ensured."""
     file: Path = tmp_path / "script.sh"
@@ -393,7 +385,6 @@ def test_shell_with_shebang_spacing(tmp_path: Path) -> None:
     assert end_idx + 1 < len(lines) and lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_r_with_shebang_spacing(tmp_path: Path) -> None:
     """R: shebang honored with exactly one blank before header."""
     file: Path = tmp_path / "analysis.R"
@@ -409,7 +400,6 @@ def test_r_with_shebang_spacing(tmp_path: Path) -> None:
     assert start_idx == 2
 
 
-@pytest.mark.pipeline
 def test_julia_with_shebang_spacing(tmp_path: Path) -> None:
     """Julia: shebang honored with exactly one blank before header."""
     file: Path = tmp_path / "compute.jl"
@@ -425,7 +415,6 @@ def test_julia_with_shebang_spacing(tmp_path: Path) -> None:
     assert start_idx == 2
 
 
-@pytest.mark.pipeline
 def test_ruby_with_shebang_and_encoding(tmp_path: Path) -> None:
     """Ruby: shebang + encoding; header after inserted blank at index 3."""
     file: Path = tmp_path / "tool.rb"
@@ -441,7 +430,6 @@ def test_ruby_with_shebang_and_encoding(tmp_path: Path) -> None:
     assert start_idx == 3
 
 
-@pytest.mark.pipeline
 def test_perl_with_shebang_spacing(tmp_path: Path) -> None:
     """Perl: exactly one blank between shebang and header."""
     file: Path = tmp_path / "script.pl"
@@ -457,7 +445,6 @@ def test_perl_with_shebang_spacing(tmp_path: Path) -> None:
     assert start_idx == 2
 
 
-@pytest.mark.pipeline
 def test_dockerfile_top_and_trailing_blank(tmp_path: Path) -> None:
     """Dockerfile: header at top; trailing blank ensured."""
     file: Path = tmp_path / "Dockerfile"
@@ -474,7 +461,6 @@ def test_dockerfile_top_and_trailing_blank(tmp_path: Path) -> None:
     assert end_idx + 1 < len(lines) and lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_yaml_top_and_trailing_blank(tmp_path: Path) -> None:
     """YAML: header at top; trailing blank ensured."""
     file: Path = tmp_path / "config.yaml"
@@ -491,7 +477,6 @@ def test_yaml_top_and_trailing_blank(tmp_path: Path) -> None:
     assert end_idx + 1 < len(lines) and lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_toml_top_and_trailing_blank(tmp_path: Path) -> None:
     """TOML: header at top; trailing blank ensured."""
     file: Path = tmp_path / "pyproject.toml"
@@ -508,7 +493,6 @@ def test_toml_top_and_trailing_blank(tmp_path: Path) -> None:
     assert end_idx + 1 < len(lines) and lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_env_without_shebang_top_and_trailing_blank(tmp_path: Path) -> None:
     """.env: header at top; trailing blank ensured."""
     file: Path = tmp_path / ".env"
@@ -525,7 +509,6 @@ def test_env_without_shebang_top_and_trailing_blank(tmp_path: Path) -> None:
     assert end_idx + 1 < len(lines) and lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_pound_crlf_preserves_newlines(tmp_path: Path) -> None:
     r"""CRLF fixtures: Pound header preserves CRLF newline style.
 
@@ -553,7 +536,6 @@ def test_pound_crlf_preserves_newlines(tmp_path: Path) -> None:
 # --- Additional tests for banner comments and placement ---
 
 
-@pytest.mark.pipeline
 def test_pound_banner_at_top_header_precedes_banner(tmp_path: Path) -> None:
     """Pound: header at top even if a banner of `#` lines exists.
 
@@ -580,7 +562,6 @@ def test_pound_banner_at_top_header_precedes_banner(tmp_path: Path) -> None:
     assert banner_idx > end_idx
 
 
-@pytest.mark.pipeline
 def test_pound_shebang_then_banner_header_between(tmp_path: Path) -> None:
     """Pound: header sits between shebang and an existing `#` banner.
 
@@ -612,7 +593,6 @@ def test_pound_shebang_then_banner_header_between(tmp_path: Path) -> None:
     assert banner_idx > end_idx
 
 
-@pytest.mark.pipeline
 def test_pound_shebang_encoding_then_banner_header_between(tmp_path: Path) -> None:
     """Pound: shebang + encoding, header between prolog and banner.
 
@@ -644,7 +624,6 @@ def test_pound_shebang_encoding_then_banner_header_between(tmp_path: Path) -> No
     assert banner_idx > end_idx
 
 
-@pytest.mark.pipeline
 def test_pound_crlf_with_banner_preserves_newlines_and_order(tmp_path: Path) -> None:
     r"""CRLF: header preserves CRLF and precedes existing banner.
 
@@ -675,7 +654,6 @@ def test_pound_crlf_with_banner_preserves_newlines_and_order(tmp_path: Path) -> 
 # --- New tests for banner variants with leading blanks and long hash rule separators ---
 
 
-@pytest.mark.pipeline
 def test_pound_banner_with_leading_blanks(tmp_path: Path) -> None:
     """Pound: header at top, preserves leading blanks before an existing banner.
 
@@ -711,7 +689,6 @@ def test_pound_banner_with_leading_blanks(tmp_path: Path) -> None:
     assert banner_idx == end_idx + 3
 
 
-@pytest.mark.pipeline
 def test_pound_long_hash_rule_banner(tmp_path: Path) -> None:
     """Pound: header at top when file starts with long hash rule lines.
 
@@ -739,7 +716,6 @@ def test_pound_long_hash_rule_banner(tmp_path: Path) -> None:
     assert lines[end_idx + 2].startswith("#")
 
 
-@pytest.mark.pipeline
 def test_pound_shebang_then_long_hash_rule_banner(tmp_path: Path) -> None:
     """Pound: shebang first, then hash rule banner; header inserted between.
 
@@ -766,7 +742,6 @@ def test_pound_shebang_then_long_hash_rule_banner(tmp_path: Path) -> None:
     assert lines[end_idx + 2].startswith("#")
 
 
-@pytest.mark.pipeline
 def test_pound_crlf_leading_blank_and_banner(tmp_path: Path) -> None:
     r"""CRLF: header at top; preserves leading blank and banner order.
 
@@ -803,7 +778,8 @@ def test_pound_crlf_leading_blank_and_banner(tmp_path: Path) -> None:
 
 
 # --- strip_header_block: test both with and without span, preserving shebang ---
-@pytest.mark.pipeline
+
+
 def test_strip_header_block_with_and_without_span_preserves_shebang(tmp_path: Path) -> None:
     """`strip_header_block` removes the header and preserves the shebang.
 
@@ -846,7 +822,6 @@ def test_strip_header_block_with_and_without_span_preserves_shebang(tmp_path: Pa
     assert strip_result_2.removed_span == (1, 3)
 
 
-@pytest.mark.pipeline
 def test_pound_encoding_only_at_top(tmp_path: Path) -> None:
     """Encoding line without shebang (PEP 263 at top).
 
@@ -865,7 +840,6 @@ def test_pound_encoding_only_at_top(tmp_path: Path) -> None:
     assert find_line(lines, sig["start_line"]) == 0
 
 
-@pytest.mark.pipeline
 def test_pound_bom_preserved(tmp_path: Path) -> None:
     """Preserve a leading UTF-8 BOM at the start of the output.
 

--- a/tests/processors/test_slash.py
+++ b/tests/processors/test_slash.py
@@ -53,7 +53,6 @@ if TYPE_CHECKING:
     from topmark.processors.types import StripHeaderResult
 
 
-@pytest.mark.pipeline
 def test_slash_processor_basics(tmp_path: Path) -> None:
     """Basics: detect file type and confirm no pre-existing header.
 
@@ -69,7 +68,6 @@ def test_slash_processor_basics(tmp_path: Path) -> None:
     assert ctx.views.header is None
 
 
-@pytest.mark.pipeline
 def test_slash_processor_with_content_matcher_detects_jsonc_in_json(tmp_path: Path) -> None:
     """Detect `.json` content as JSONC and confirm no pre-existing header.
 
@@ -86,7 +84,6 @@ def test_slash_processor_with_content_matcher_detects_jsonc_in_json(tmp_path: Pa
     assert ctx.views.header is None
 
 
-@pytest.mark.pipeline
 def test_slash_insert_top_and_trailing_blank(tmp_path: Path) -> None:
     """Insert a header at the top and ensure a trailing blank line follows.
 
@@ -105,7 +102,6 @@ def test_slash_insert_top_and_trailing_blank(tmp_path: Path) -> None:
     assert end_idx + 1 < len(lines) and lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_slash_detect_existing_header(tmp_path: Path) -> None:
     """Detect an existing header and parse fields.
 
@@ -147,7 +143,6 @@ def test_slash_detect_existing_header(tmp_path: Path) -> None:
     ctx.views.release_all()  # Release the views
 
 
-@pytest.mark.pipeline
 @pytest.mark.parametrize(
     "header_fields, expected_status",
     [
@@ -202,7 +197,6 @@ def test_slash_malformed_header_fields(
     assert ctx.status.header == expected_status
 
 
-@pytest.mark.pipeline
 def test_slash_idempotent_reapply_no_diff(tmp_path: Path) -> None:
     """Re-applying insertion is a no-op (idempotent).
 
@@ -225,7 +219,6 @@ def test_slash_idempotent_reapply_no_diff(tmp_path: Path) -> None:
     assert lines1 == lines2
 
 
-@pytest.mark.pipeline
 def test_slash_crlf_preserves_newlines(tmp_path: Path) -> None:
     """Preserve CRLF newlines on Windows-style inputs.
 
@@ -243,7 +236,6 @@ def test_slash_crlf_preserves_newlines(tmp_path: Path) -> None:
         assert ln.endswith("\r\n"), f"line {i} not CRLF: {ln!r}"
 
 
-@pytest.mark.pipeline
 def test_slash_strip_header_block_with_and_without_span(tmp_path: Path) -> None:
     """`strip_header_block` removes the block with or without explicit bounds.
 
@@ -272,7 +264,6 @@ def test_slash_strip_header_block_with_and_without_span(tmp_path: Path) -> None:
     assert strip_result_2.lines == strip_result_1.lines
 
 
-@pytest.mark.pipeline
 def test_slash_replace_preserves_crlf(tmp_path: Path) -> None:
     """Ensure replace path preserves CRLF newlines for C++ sources.
 

--- a/tests/processors/test_slash_indent.py
+++ b/tests/processors/test_slash_indent.py
@@ -27,8 +27,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pytest
-
 from tests.helpers.pipeline import BlockSignatures
 from tests.helpers.pipeline import expected_block_lines_for
 from tests.helpers.pipeline import find_line
@@ -52,7 +50,6 @@ if TYPE_CHECKING:
     from topmark.pipeline.protocols import Step
 
 
-@pytest.mark.pipeline
 def test_jsonc_insert_at_top_with_no_pre_prefix_indent(tmp_path: Path) -> None:
     """JSONC insertion starts at column 0 and adds one blank line after the block.
 
@@ -81,7 +78,6 @@ def test_jsonc_insert_at_top_with_no_pre_prefix_indent(tmp_path: Path) -> None:
     assert end_idx + 1 < len(lines) and lines[end_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_jsonc_replace_preserves_pre_prefix_indent(tmp_path: Path) -> None:
     """Replacement preserves pre-prefix indentation of an existing TopMark header.
 
@@ -145,7 +141,6 @@ def test_jsonc_replace_preserves_pre_prefix_indent(tmp_path: Path) -> None:
     assert after_prefix.startswith("  "), after_prefix
 
 
-@pytest.mark.pipeline
 def test_jsonc_replace_keeps_crlf_and_indent(tmp_path: Path) -> None:
     """Replacement keeps CRLF line endings and preserved pre-prefix indent."""
     file_name: str = "crlf_indented.jsonc"

--- a/tests/processors/test_xml.py
+++ b/tests/processors/test_xml.py
@@ -74,7 +74,6 @@ def _xml_processor_with_policy(*, ensure_blank_after_header: bool) -> XmlHeaderP
     return processor
 
 
-@pytest.mark.pipeline
 def test_xml_processor_basics(tmp_path: Path) -> None:
     """Basic detection and scan.
 
@@ -97,7 +96,6 @@ def test_xml_processor_basics(tmp_path: Path) -> None:
     assert ctx.views.header is None
 
 
-@pytest.mark.pipeline
 def test_html_top_of_file_with_trailing_blank(tmp_path: Path) -> None:
     """Insert header at the very top of plain HTML and keep a trailing blank.
 
@@ -123,7 +121,6 @@ def test_html_top_of_file_with_trailing_blank(tmp_path: Path) -> None:
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_xml_with_declaration_only(tmp_path: Path) -> None:
     """XML with only a declaration: insert after declaration (+1 blank).
 
@@ -149,7 +146,6 @@ def test_xml_with_declaration_only(tmp_path: Path) -> None:
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_xml_with_declaration_and_doctype(tmp_path: Path) -> None:
     """XML with declaration + DOCTYPE: insert after both (+1 blank).
 
@@ -175,7 +171,6 @@ def test_xml_with_declaration_and_doctype(tmp_path: Path) -> None:
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_svg_with_declaration(tmp_path: Path) -> None:
     """SVG (XML) with declaration: insert after declaration (+1 blank).
 
@@ -200,7 +195,6 @@ def test_svg_with_declaration(tmp_path: Path) -> None:
     assert start_idx == 3
 
 
-@pytest.mark.pipeline
 def test_vue_top_of_file(tmp_path: Path) -> None:
     """Vue SFC behaves like HTML: header at top with trailing blank.
 
@@ -222,7 +216,6 @@ def test_vue_top_of_file(tmp_path: Path) -> None:
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_svelte_top_of_file(tmp_path: Path) -> None:
     """Svelte component behaves like HTML: header at top with trailing blank.
 
@@ -244,7 +237,6 @@ def test_svelte_top_of_file(tmp_path: Path) -> None:
         assert close_idx + 1 < len(lines) and lines[close_idx + 1].strip() == ""
 
 
-@pytest.mark.pipeline
 def test_xml_single_line_declaration(tmp_path: Path) -> None:
     """Declaration and root on one line: insert after decl (+1 blank).
 
@@ -347,7 +339,6 @@ def test_xml_prolog_and_body_on_same_line_alllowed_by_policy(tmp_path: Path) -> 
     assert re.sub(r"\s+", "", original) == re.sub(r"\s+", "", roundtrip)
 
 
-@pytest.mark.pipeline
 def test_xml_single_line_decl_and_doctype(tmp_path: Path) -> None:
     """Declaration + DOCTYPE + root on one line: insert after prolog (+1 blank).
 
@@ -369,7 +360,6 @@ def test_xml_single_line_decl_and_doctype(tmp_path: Path) -> None:
     assert ctx.is_halted is True
 
 
-@pytest.mark.pipeline
 def test_html_with_existing_banner_comment(tmp_path: Path) -> None:
     """Header must precede any pre-existing banner comment in HTML.
 
@@ -399,7 +389,6 @@ def test_html_with_existing_banner_comment(tmp_path: Path) -> None:
         assert banner_idx > close_idx
 
 
-@pytest.mark.pipeline
 def test_xml_decl_then_existing_banner_comment(tmp_path: Path) -> None:
     """XML with declaration and a banner: header after decl, before banner.
 
@@ -427,7 +416,6 @@ def test_xml_decl_then_existing_banner_comment(tmp_path: Path) -> None:
         assert banner_idx > close_idx
 
 
-@pytest.mark.pipeline
 def test_xml_decl_doctype_then_existing_banner_comment(tmp_path: Path) -> None:
     """XML with declaration + DOCTYPE and a banner: header after prolog.
 
@@ -460,7 +448,8 @@ def test_xml_decl_doctype_then_existing_banner_comment(tmp_path: Path) -> None:
 
 
 # --- strip_header_block: test XML declaration is preserved, header is removed ---
-@pytest.mark.pipeline
+
+
 def test_xml_strip_header_block_respects_declaration(tmp_path: Path) -> None:
     """`strip_header_block` removes the header and preserves the XML declaration.
 
@@ -502,7 +491,6 @@ def test_xml_strip_header_block_respects_declaration(tmp_path: Path) -> None:
     assert strip_result_2.removed_span == (1, 3)
 
 
-@pytest.mark.pipeline
 def test_xml_doctype_with_internal_subset(tmp_path: Path) -> None:
     """DOCTYPE with simple internal subset (multi-line) is respected.
 
@@ -526,7 +514,6 @@ def test_xml_doctype_with_internal_subset(tmp_path: Path) -> None:
     assert start_idx == 5  # decl(0) doctype(1..3) blank(4) start(5)
 
 
-@pytest.mark.pipeline
 def test_xml_bom_preserved_text_insert(tmp_path: Path) -> None:
     """Ensure XML processor preserves BOM on text-insert path.
 

--- a/tests/toml/machine/test_toml_machine_payloads.py
+++ b/tests/toml/machine/test_toml_machine_payloads.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from topmark.diagnostic.model import MutableDiagnosticLog
 from topmark.toml.keys import Toml
 from topmark.toml.machine.payloads import build_toml_provenance_payload
@@ -38,7 +36,6 @@ if TYPE_CHECKING:
     from topmark.toml.validation import TomlValidationIssue
 
 
-@pytest.mark.pipeline
 def test_toml_provenance_payload_uses_posix_paths_for_file_backed_layers(
     tmp_path: Path,
 ) -> None:
@@ -86,7 +83,6 @@ def test_toml_provenance_payload_uses_posix_paths_for_file_backed_layers(
     assert file_backed_layer.toml[Toml.SECTION_FIELDS] == {"project": "Demo"}
 
 
-@pytest.mark.pipeline
 def test_toml_provenance_payload_uses_posix_path_for_discovery_anchor(
     tmp_path: Path,
 ) -> None:
@@ -105,7 +101,6 @@ def test_toml_provenance_payload_uses_posix_path_for_discovery_anchor(
     assert payload.to_dict()["discovery_anchor"] == workspace.as_posix()
 
 
-@pytest.mark.pipeline
 def test_toml_schema_accepts_dump_only_keys_in_provenance_mode() -> None:
     """Provenance validation should accept dump-only schema keys."""
     issues: tuple[TomlValidationIssue, ...] = TOPMARK_TOML_SCHEMA.validate_section_keys(
@@ -117,7 +112,6 @@ def test_toml_schema_accepts_dump_only_keys_in_provenance_mode() -> None:
     assert issues == ()
 
 
-@pytest.mark.pipeline
 def test_toml_schema_rejects_dump_only_keys_in_input_mode() -> None:
     """Input validation should reject dump-only schema keys."""
     issues: tuple[TomlValidationIssue, ...] = TOPMARK_TOML_SCHEMA.validate_section_keys(

--- a/tests/toml/test_schema_validation_loading.py
+++ b/tests/toml/test_schema_validation_loading.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
 # --- Pyproject extraction and source-loading validation ---
 
 
-@pytest.mark.toml
 def test_load_topmark_toml_table_extracts_tool_topmark_from_pyproject_table() -> None:
     """`load_topmark_toml_table(..., from_pyproject=True)` extracts `[tool.topmark]`."""
     pyproject_tbl: TomlTable = tomlkit.parse(
@@ -69,7 +68,6 @@ def test_load_topmark_toml_table_extracts_tool_topmark_from_pyproject_table() ->
     assert header_section[Toml.KEY_FIELDS] == ["file"]
 
 
-@pytest.mark.toml
 def test_load_topmark_toml_source_distinguishes_missing_vs_empty_tool_topmark(
     tmp_path: Path,
 ) -> None:
@@ -131,7 +129,6 @@ def test_load_topmark_toml_source_distinguishes_missing_vs_empty_tool_topmark(
 # --- File-based TOML validation helpers ---
 
 
-@pytest.mark.toml
 @pytest.mark.parametrize(
     "filename",
     ["topmark.toml", "pyproject.toml"],
@@ -176,7 +173,6 @@ def test_unknown_keys_reported_via_from_toml_file(
     )
 
 
-@pytest.mark.toml
 def test_unknown_key_in_config_section_warns_via_from_toml_file(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -201,7 +197,6 @@ def test_unknown_key_in_config_section_warns_via_from_toml_file(
     )
 
 
-@pytest.mark.toml
 def test_unknown_key_in_writer_section_warns_via_from_toml_file(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/toml/test_schema_validation_missing_sections.py
+++ b/tests/toml/test_schema_validation_missing_sections.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from tests.helpers.diagnostics import assert_not_warned
 from tests.toml.conftest import draft_from_topmark_toml_table
 from topmark.diagnostic.model import DiagnosticLevel
@@ -33,6 +31,8 @@ from topmark.toml.validation import TomlDiagnosticCode
 from topmark.toml.validation import TomlValidationIssue
 
 if TYPE_CHECKING:
+    import pytest
+
     from topmark.config.model import MutableConfig
     from topmark.toml.parse import ParsedTopmarkToml
 
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 # --- Missing-section and empty-source validation ---
 
 
-@pytest.mark.toml
 def test_empty_topmark_toml_table_produces_empty_draft_without_schema_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -56,7 +55,6 @@ def test_empty_topmark_toml_table_produces_empty_draft_without_schema_warning(
     assert stats.n_info > 0
 
 
-@pytest.mark.toml
 def test_empty_topmark_toml_table_emits_info_diagnostics_for_missing_sections() -> None:
     """An empty TopMark TOML table emits INFO issues for each missing known section."""
     parsed: ParsedTopmarkToml | None = load_topmark_toml_table({})
@@ -89,7 +87,6 @@ def test_empty_topmark_toml_table_emits_info_diagnostics_for_missing_sections() 
     }
 
 
-@pytest.mark.toml
 def test_present_section_is_not_reported_as_missing_info_diagnostic() -> None:
     """Present known sections are excluded from missing-section INFO diagnostics."""
     parsed: ParsedTopmarkToml | None = load_topmark_toml_table(

--- a/tests/toml/test_schema_validation_policy.py
+++ b/tests/toml/test_schema_validation_policy.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
     from topmark.toml.parse import ParsedTopmarkToml
 
 
-@pytest.mark.toml
 def test_policy_by_type_unknown_keys_warn(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -63,7 +62,6 @@ def test_policy_by_type_unknown_keys_warn(
     )
 
 
-@pytest.mark.toml
 def test_policy_by_type_entry_wrong_type_warns(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -80,7 +78,6 @@ def test_policy_by_type_entry_wrong_type_warns(
     )
 
 
-@pytest.mark.toml
 def test_policy_by_type_entry_wrong_type_uses_invalid_nested_section_type_code() -> None:
     """Malformed nested policy tables emit INVALID_NESTED_SECTION_TYPE and are ignored."""
     parsed: ParsedTopmarkToml | None = load_topmark_toml_table(
@@ -112,7 +109,6 @@ def test_policy_by_type_entry_wrong_type_uses_invalid_nested_section_type_code()
     }
 
 
-@pytest.mark.toml
 def test_policy_by_type_entry_wrong_type_does_not_become_effective_policy_override() -> None:
     """Malformed nested policy entries do not produce effective policy overrides."""
     draft: MutableConfig = draft_from_topmark_toml_table(
@@ -126,7 +122,6 @@ def test_policy_by_type_entry_wrong_type_does_not_become_effective_policy_overri
     assert draft.policy_by_type == {}
 
 
-@pytest.mark.toml
 def test_policy_by_type_valid_keys_parse_and_unknown_keys_are_ignored(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -153,7 +148,6 @@ def test_policy_by_type_valid_keys_parse_and_unknown_keys_are_ignored(
     )
 
 
-@pytest.mark.toml
 @pytest.mark.parametrize("policy_file_type_id", ["python", "topmark:python"])
 def test_policy_by_type_public_identifier_freezes_to_qualified_key(
     policy_file_type_id: str,
@@ -175,7 +169,6 @@ def test_policy_by_type_public_identifier_freezes_to_qualified_key(
     assert cfg.policy_by_type["topmark:python"].header_mutation_mode == HeaderMutationMode.ADD_ONLY
 
 
-@pytest.mark.toml
 def test_policy_by_type_quoted_qualified_toml_key_parses_and_freezes() -> None:
     """Quoted qualified TOML table keys support canonical file type identifiers."""
     parsed: ParsedTopmarkToml | None = load_topmark_toml_table(

--- a/tests/toml/test_schema_validation_special_section.py
+++ b/tests/toml/test_schema_validation_special_section.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
 # --- In-memory special-section validation ---
 
 
-@pytest.mark.toml
 def test_fields_table_is_free_form_and_not_subject_to_unknown_key_validation(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -69,7 +68,6 @@ def test_fields_table_is_free_form_and_not_subject_to_unknown_key_validation(
 # --- Source-local and dump-only section rules ---
 
 
-@pytest.mark.toml
 def test_unknown_key_in_config_section_warns_and_known_key_still_resolves(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -93,7 +91,6 @@ def test_unknown_key_in_config_section_warns_and_known_key_still_resolves(
     assert draft.header_fields == []
 
 
-@pytest.mark.toml
 def test_unknown_key_in_writer_section_warns_and_is_recorded(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -115,7 +112,6 @@ def test_unknown_key_in_writer_section_warns_and_is_recorded(
     )
 
 
-@pytest.mark.toml
 @pytest.mark.parametrize(
     ("section", "dump_only_key"),
     [
@@ -146,7 +142,6 @@ def test_dump_only_keys_in_input_mode_warn_and_are_recorded(
     )
 
 
-@pytest.mark.toml
 @pytest.mark.parametrize(
     ("section", "dump_only_key"),
     [

--- a/tests/toml/test_schema_validation_top_level.py
+++ b/tests/toml/test_schema_validation_top_level.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
 # --- In-memory whole-source TOML validation ---
 
 
-@pytest.mark.toml
 def test_unknown_top_level_keys_warn_and_are_recorded(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -61,7 +60,6 @@ def test_unknown_top_level_keys_warn_and_are_recorded(
     )
 
 
-@pytest.mark.toml
 def test_unknown_top_level_table_warns_and_is_recorded(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -80,7 +78,6 @@ def test_unknown_top_level_table_warns_and_is_recorded(
     )
 
 
-@pytest.mark.toml
 def test_unknown_top_level_scalar_uses_unknown_top_level_key_code() -> None:
     """Unknown top-level scalar entries use the dedicated key diagnostic code."""
     parsed: ParsedTopmarkToml | None = load_topmark_toml_table(
@@ -102,7 +99,6 @@ def test_unknown_top_level_scalar_uses_unknown_top_level_key_code() -> None:
     assert matching[0].path == ("unknown_root_key",)
 
 
-@pytest.mark.toml
 def test_unknown_top_level_table_uses_unknown_top_level_section_code() -> None:
     """Unknown top-level tables use the dedicated section diagnostic code."""
     parsed: ParsedTopmarkToml | None = load_topmark_toml_table(
@@ -124,7 +120,6 @@ def test_unknown_top_level_table_uses_unknown_top_level_section_code() -> None:
     assert matching[0].path == ("bogus",)
 
 
-@pytest.mark.toml
 def test_unknown_keys_are_reported_individually(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -152,7 +147,6 @@ def test_unknown_keys_are_reported_individually(
     )
 
 
-@pytest.mark.toml
 def test_unknown_section_keys_warn_and_are_recorded(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -174,7 +168,6 @@ def test_unknown_section_keys_warn_and_are_recorded(
     )
 
 
-@pytest.mark.toml
 @pytest.mark.parametrize(
     "section, valid_key, valid_value",
     [
@@ -208,7 +201,6 @@ def test_unknown_key_in_known_section_warns_and_is_recorded(
     )
 
 
-@pytest.mark.toml
 def test_section_wrong_type_warns_and_is_ignored(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -224,7 +216,6 @@ def test_section_wrong_type_warns_and_is_ignored(
     )
 
 
-@pytest.mark.toml
 def test_section_wrong_type_uses_invalid_section_type_code_and_is_ignored() -> None:
     """Malformed known sections emit INVALID_SECTION_TYPE and are ignored."""
     parsed: ParsedTopmarkToml | None = load_topmark_toml_table(

--- a/uv.lock
+++ b/uv.lock
@@ -1702,6 +1702,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "tomlkit" },
 ]
 
 [package.metadata]
@@ -1742,6 +1743,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'docs'", specifier = ">=0.15.20,<0.16.0" },
     { name = "taplo", marker = "extra == 'dev'", specifier = ">=0.9.3,<0.10.0" },
     { name = "tomlkit", specifier = ">=0.15.0,<0.16.0" },
+    { name = "tomlkit", marker = "extra == 'test'", specifier = ">=0.15.0,<0.16.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=6.2.0,<7.0.0" },
     { name = "typing-extensions", specifier = ">=4.15.0,<5.0.0" },
     { name = "typing-extensions", marker = "extra == 'docs'", specifier = ">=4.15.0,<5.0.0" },


### PR DESCRIPTION
## Summary

- Audits and normalizes pytest marker usage for #215.
- Removes package-only subsystem markers from the declared marker taxonomy.
- Keeps pytest markers focused on cross-cutting semantics such as `integration`, `exit_code`, `case_insensitive_fs`, `hypothesis_slow`, and `dev_validation`.
- Aligns Nox and Makefile marker expressions with the reduced marker set.
- Adds developer-validation coverage for marker hygiene:
  - custom markers used by tests must be declared;
  - declared markers must be used by tests or referenced by project tooling;
  - marker expressions in Nox and Makefile must not reference undeclared markers.
- Updates `docs/ci/test-validation.md` and `CHANGELOG.md` to document the normalized convention.

## Validation

- `pytest -q tests/dev_validation`
- `pytest --collect-only -q tests`
- Representative marker selections with `pytest -m ...`
- Representative `nox -s qa -- -m ...` marker selections

Closes #215