### PR TITLE
Add local pre-PR validation gate

### DIFF
--- a/.bake.toml
+++ b/.bake.toml
@@ -31,8 +31,8 @@ max_line_length              = 120
 
 # PHONY settings
 group_phony_declarations       = false
-phony_at_top                   = false
-auto_insert_phony_declarations = false
+phony_at_top                   = true
+auto_insert_phony_declarations = true
 
 # General settings - enable proper formatting
 remove_trailing_whitespace  = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,8 +370,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Linux canonical QA is already covered by the supported Python matrix.
+        # This job keeps the additional platform/filesystem coverage focused on macOS and Windows.
         os:
-          - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,10 @@ ______________________________________________________________________
 - Documented GitHub issue 183, including structured-edit-driven comparison, reduced patch-generation
   materialization, centralized step lifecycle enforcement, follow-up benchmark measurements, and the
   remaining comparison/diff ownership boundaries.
+- Documented supported local `pytest-xdist` workflows, including the rationale for keeping CI pytest
+  execution serial within individual jobs while using job-level parallelism.
+- Updated contributor and CI guidance to recommend the local pre-PR validation gate, document its
+  relationship to GitHub CI, and cross-reference the relevant validation workflow documentation.
 
 ### Internal - Unreleased
 
@@ -515,6 +519,15 @@ ______________________________________________________________________
 - Hardened CLI human-output regression tests against Rich styling, panel borders, terminal-width
   wrapping, and other layout differences by replacing brittle raw output assertions with semantic
   Rich-aware assertion helpers.
+- Reduced duplicate Linux validation in GitHub Actions by limiting the dedicated cross-platform
+  filesystem job to macOS and Windows while retaining canonical Linux QA through the supported
+  Python-version matrix.
+- Added a dedicated `pre_pr` Nox session together with a `make pre-pr` convenience target,
+  establishing the recommended local pre-PR validation gate while preserving GitHub CI as the
+  authoritative validation surface.
+- Standardized Makefile `.PHONY` declarations by colocating them with their associated targets,
+  reducing maintenance overhead for predominantly phony developer targets and aligning with the
+  project's `mbake` formatting conventions.
 
 ### Notes - Unreleased
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,12 @@ cd topmark
 make venv
 make venv-sync-dev
 
-# Run core quality checks and tests
+# Run the recommended local pre-PR validation gate
+make pre-pr     # formatting, lint, docs, canonical QA, API snapshot
+
+# Additional validation commands
 make verify     # lint, formatting, docs, links
-make test       # canonical nox validation matrix
+make test       # full nox validation matrix
 
 # Run tests locally (current interpreter only)
 make pytest     # supports PYTEST_PAR="-n auto"
@@ -72,6 +75,14 @@ For the full installation and development-environment setup guide, see:
 ______________________________________________________________________
 
 ## Testing
+
+Before opening or updating a pull request, run the recommended local pre-PR validation gate:
+
+```bash
+make pre-pr
+```
+
+This provides a fast local confidence check but does not replace the full GitHub CI validation.
 
 Run the full `nox` test matrix:
 
@@ -386,7 +397,7 @@ Keep messages short (≤72 chars) and use the body to explain *why*.
 
 - [ ] PR title follows Conventional Commits
 - [ ] Related issue referenced when applicable
-- [ ] `make verify` and `make test` pass
+- [ ] `make pre-pr` passes
 - [ ] Docs updated if needed
 - [ ] Public API snapshot updated if applicable
 - [ ] Release tag / changelog plan is correct for release-related PRs

--- a/Makefile
+++ b/Makefile
@@ -8,30 +8,10 @@
 #
 # topmark:header:end
 
-.PHONY: \
-	api-snapshot api-snapshot-dev api-snapshot-ensure-clean api-snapshot-update \
-	check-lychee check-uv check-venv code-hygiene \
-	coverage coverage-erase \
-	docstring-links \
-	docs-build docs-clean docs-hygiene docs-serve \
-	format format-check format-docstrings \
-	help hygiene \
-	links links-all links-site links-src \
-	lint lint-fixall \
-	package-check \
-	perf-baseline \
-	property-test \
-	pytest pytest-full \
-	release-check release-full release-qa-api-% \
-	test \
-	uv-lock uv-lock-upgrade \
-	venv venv-clean venv-sync-all venv-sync-dev venv-sync-docs \
-	verify
-
 .DEFAULT_GOAL := help
 NOX ?= nox
 NOX_FLAGS ?= --no-verbose       # keep quiet by default; CI can override
-PYTEST_PAR ?= # e.g. set PYTEST_PAR="-n auto" or "-n 4"
+PYTEST_PAR ?= # e.g. set PYTEST_PAR="-n auto" or "-n 4" for pytest-capable targets
 PY ?= python
 VENV := .venv
 VENV_BIN := $(VENV)/bin
@@ -40,20 +20,25 @@ UV ?= uv
 PUBLIC_API_JSON := tests/api/public_api_snapshot.json
 
 # Simple tool presence checks
+.PHONY: check-venv
 check-venv:
 	@command -v $(NOX) >/dev/null 2>&1 || (echo "❌ nox not found. Install with: pipx install nox" && exit 1)
 
+.PHONY: check-lychee
 check-lychee:
 	@command -v lychee >/dev/null 2>&1 || (echo "❌ lychee not found. Install with: brew install lychee" && exit 1)
 
+.PHONY: check-uv
 check-uv:
 	@command -v $(UV) >/dev/null 2>&1 || (echo "❌ uv not found. Install uv and ensure it is on PATH." && exit 1)
 
+.PHONY: help
 help:
 	@echo "Usage: make <target>"
 	@echo ""
 	@echo "Core:"
 	@echo "  verify          Run formatting checks, lint, and one typecheck env"
+	@echo "  pre-pr          Run the recommended local pre-PR gate; supports PYTEST_PAR=-n auto"
 	@echo "  lint            Run ruff + pydoclint + mbake"
 	@echo "  lint-fixall     Run ruff with --fix (auto-fix lint issues)"
 	@echo "  format-check    Check code/markdown/toml/Makefile formatting"
@@ -64,15 +49,15 @@ help:
 	@echo "  code-hygiene    Check Python comments/docstrings/string prose hygiene"
 	@echo "  hygiene         Run all prose/documentation hygiene checks"
 	@echo "Tests:"
-	@echo "  test            Run the test suite (nox: qa)"
+	@echo "  test            Run the test suite (nox: qa); supports PYTEST_PAR=-n auto"
 	@echo "  pytest          Run tests with current interpreter (no nox), skipping Hypothesis slow tests; supports PYTEST_PAR=-n auto"
 	@echo "  pytest-full     Run all tests with current interpreter (no nox); supports PYTEST_PAR=-n auto"
-	@echo "  coverage        Run coverage testing"
+	@echo "  coverage        Run coverage testing; supports PYTEST_PAR=-n auto"
 	@echo "  coverage-erase  Erase coverage testing output (.coverage coverage.xml coverage.json htmlcov .coverage.*)"
 	@echo "  property-test   Run Hypothesis hardening tests (manual, opt-in)"
 	@echo "  perf-baseline   Run pipeline memory/allocation baselines (manual, opt-in)"
 	@echo ""
-	@echo "  release-check   Run the deterministic pre-release gate (nox: release_check)"
+	@echo "  release-check   Run the deterministic pre-release gate; supports PYTEST_PAR=-n auto"
 	@echo "  release-full    Run the full release gate incl. links + packaging + Python matrix"
 	@echo ""
 	@echo "  package-check   Run package sanity checks (nox: package_check)"
@@ -104,27 +89,38 @@ help:
 	@echo "  uv-lock         Generate or refresh uv.lock from pyproject.toml"
 	@echo "  uv-lock-upgrade Refresh uv.lock with dependency upgrades"
 
+.PHONY: test
 test: check-venv
 	@echo "Running tests via nox..."
 	# We pass -- followed by the variable.
 	# If PYTEST_PAR is empty, it does nothing; if it has "-n auto", pytest receives it.
 	$(NOX) $(NOX_FLAGS) -s qa -- $(PYTEST_PAR)
 
+.PHONY: coverage
 coverage: check-venv
-	$(NOX) $(NOX_FLAGS) -s coverage
+	$(NOX) $(NOX_FLAGS) -s coverage -- $(PYTEST_PAR)
 
+.PHONY: coverage-erase
 coverage-erase:
 	@rm -rf .coverage coverage.xml coverage.json htmlcov .coverage.*
 
+.PHONY: verify
 verify: check-venv
 	@echo "Running non-destructive checks via nox..."
 	$(NOX) $(NOX_FLAGS) -s format_check -s lint -s docstring_links -s docs_hygiene -s code_hygiene -s links -s docs
 	@echo "All quality checks passed!"
 
+.PHONY: pre-pr
+pre-pr: check-venv
+	@echo "Running recommended local pre-PR validation via nox..."
+	$(NOX) $(NOX_FLAGS) -s pre_pr -- $(PYTEST_PAR)
+
+.PHONY: release-check
 release-check: check-venv
 	@echo "Running release gate (deterministic) via nox..."
-	$(NOX) $(NOX_FLAGS) -s release_check
+	$(NOX) $(NOX_FLAGS) -s release_check -- $(PYTEST_PAR)
 
+.PHONY: package-check
 package-check: check-venv
 	@echo "Running packaging sanity checks via nox..."
 	$(NOX) $(NOX_FLAGS) -s package_check
@@ -137,6 +133,7 @@ JOBS ?= 5
 # This keeps the Makefile clean.
 RELEASE_PYTHONS := $(shell $(NOX) -l | awk '{print $$1}' | grep '^qa_api-' | cut -d'-' -f2 | sort -V)
 
+.PHONY: release-full
 release-full: check-venv check-lychee
 	@echo "Running full release gate for versions: $(RELEASE_PYTHONS) (serial gates + parallel Python matrix)..."
 	# Serial, non-matrix gates first:
@@ -149,78 +146,101 @@ release-qa-api-%: check-venv
 	@echo "QA+API snapshot (one env) for Python $*"
 	$(NOX) $(NOX_FLAGS) -s qa_api -p $* -- $(PYTEST_PAR)
 
+.PHONY: lint
 lint: check-venv
 	$(NOX) $(NOX_FLAGS) -s lint
 
+.PHONY: lint-fixall
 lint-fixall: check-venv
 	$(NOX) $(NOX_FLAGS) -s lint_fixall
 
+.PHONY: format-check
 format-check: check-venv
 	$(NOX) $(NOX_FLAGS) -s format_check
 
+.PHONY: format
 format: check-venv
 	$(NOX) $(NOX_FLAGS) -s format
 
+.PHONY: format-docstrings
 format-docstrings: check-uv
 	@echo "Auto-formatting docstrings (settings from pyproject.toml)..."
 	$(VENV_BIN)/pydocstringformatter --write src/topmark/ tools/
 
+.PHONY: docstring-links
 docstring-links: check-venv
 	$(NOX) $(NOX_FLAGS) -s docstring_links
 
+.PHONY: docs-hygiene
 docs-hygiene: check-venv
 	$(NOX) $(NOX_FLAGS) -s docs_hygiene
 
+.PHONY: code-hygiene
 code-hygiene:
 	$(NOX) $(NOX_FLAGS) -s code_hygiene
 
+.PHONY: hygiene
 hygiene: docs-hygiene code-hygiene
 
 # Run pytest directly (no nox) with the current interpreter
+.PHONY: pytest
 pytest:
 	@echo "Running pytest locally -- skipping Hypothesis slow tests"
 	pytest $(PYTEST_PAR) -m "not hypothesis_slow" -q
 
+.PHONY: pytest-full
 pytest-full:
 	@echo "Running all pytest locally -- including Hypothesis slow tests"
 	pytest $(PYTEST_PAR) -q
 
+.PHONY: property-test
 property-test: check-venv
 	$(NOX) $(NOX_FLAGS) -s property_test
 
+.PHONY: perf-baseline
 perf-baseline: check-venv
 	$(NOX) $(NOX_FLAGS) -s perf_baseline
 
+.PHONY: docs-build
 docs-build: check-venv
 	$(NOX) $(NOX_FLAGS) -s docs
 
+.PHONY: docs-serve
 docs-serve: check-venv
 	$(NOX) $(NOX_FLAGS) -s docs_serve
 
+.PHONY: docs-clean
 docs-clean:
 	rm -rf site
 
+.PHONY: links
 links: check-lychee
 	$(NOX) $(NOX_FLAGS) -s links
 
+.PHONY: links-src
 links-src: check-lychee
 	$(NOX) $(NOX_FLAGS) -s links_src
 
+.PHONY: links-all
 links-all: check-lychee
 	$(NOX) $(NOX_FLAGS) -s links_all
 
+.PHONY: links-site
 links-site: check-lychee
 	$(NOX) $(NOX_FLAGS) -s links_site
 
+.PHONY: api-snapshot
 api-snapshot: check-venv
 	$(NOX) $(NOX_FLAGS) -s api_snapshot
 
 # Local fast check (current interpreter only)
+.PHONY: api-snapshot-dev
 api-snapshot-dev: check-venv
 	@$(VENV_BIN)/pytest -qq tests/api/test_public_api_snapshot.py && \
 	echo "✅ Public API snapshot unchanged."
 
 # Update snapshot (interactive)
+.PHONY: .api-snapshot-update
 .api-snapshot-update: check-venv
 	@$(VENV_BIN)/$(PY) tools/api_snapshot.py "$(PUBLIC_API_JSON)"
 	@if git diff --quiet -- "$(PUBLIC_API_JSON)" ; then \
@@ -231,11 +251,13 @@ api-snapshot-dev: check-venv
 		echo "⚠️  Review diff, add $(PUBLIC_API_JSON) to git, bump version & update CHANGELOG."; \
 	fi
 
+.PHONY: api-snapshot-update
 api-snapshot-update:
 	@read -p "⚠️  This will overwrite the public API snapshot. Continue? [y/N] " confirm && [ "$$confirm" = "y" ] && \
 	$(MAKE) .api-snapshot-update
 
 # Fail if snapshot differs from index
+.PHONY: api-snapshot-ensure-clean
 api-snapshot-ensure-clean: check-venv
 	@if git diff --quiet -- "$(PUBLIC_API_JSON)"; then \
 		echo "✅ Public API snapshot clean: $(PUBLIC_API_JSON)"; \
@@ -250,6 +272,7 @@ api-snapshot-ensure-clean: check-venv
 #
 # Local editor venv bootstrap.
 # We keep a project-local .venv for IDE integration, and let uv manage it directly.
+.PHONY: venv
 venv: check-uv
 	@test -d $(VENV) || ( \
 		echo "Creating $(VENV) via uv..." && \
@@ -257,6 +280,7 @@ venv: check-uv
 		)
 	@echo "Activate with: source $(VENV_BIN)/activate"
 
+.PHONY: venv-sync-dev
 venv-sync-dev: venv
 	$(UV) sync --extra dev --extra typing --extra test
 	@echo "Synced dev/test/typing extras into $(VENV)."
@@ -264,24 +288,29 @@ venv-sync-dev: venv
 # Sync docs-only extras into the shared venv.
 # NOTE: running this will remove dev/test/typing tools which are not part of the docs environment.
 # Prefer venv-sync-all for a combined environment.
+.PHONY: venv-sync-docs
 venv-sync-docs: venv
 	$(UV) sync --extra docs
 	@echo "Synced docs extras into $(VENV)."
 
 # Sync the union of dev/test/typing/docs extras into the shared venv.
 # This is the recommended target for local MkDocs development and VS Code import resolution.
+.PHONY: venv-sync-all
 venv-sync-all: venv
 	$(UV) sync --extra dev --extra typing --extra test --extra docs
 	@echo "Synced dev/test/typing/docs extras into $(VENV)."
 
+.PHONY: venv-clean
 venv-clean:
 	@rm -rf $(VENV)
 	@echo "Removed $(VENV)."
 
 #
 # ---- UV project lock workflow (canonical dependency management) ----
+.PHONY: uv-lock
 uv-lock: check-uv
 	$(UV) lock
 
+.PHONY: uv-lock-upgrade
 uv-lock-upgrade: check-uv
 	$(UV) lock --upgrade

--- a/docs/ci/ci-workflow.md
+++ b/docs/ci/ci-workflow.md
@@ -89,20 +89,20 @@ ______________________________________________________________________
 
 ## Jobs and validation scope
 
-| Job                 | Purpose                                                                 | Main tools                                 |
-| ------------------- | ----------------------------------------------------------------------- | ------------------------------------------ |
-| `changes`           | Detect changed file groups for PR job gating and summarize the result   | `dorny/paths-filter`                       |
-| `python-metadata`   | Resolve supported and canonical Python versions for CI jobs             | `nox`, `pyproject.toml`                    |
-| `lint`              | Validate formatting, linting, typing, and docstring links               | `nox`, `ruff`, `pyright`                   |
-| `pre-commit`        | Run configured pre-commit hooks                                         | `pre-commit`                               |
-| `docs`              | Build the documentation site in strict mode                             | `nox`, `mkdocs`                            |
-| `tests`             | Run the supported Python test matrix                                    | `nox`, `pytest`                            |
-| `filesystem-tests`  | Run canonical Python tests across Linux, macOS, and Windows filesystems | `nox`, `pytest`                            |
-| `coverage`          | Generate and publish canonical coverage reports                         | `nox`, `coverage.py`, `pytest`             |
-| `api-snapshot`      | Check public API stability for source-changing pull requests            | `nox`, `tools/api_snapshot.py`             |
-| `links`             | Validate links in source Markdown files                                 | `lycheeverse/lychee-action`, `lychee.toml` |
-| `links-site`        | Validate links in the rendered MkDocs site, including generated pages   | `mkdocs`, `lycheeverse/lychee-action`      |
-| `release-artifacts` | Build and upload release artifacts for version tags                     | `uv build`, `actions/upload-artifact`      |
+| Job                 | Purpose                                                               | Main tools                                 |
+| ------------------- | --------------------------------------------------------------------- | ------------------------------------------ |
+| `changes`           | Detect changed file groups for PR job gating and summarize the result | `dorny/paths-filter`                       |
+| `python-metadata`   | Resolve supported and canonical Python versions for CI jobs           | `nox`, `pyproject.toml`                    |
+| `lint`              | Validate formatting, linting, typing, and docstring links             | `nox`, `ruff`, `pyright`                   |
+| `pre-commit`        | Run configured pre-commit hooks                                       | `pre-commit`                               |
+| `docs`              | Build the documentation site in strict mode                           | `nox`, `mkdocs`                            |
+| `tests`             | Run the supported Python test matrix                                  | `nox`, `pytest`                            |
+| `filesystem-tests`  | Run canonical Python tests across macOS and Windows filesystems       | `nox`, `pytest`                            |
+| `coverage`          | Generate and publish canonical coverage reports                       | `nox`, `coverage.py`, `pytest`             |
+| `api-snapshot`      | Check public API stability for source-changing pull requests          | `nox`, `tools/api_snapshot.py`             |
+| `links`             | Validate links in source Markdown files                               | `lycheeverse/lychee-action`, `lychee.toml` |
+| `links-site`        | Validate links in the rendered MkDocs site, including generated pages | `mkdocs`, `lycheeverse/lychee-action`      |
+| `release-artifacts` | Build and upload release artifacts for version tags                   | `uv build`, `actions/upload-artifact`      |
 
 Most jobs delegate validation to nox sessions so local development and CI share the same stable
 validation contracts and execution semantics. The `python-metadata` job resolves supported Python
@@ -110,10 +110,11 @@ versions and the canonical single-version Python from project metadata through
 `nox -s print_python_matrix`. The test matrix consumes that supported-version list with `fail-fast`
 disabled so failures on one Python version do not hide failures on others.
 
-Filesystem-sensitive behavior is validated separately by the `filesystem-tests` job. That job runs
-the canonical Python QA session across Ubuntu, macOS, and Windows so platform-dependent path and
-filesystem semantics are checked on real GitHub-hosted filesystems without multiplying the full
-supported Python-version matrix across every operating system.
+Filesystem-sensitive behavior is validated separately by the `filesystem-tests` job. The supported
+Python-version matrix already runs canonical Linux QA on Ubuntu, so `filesystem-tests` focuses on
+macOS and Windows as the additional platform/filesystem coverage points. This keeps
+platform-dependent path and filesystem semantics checked on real GitHub-hosted filesystems without
+multiplying the full supported Python-version matrix across every operating system.
 
 This job also protects TopMark's filesystem-identity evaluation contract. That includes
 filesystem-identity normalization for platform-sensitive path spellings and processing-target
@@ -130,7 +131,7 @@ matrix.
 The coverage job depends on the full supported-version test matrix succeeding before coverage
 reports are generated. This keeps the compatibility matrix as the primary validation gate while
 avoiding additional coverage-processing noise after known test failures. Platform-dependent
-filesystem validation remains a separate gate through `filesystem-tests`.
+macOS/Windows filesystem validation remains a separate gate through `filesystem-tests`.
 
 Canonical single-version jobs such as linting, documentation builds, coverage, API snapshot checks,
 and release-artifact construction use the same resolved canonical Python value rather than carrying
@@ -205,7 +206,17 @@ ______________________________________________________________________
 
 ## Local reproduction
 
-The closest local equivalents are the nox sessions used by CI:
+For routine pull-request preparation, run the recommended local pre-PR gate:
+
+```bash
+make pre-pr
+```
+
+This command is a local confidence shortcut. It runs the practical source-tree checks expected
+before opening or updating a PR, but it does not replace GitHub CI, cross-platform filesystem
+validation, release-artifact construction, or network-dependent link validation.
+
+The closest lower-level local equivalents are the nox sessions used by CI:
 
 ```bash
 nox -s print_python_matrix
@@ -217,12 +228,30 @@ nox -s qa -p 3.13
 nox -s coverage -p 3.13
 ```
 
-The `filesystem-tests` job runs the same canonical `qa` session on Ubuntu, macOS, and Windows. Local
-reproduction can validate the current machine's filesystem behavior, but it cannot replace the
-cross-platform GitHub-hosted runs for case-sensitivity and path-canonicalization behavior. In this
-job, symlink creation is mandatory through `TOPMARK_REQUIRE_SYMLINKS=1`; if a Windows runner loses
-symlink capability because Developer Mode or equivalent privileges are unavailable, the job fails
-rather than reporting a misleading skip.
+The `filesystem-tests` job runs the same canonical `qa` session on macOS and Windows. Linux QA is
+covered by the supported Python-version test matrix on Ubuntu. Local reproduction can validate the
+current machine's filesystem behavior, but it cannot replace the cross-platform GitHub-hosted runs
+for case-sensitivity and path-canonicalization behavior. In this job, symlink creation is mandatory
+through `TOPMARK_REQUIRE_SYMLINKS=1`; if a Windows runner loses symlink capability because Developer
+Mode or equivalent privileges are unavailable, the job fails rather than reporting a misleading
+skip.
+
+For local speedups, pytest-capable nox sessions and Makefile targets accept forwarded pytest
+arguments. Parallel pytest execution with `pytest-xdist` is supported as an opt-in developer
+workflow, for example:
+
+```bash
+make pre-pr PYTEST_PAR="-n auto"
+make test PYTEST_PAR="-n auto"
+nox -s pre_pr -- -n auto
+nox -s qa -p 3.13 -- -n auto
+nox -s coverage -p 3.13 -- -n auto
+nox -s release_check -- -n auto
+```
+
+CI intentionally keeps pytest invocations serial inside each job. Job-level matrix parallelism
+already validates supported Python versions and platform behavior, while serial per-job pytest logs
+keep coverage reports and release-gate failures easier to diagnose.
 
 The concrete `3.13` commands shown here reflect the current canonical Python version. That value is
 resolved from project metadata and is expected to move when the supported Python range moves.
@@ -268,9 +297,11 @@ When editing this workflow:
 - keep Python-version metadata sourced from `pyproject.toml` through `nox -s print_python_matrix`;
 - keep the coverage job canonical and lightweight rather than instrumenting the full compatibility
   matrix;
-- keep platform-dependent filesystem behavior covered by the canonical cross-platform
-  `filesystem-tests` job rather than expanding the full Python-version matrix across all operating
-  systems;
+- keep Linux canonical QA covered by the supported Python matrix and keep additional
+  platform-dependent filesystem behavior covered by the macOS/Windows `filesystem-tests` job rather
+  than expanding the full Python-version matrix across all operating systems;
+- keep pytest-xdist as an explicit local opt-in unless CI runner behavior and coverage diagnostics
+  are deliberately re-evaluated;
 - keep coverage reporting lightweight and diagnostic rather than turning it into a percentage-driven
   release gate;
 - keep release artifact building in CI unless the release trust model is deliberately redesigned;

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -14,7 +14,8 @@ topmark:header:end
 
 TopMark uses a deliberately explicit CI and validation structure. GitHub workflows provide
 orchestration, nox sessions define stable reusable validation contracts, pytest markers describe
-validation intent, and Makefile targets provide local developer shortcuts.
+validation intent, and Makefile targets provide local developer shortcuts, including the recommended
+pre-PR validation gate.
 
 {% include-markdown "\_snippets/terminology.md" %}
 
@@ -37,8 +38,9 @@ workflows rather than correctness-validation or release-gating checks.
   linting, API snapshots, and release artifacts produced from trusted CI runs.
 - [Setup Python + nox action](./setup-python-nox-action.md) - documents the shared Python, uv,
   cache, and nox bootstrap layer used by CI jobs.
-- [Test validation](./test-validation.md) - explains pytest markers, validation categories, local
-  test commands, CI inclusion rules, and how nox and Makefile targets map onto the test suite.
+- [Test validation](./test-validation.md) - explains pytest markers, validation categories, the
+  recommended local pre-PR validation gate, local test commands, CI inclusion rules, and how nox and
+  Makefile targets map onto the test suite.
 - [Published artifact validation](./published-artifact-validation.md) - validates installation and
   runtime behavior from packages already published to PyPI or TestPyPI in clean runner environments.
 
@@ -74,6 +76,7 @@ Use this family of pages as follows:
 
 | Question                                                         | Start here                                                          |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------- |
+| What should I run before opening or updating a pull request?     | [Test validation](./test-validation.md)                             |
 | What runs on pull requests and pushes?                           | [CI workflow](./ci-workflow.md)                                     |
 | How are Python, uv, and nox bootstrapped in CI jobs?             | [Setup Python + nox action](./setup-python-nox-action.md)           |
 | Which tests are included, skipped, slow, or integration-focused? | [Test validation](./test-validation.md)                             |

--- a/docs/ci/test-validation.md
+++ b/docs/ci/test-validation.md
@@ -130,6 +130,16 @@ Supported Python versions are resolved by `noxfile.py` from `pyproject.toml` usi
 metadata helpers. Matrix sessions run across the supported Python versions, while canonical
 single-version sessions use the second most recent supported Python version.
 
+Run the recommended local pre-PR validation gate before opening or updating a pull request:
+
+```bash
+make pre-pr
+```
+
+The pre-PR gate runs formatting checks, lint checks, documentation hygiene, a strict docs build, the
+canonical Python QA session, and the public API snapshot check. It is a local confidence shortcut
+rather than a replacement for GitHub CI.
+
 Run the full default test suite through nox on the canonical Python version:
 
 ```bash
@@ -165,6 +175,33 @@ Run slow property tests only when intentionally investigating property-test beha
 ```bash
 pytest -m hypothesis_slow
 ```
+
+______________________________________________________________________
+
+## Parallel local pytest execution
+
+TopMark includes `pytest-xdist` in the test dependency group. Normal nox sessions and selected
+Makefile targets keep pytest execution serial by default, but they support forwarded pytest
+arguments for local experimentation and faster feedback.
+
+Common opt-in examples are:
+
+```bash
+make pre-pr PYTEST_PAR="-n auto"
+make test PYTEST_PAR="-n auto"
+make coverage PYTEST_PAR="-n auto"
+make release-check PYTEST_PAR="-n auto"
+nox -s pre_pr -- -n auto
+nox -s qa -p 3.13 -- -n auto
+nox -s qa_api -p 3.13 -- -n auto
+nox -s coverage -p 3.13 -- -n auto
+nox -s release_check -- -n auto
+```
+
+CI keeps pytest execution serial inside each job even though local parallel execution is supported.
+The workflow already uses job-level parallelism for the supported Python matrix and the
+cross-platform filesystem checks. Keeping per-job pytest execution serial makes coverage artifacts,
+release-gate diagnostics, and failure logs easier to compare across runs.
 
 ______________________________________________________________________
 
@@ -216,8 +253,10 @@ Common mappings are:
 
 | Need                                              | Preferred command                  |
 | ------------------------------------------------- | ---------------------------------- |
+| Run the recommended local pre-PR gate             | `make pre-pr`                      |
 | Run the main quality gate on the canonical Python | `nox -s qa -p 3.13`                |
 | Generate canonical coverage data                  | `nox -s coverage -p 3.13`          |
+| Run local pytest in parallel                      | `nox -s qa -p 3.13 -- -n auto`     |
 | Print CI Python metadata                          | `nox -s print_python_matrix`       |
 | Run a marker-specific test subset                 | `nox -s qa -p 3.13 -- -m <marker>` |
 | Build documentation                               | `nox -s docs`                      |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,6 +28,7 @@ ______________________________________________________________________
 | Goal                                                     | Recommended page                                                                     |
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | Set up a local development environment                   | [Installation guide](install.md)                                                     |
+| Run local pre-PR validation                              | [Test validation](ci/test-validation.md)                                             |
 | Understand contribution workflow and validation commands | [CONTRIBUTING.md](https://github.com/shutterfreak/topmark/blob/main/CONTRIBUTING.md) |
 | Understand project architecture                          | [Architecture](dev/architecture.md)                                                  |
 | Understand documentation conventions                     | [Documentation conventions](dev/documentation-conventions.md)                        |

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,6 +28,7 @@ Sessions:
   - `code_hygiene`: Enforce lightweight Python prose hygiene (custom tool).
   - `qa`: Per-Python session that runs pytest and pyright.
   - `qa_api`: Per-Python session that runs pytest + API snapshot + pyright in one env.
+  - `pre_pr`: Recommended local pre-PR validation gate.
   - `api_snapshot`: Public API snapshot test (per Python).
   - `property_test`: Long-running property tests (opt-in).
   - `perf_baseline`: Local pipeline memory/allocation baseline benchmarks (opt-in).
@@ -46,6 +47,7 @@ Common invocations:
   - `nox -s format_check`
   - `nox -s docs`
   - `nox -s qa` (runs for all configured Python versions)
+  - `nox -s pre_pr` (recommended before opening or updating a PR)
 """
 
 from __future__ import annotations
@@ -292,6 +294,52 @@ def qa_api(session: nox.Session) -> None:
         "pyright",
         "--pythonversion",
         py_ver,
+    )
+
+
+@nox.session(python=False)
+def pre_pr(session: nox.Session) -> None:
+    """Run the recommended local pre-PR validation gate.
+
+    This session is a source-tree confidence check for routine pull-request preparation.
+    It intentionally does not replace GitHub CI, cross-platform filesystem validation,
+    release-artifact construction, or network-dependent link validation.
+
+    Any arguments passed after `--` are forwarded to the canonical `qa` pytest run.
+    """
+    serial_sessions: tuple[str, ...] = (
+        "format_check",
+        "lint",
+        "docstring_links",
+        "docs_hygiene",
+        "code_hygiene",
+        "docs",
+    )
+    for session_name in serial_sessions:
+        session.run(
+            "nox",
+            "-s",
+            session_name,
+            external=True,
+        )
+
+    session.run(
+        "nox",
+        "-s",
+        "qa",
+        "-p",
+        CANONICAL_PYTHON,
+        "--",
+        *session.posargs,
+        external=True,
+    )
+    session.run(
+        "nox",
+        "-s",
+        "api_snapshot",
+        "-p",
+        CANONICAL_PYTHON,
+        external=True,
     )
 
 


### PR DESCRIPTION
## Summary

- add a dedicated `pre_pr` Nox session and `make pre-pr` convenience target for routine local PR validation
- document local `pytest-xdist` opt-in workflows while keeping CI pytest execution serial within each job
- reduce duplicate Linux validation by limiting the dedicated filesystem CI job to macOS and Windows
- update contributor and CI documentation to explain the new pre-PR workflow and its relationship to GitHub CI
- colocate Makefile `.PHONY` declarations with their targets to align with the configured `mbake` style

## Rationale

This addresses #217 by reviewing TopMark's pytest execution strategy and CI validation model without simply enabling `pytest -n auto` by default.

Local experiments showed that `qa`, `qa_api`, `coverage`, and `release_check` all tolerate `pytest-xdist`, including coverage artifact generation. This PR therefore documents xdist as a supported local opt-in while keeping CI jobs serial for deterministic diagnostics and coverage reporting.

The CI workflow now avoids one redundant canonical Linux filesystem pass: Linux QA remains covered by the supported Python-version matrix, while the dedicated filesystem job focuses on macOS and Windows platform behavior.

## Validation

- `nox -s qa -- -n auto`
- `nox -s qa_api -- -n auto`
- `nox -s coverage -- -n auto`
- `nox -s release_check -- -n auto`
- `make pre-pr`
- `mbake validate --config .bake.toml Makefile`
- `mbake format --check --config .bake.toml Makefile`

Closes #217