### PR TITLE
Expand `topmark.presentation` rendering contract coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,6 +516,11 @@ ______________________________________________________________________
 - Added focused regression coverage for Rich-aware CLI output assertion helpers, including
   layout-independent verification of strict file-type overlap diagnostics across ANSI styling, panel
   rendering, and wrapped terminal output.
+- Expanded presentation-layer regression coverage for TEXT, Markdown, and shared presentation
+  helpers, including pipeline guidance rendering, probe rendering, version formatting, configuration
+  presentation, diagnostic presentation, and shared presentation utilities. Added focused contract
+  tests for durable `ProcessingResult` and diagnostic models while reducing duplicated
+  probe-rendering logic through shared presentation helpers.
 - Hardened CLI human-output regression tests against Rich styling, panel borders, terminal-width
   wrapping, and other layout differences by replacing brittle raw output assertions with semantic
   Rich-aware assertion helpers.

--- a/src/topmark/presentation/markdown/probe.py
+++ b/src/topmark/presentation/markdown/probe.py
@@ -24,12 +24,12 @@ from topmark.presentation.markdown.diagnostic import render_diagnostics_markdown
 from topmark.presentation.markdown.paths import render_path_display_markdown
 from topmark.presentation.markdown.utils import markdown_code_span
 from topmark.presentation.markdown.utils import render_markdown_table
+from topmark.presentation.shared.probe import format_probe_match_signals
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from topmark.pipeline.result import ProbeCandidateSnapshot
-    from topmark.pipeline.result import ProbeMatchSnapshot
     from topmark.pipeline.result import ProbeSnapshot
     from topmark.pipeline.result import ProcessingResult
     from topmark.presentation.shared.pipeline import ProbeCommandHumanReport
@@ -131,17 +131,7 @@ def _render_probe_match_signals_markdown(
     Returns:
         Compact Markdown-safe match signal summary.
     """
-    match: ProbeMatchSnapshot = candidate.match
-    parts: list[str] = [
-        f"extension={str(match.extension).lower()}",
-        f"filename={str(match.filename).lower()}",
-        f"pattern={str(match.pattern).lower()}",
-        f"content_probe={str(match.content_probe_allowed).lower()}",
-        f"content_match={str(match.content_match).lower()}",
-    ]
-    if match.content_error is not None:
-        parts.append(f"content_error={match.content_error}")
-    return markdown_code_span(" ".join(parts))
+    return markdown_code_span(format_probe_match_signals(candidate))
 
 
 def _render_probe_candidates_markdown(

--- a/src/topmark/presentation/shared/probe.py
+++ b/src/topmark/presentation/shared/probe.py
@@ -1,0 +1,49 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : probe.py
+#   file_relpath : src/topmark/presentation/shared/probe.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Shared probe presentation helpers.
+
+This module contains Click-free formatting helpers shared by human-facing probe
+renderers. The helpers intentionally return plain, presentation-neutral text so
+format-specific renderers can apply Markdown escaping, code spans, or TEXT
+styling at the boundary.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from topmark.pipeline.result import ProbeCandidateSnapshot
+    from topmark.pipeline.result import ProbeMatchSnapshot
+
+
+def format_probe_match_signals(
+    candidate: ProbeCandidateSnapshot,
+) -> str:
+    """Format candidate match signals as compact plain text.
+
+    Args:
+        candidate: Probe candidate whose match signals should be rendered.
+
+    Returns:
+        Compact match-signal summary without format-specific escaping or styling.
+    """
+    match: ProbeMatchSnapshot = candidate.match
+    parts: list[str] = [
+        f"extension={str(match.extension).lower()}",
+        f"filename={str(match.filename).lower()}",
+        f"pattern={str(match.pattern).lower()}",
+        f"content_probe={str(match.content_probe_allowed).lower()}",
+        f"content_match={str(match.content_match).lower()}",
+    ]
+    if match.content_error is not None:
+        parts.append(f"content_error={match.content_error}")
+    return " ".join(parts)

--- a/src/topmark/presentation/text/probe.py
+++ b/src/topmark/presentation/text/probe.py
@@ -24,13 +24,12 @@ from topmark.cli.presentation import TextStyler
 from topmark.cli.presentation import style_for_role
 from topmark.core.presentation import StyleRole
 from topmark.presentation.shared.paths import get_display_path
+from topmark.presentation.shared.probe import format_probe_match_signals
 from topmark.presentation.text.diagnostic import render_diagnostics_text
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from topmark.pipeline.result import ProbeCandidateSnapshot
-    from topmark.pipeline.result import ProbeMatchSnapshot
     from topmark.pipeline.result import ProbeSnapshot
     from topmark.pipeline.result import ProcessingResult
     from topmark.presentation.shared.pipeline import ProbeCommandHumanReport
@@ -186,30 +185,6 @@ def _render_probe_selected_details_text(
     return lines
 
 
-def _format_probe_match_signals_text(
-    candidate: ProbeCandidateSnapshot,
-) -> str:
-    """Format candidate match signals as compact TEXT.
-
-    Args:
-        candidate: Probe candidate whose match signals should be rendered.
-
-    Returns:
-        Compact match-signal summary.
-    """
-    match: ProbeMatchSnapshot = candidate.match
-    parts: list[str] = [
-        f"extension={str(match.extension).lower()}",
-        f"filename={str(match.filename).lower()}",
-        f"pattern={str(match.pattern).lower()}",
-        f"content_probe={str(match.content_probe_allowed).lower()}",
-        f"content_match={str(match.content_match).lower()}",
-    ]
-    if match.content_error is not None:
-        parts.append(f"content_error={match.content_error}")
-    return " ".join(parts)
-
-
 def _render_probe_candidates_text(
     *,
     probe: ProbeSnapshot,
@@ -243,7 +218,7 @@ def _render_probe_candidates_text(
             if candidate.selected
             else emphasis_styler(candidate_label)
         )
-        lines.append(muted_styler(f"       match: {_format_probe_match_signals_text(candidate)}"))
+        lines.append(muted_styler(f"       match: {format_probe_match_signals(candidate)}"))
     return lines
 
 

--- a/tests/cli/test_unified_diff_rendering.py
+++ b/tests/cli/test_unified_diff_rendering.py
@@ -1,0 +1,112 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_unified_diff_rendering.py
+#   file_relpath : tests/cli/test_unified_diff_rendering.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+r"""Unit tests for CLI unified diff rendering helpers.
+
+These tests focus on the structure-aware formatter used by TEXT presentation:
+header-slot handling, hunk-body classification, escaped control characters, and
+line-number gutters. They intentionally avoid asserting exact Rich styles beyond
+checking that styled output remains ANSI-enabled where requested.
+"""
+
+from __future__ import annotations
+
+from topmark.cli.rendering.unified_diff import format_patch_styled
+
+
+def test_format_patch_styled_accepts_sequence_and_renders_plain_diff() -> None:
+    """Sequence input should be normalized and rendered without styling."""
+    rendered: str = format_patch_styled(
+        patch=[
+            "--- old.py",
+            "+++ new.py",
+            "@@ -1 +1 @@",
+            "-old",
+            "+new",
+            " context",
+        ],
+        styled=False,
+    )
+
+    assert rendered == "--- old.py\n+++ new.py\n@@ -1 +1 @@\n-old\n+new\n context\n"
+
+
+def test_format_patch_styled_escapes_control_characters_in_sequence_input() -> None:
+    """Rendered previews should make embedded CR/LF characters explicit."""
+    rendered: str = format_patch_styled(
+        patch=[
+            "--- old.py\r\n",
+            "+++ new.py\n",
+            "@@ -1 +1 @@",
+            "-old\r",
+            "+new\n",
+        ],
+        styled=False,
+    )
+
+    assert "--- old.py\\r\\n" in rendered
+    assert "+++ new.py\\n" in rendered
+    assert "-old\\r" in rendered
+    assert "+new\\n" in rendered
+    assert "\r" not in rendered
+
+
+def test_format_patch_styled_renders_no_newline_marker_as_metadata() -> None:
+    """No-newline markers should be emitted as diff metadata lines."""
+    rendered: str = format_patch_styled(
+        patch="--- old.py\n+++ new.py\n@@ -1 +1 @@\n-old\n+new\n\\ No newline at end of file",
+        styled=False,
+    )
+
+    assert rendered.endswith("\\ No newline at end of file\n")
+
+
+def test_format_patch_styled_does_not_classify_plus_minus_outside_hunks() -> None:
+    """Leading plus/minus content outside hunks should remain literal text."""
+    rendered: str = format_patch_styled(
+        patch=[
+            "--- old.py",
+            "+++ new.py",
+            "+not an addition outside a hunk",
+            "-not a deletion outside a hunk",
+            "---> not an old-file header",
+        ],
+        styled=False,
+    )
+
+    assert "+not an addition outside a hunk" in rendered
+    assert "-not a deletion outside a hunk" in rendered
+    assert "---> not an old-file header" in rendered
+
+
+def test_format_patch_styled_line_numbers_are_plain_when_styling_is_disabled() -> None:
+    """Plain line-number gutters should be deterministic."""
+    rendered: str = format_patch_styled(
+        patch=["--- old.py", "+++ new.py"],
+        styled=False,
+        show_line_numbers=True,
+    )
+
+    assert rendered == "0001|--- old.py\n0002|+++ new.py\n"
+
+
+def test_format_patch_styled_line_numbers_are_styled_when_requested() -> None:
+    """Styled line-number gutters should keep text content while emitting ANSI."""
+    rendered: str = format_patch_styled(
+        patch=["--- old.py", "+++ new.py", "@@ -1 +1 @@", "-old", "+new"],
+        styled=True,
+        show_line_numbers=True,
+    )
+
+    assert "0001|" in rendered
+    assert "--- old.py" in rendered
+    assert "0005|" in rendered
+    assert "+new" in rendered
+    assert "\x1b[" in rendered

--- a/tests/diagnostic/__init__.py
+++ b/tests/diagnostic/__init__.py
@@ -1,0 +1,13 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : __init__.py
+#   file_relpath : tests/diagnostic/__init__.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for topmark.diagnostic behavior."""
+
+from __future__ import annotations

--- a/tests/diagnostic/test_model.py
+++ b/tests/diagnostic/test_model.py
@@ -1,0 +1,74 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_model.py
+#   file_relpath : tests/diagnostic/test_model.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Diagnostic model contract tests."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from topmark.diagnostic.model import Diagnostic
+from topmark.diagnostic.model import DiagnosticLevel
+from topmark.diagnostic.model import DiagnosticStats
+from topmark.diagnostic.model import MutableDiagnosticLog
+
+
+def test_diagnostic_stats_get_rejects_unknown_level() -> None:
+    """DiagnosticStats.get should reject unsupported level-like values."""
+    stats = DiagnosticStats(n_info=1, n_warning=2, n_error=3)
+
+    with pytest.raises(ValueError, match="Unsupported diagnostic level"):
+        stats.get(cast("DiagnosticLevel", "notice"))
+
+
+def test_diagnostic_stats_triage_summary_respects_error_threshold() -> None:
+    """Error-threshold summaries should stop after errors."""
+    stats = DiagnosticStats(n_info=3, n_warning=2, n_error=1)
+
+    assert stats.triage_summary(DiagnosticLevel.ERROR) == "1 error"
+
+
+def test_diagnostic_stats_triage_summary_respects_warning_threshold() -> None:
+    """Warning-threshold summaries should include errors and warnings only."""
+    stats = DiagnosticStats(n_info=3, n_warning=2, n_error=1)
+
+    assert stats.triage_summary(DiagnosticLevel.WARNING) == "1 error, 2 warnings"
+
+
+def test_diagnostic_stats_triage_summary_handles_warning_only_threshold() -> None:
+    """Warning-threshold summaries should work when no errors are present."""
+    stats = DiagnosticStats(n_info=3, n_warning=2, n_error=0)
+
+    assert stats.triage_summary(DiagnosticLevel.WARNING) == "2 warnings"
+
+
+def test_diagnostic_stats_triage_summary_returns_empty_string_without_matches() -> None:
+    """Empty stats should render an empty triage summary."""
+    stats = DiagnosticStats(n_info=0, n_warning=0, n_error=0)
+
+    assert stats.triage_summary() == ""
+
+
+def test_mutable_diagnostic_log_has_info_reflects_info_entries() -> None:
+    """MutableDiagnosticLog.has_info should track whether info entries exist."""
+    log = MutableDiagnosticLog()
+
+    assert not log.has_info
+
+    log.add(
+        Diagnostic(
+            level=DiagnosticLevel.INFO,
+            message="Detail",
+        )
+    )
+
+    assert log.has_info

--- a/tests/presentation/test_config_rendering.py
+++ b/tests/presentation/test_config_rendering.py
@@ -1,0 +1,501 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_config_rendering.py
+#   file_relpath : tests/presentation/test_config_rendering.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for human-facing config presentation renderers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Protocol
+
+import pytest
+
+import topmark.presentation.shared.config as shared_config
+from topmark.config.io.deserializers import mutable_config_from_defaults
+from topmark.diagnostic.model import MutableDiagnosticLog
+from topmark.presentation.markdown.config import render_config_check_markdown
+from topmark.presentation.markdown.config import render_config_defaults_markdown
+from topmark.presentation.markdown.config import render_config_dump_markdown
+from topmark.presentation.markdown.config import render_config_init_markdown
+from topmark.presentation.shared.config import ConfigCheckHumanReport
+from topmark.presentation.shared.config import ConfigDefaultsHumanReport
+from topmark.presentation.shared.config import ConfigDumpHumanReport
+from topmark.presentation.shared.config import ConfigInitHumanReport
+from topmark.presentation.shared.config import build_config_check_human_report
+from topmark.presentation.shared.config import build_config_defaults_human_report
+from topmark.presentation.shared.config import build_config_dump_human_report
+from topmark.presentation.shared.config import build_config_init_human_report
+from topmark.presentation.shared.diagnostic import HumanDiagnosticCounts
+from topmark.presentation.shared.diagnostic import HumanDiagnosticLine
+from topmark.presentation.text.config import render_config_check_text
+from topmark.presentation.text.config import render_config_defaults_text
+from topmark.presentation.text.config import render_config_dump_text
+from topmark.presentation.text.config import render_config_init_text
+from topmark.toml.parse import ParsedTopmarkToml
+from topmark.toml.parse import SourceConfigLoadingOptions
+from topmark.toml.parse import SourceTomlOptions
+from topmark.toml.resolution import ResolvedTopmarkTomlSource
+from topmark.toml.resolution import ResolvedTopmarkTomlSources
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from topmark.config.model import FrozenConfig
+    from topmark.config.resolution.layers import ConfigLayer
+    from topmark.toml.types import TomlTable
+
+
+class _ConfigInitRenderer(Protocol):
+    """Callable protocol for config init renderers."""
+
+    def __call__(self, prepared: ConfigInitHumanReport) -> str:
+        """Render a config init report."""
+        ...
+
+
+class _ConfigDefaultsRenderer(Protocol):
+    """Callable protocol for config defaults renderers."""
+
+    def __call__(self, prepared: ConfigDefaultsHumanReport) -> str:
+        """Render a config defaults report."""
+        ...
+
+
+class _ConfigDumpRenderer(Protocol):
+    """Callable protocol for config dump renderers."""
+
+    def __call__(self, prepared: ConfigDumpHumanReport) -> str:
+        """Render a config dump report."""
+        ...
+
+
+class _TemplateFallbackError(Exception):
+    """Distinct fallback error used in config renderer tests."""
+
+
+def _parsed_toml_fragment(fragment: TomlTable) -> ParsedTopmarkToml:
+    """Return a parsed TOML object around a source-local fragment."""
+    return ParsedTopmarkToml(
+        config_loading_options=SourceConfigLoadingOptions(),
+        layered_config=fragment,
+        writer_options=None,
+        source_options=SourceTomlOptions(),
+        toml_fragment=fragment,
+        validation_issues=(),
+    )
+
+
+def _counts() -> HumanDiagnosticCounts:
+    """Return non-zero diagnostic counts for config presentation tests."""
+    return HumanDiagnosticCounts(info=1, warning=1, error=1)
+
+
+def _diagnostics() -> list[HumanDiagnosticLine]:
+    """Return stable diagnostic lines for config presentation tests."""
+    return [
+        HumanDiagnosticLine(
+            level="error",
+            message="invalid setting",
+        ),
+        HumanDiagnosticLine(
+            level="warning",
+            message="deprecated setting",
+        ),
+        HumanDiagnosticLine(
+            level="info",
+            message="using defaults",
+        ),
+    ]
+
+
+def _check_report(*, merged_toml: str | None, verbosity_level: int) -> ConfigCheckHumanReport:
+    """Build a config-check report with diagnostics and config-file details."""
+    return ConfigCheckHumanReport(
+        config_files=["topmark.toml"],
+        ok=False,
+        strict=True,
+        merged_toml=merged_toml,
+        counts=_counts(),
+        diagnostics=_diagnostics(),
+        verbosity_level=verbosity_level,
+        styled=False,
+    )
+
+
+def _dump_report(
+    *,
+    show_config_layers: bool,
+    provenance_toml: str | None,
+    verbosity_level: int,
+) -> ConfigDumpHumanReport:
+    """Build a config-dump report for text and Markdown renderer tests."""
+    return ConfigDumpHumanReport(
+        config_files=["topmark.toml"],
+        merged_toml='project = "Example"\n',
+        provenance_toml=provenance_toml,
+        show_config_layers=show_config_layers,
+        verbosity_level=verbosity_level,
+        styled=False,
+    )
+
+
+def test_build_config_init_human_report_applies_root_before_pyproject_nesting() -> None:
+    """Config init preparation should preserve root mode inside `[tool.topmark]`."""
+    report: ConfigInitHumanReport = build_config_init_human_report(
+        for_pyproject=True,
+        root=True,
+        verbosity_level=0,
+        styled=False,
+    )
+
+    assert "[tool.topmark.config]" in report.toml_text
+    assert "root = true" in report.toml_text
+    assert report.error is None
+
+
+def test_build_config_defaults_human_report_can_render_root_pyproject_defaults() -> None:
+    """Config defaults preparation should render copyable pyproject-root TOML."""
+    report: ConfigDefaultsHumanReport = build_config_defaults_human_report(
+        for_pyproject=True,
+        root=True,
+        verbosity_level=0,
+        styled=False,
+    )
+
+    assert "[tool.topmark.config]" in report.toml_text
+    assert "root = true" in report.toml_text
+
+
+def test_build_config_dump_human_report_with_empty_resolved_sources_exports_default_layer() -> None:
+    """Layered dump preparation should always include the built-in defaults layer."""
+    config: FrozenConfig = mutable_config_from_defaults().freeze()
+    report: ConfigDumpHumanReport = build_config_dump_human_report(
+        config=config,
+        resolved_toml=ResolvedTopmarkTomlSources(
+            sources=[],
+            writer_options=None,
+            strict=None,
+        ),
+        show_config_layers=True,
+        verbosity_level=0,
+        styled=False,
+    )
+
+    assert report.show_config_layers is True
+    assert report.provenance_toml is not None
+    assert "[[layers]]" in report.provenance_toml
+    assert 'origin = "<defaults>"' in report.provenance_toml
+    assert "[fields]" in report.merged_toml
+
+
+def test_build_config_check_human_report_verbose_prepares_effective_toml() -> None:
+    """Verbose config-check preparation should include rendered effective TOML."""
+    config: FrozenConfig = mutable_config_from_defaults().freeze()
+    report: ConfigCheckHumanReport = build_config_check_human_report(
+        config=config,
+        resolved_sources=ResolvedTopmarkTomlSources(
+            sources=[],
+            writer_options=None,
+            strict=None,
+        ),
+        ok=True,
+        strict=False,
+        verbosity_level=2,
+        styled=False,
+    )
+
+    assert report.ok is True
+    assert report.strict is False
+    assert report.merged_toml is not None
+    assert "[fields]" in report.merged_toml
+    assert report.counts.error == 0
+    assert report.diagnostics == []
+
+
+def test_render_config_init_markdown_without_fallback_returns_toml_only() -> None:
+    """Markdown config init should omit fallback footer when no template error occurred."""
+    output: str = render_config_init_markdown(
+        ConfigInitHumanReport(
+            toml_text='project = "Clean"\n',
+            error=None,
+            verbosity_level=0,
+            styled=False,
+        )
+    )
+
+    assert output.startswith("# Initial TopMark Configuration (TOML)")
+    assert 'project = "Clean"' in output
+    assert "Warning" not in output
+    assert "Generated by TopMark" not in output
+
+
+def test_render_config_check_text_without_diagnostics_reports_compact_ok_status() -> None:
+    """TEXT config check should render a compact OK status without diagnostics."""
+    output: str = render_config_check_text(
+        ConfigCheckHumanReport(
+            config_files=[],
+            ok=True,
+            strict=False,
+            merged_toml=None,
+            counts=HumanDiagnosticCounts(info=0, warning=0, error=0),
+            diagnostics=[],
+            verbosity_level=0,
+            styled=False,
+        )
+    )
+
+    assert "✅ Config OK (no diagnostics). [strict: off]" in output
+    assert output.endswith("✅ OK")
+    assert "Config files processed" not in output
+
+
+def test_render_config_check_markdown_without_diagnostics_or_toml_omits_optional_sections() -> None:
+    """Markdown config check should omit optional diagnostics and TOML sections when absent."""
+    output: str = render_config_check_markdown(
+        ConfigCheckHumanReport(
+            config_files=[],
+            ok=True,
+            strict=False,
+            merged_toml=None,
+            counts=HumanDiagnosticCounts(info=0, warning=0, error=0),
+            diagnostics=[],
+            verbosity_level=0,
+            styled=False,
+        )
+    )
+
+    assert "- **Status:** OK" in output
+    assert "### Diagnostics" not in output
+    assert "### Effective merged TOML" not in output
+    assert "### Config files processed (0)" in output
+
+
+def test_render_config_dump_text_without_layers_verbose_includes_files_and_single_toml() -> None:
+    """Verbose TEXT config dump should render loaded files and one flattened TOML block."""
+    output: str = render_config_dump_text(
+        _dump_report(
+            show_config_layers=False,
+            provenance_toml=None,
+            verbosity_level=1,
+        )
+    )
+
+    assert "Config files processed: 1" in output
+    assert "Loaded config 1: topmark.toml" in output
+    assert "TopMark Config Dump (TOML):" in output
+    assert "TopMark Config Provenance Layers" not in output
+    assert 'project = "Example"' in output
+
+
+def test_build_config_dump_human_report_exports_file_backed_source_layer(
+    tmp_path: Path,
+) -> None:
+    """Layered dump preparation should include file-backed source fragments."""
+    config_path: Path = tmp_path / "topmark.toml"
+    config_path.write_text('[fields]\nproject = "Layered"\n', encoding="utf-8")
+    fragment: TomlTable = {"fields": {"project": "Layered"}}
+    config: FrozenConfig = mutable_config_from_defaults().freeze()
+
+    report: ConfigDumpHumanReport = build_config_dump_human_report(
+        config=config,
+        resolved_toml=ResolvedTopmarkTomlSources(
+            sources=[
+                ResolvedTopmarkTomlSource(
+                    path=config_path,
+                    parsed=_parsed_toml_fragment(fragment),
+                    kind="explicit",
+                    validation_issues=(),
+                    load_diagnostics=MutableDiagnosticLog().freeze(),
+                )
+            ],
+            writer_options=None,
+            strict=None,
+        ),
+        show_config_layers=True,
+        verbosity_level=0,
+        styled=False,
+    )
+
+    assert report.provenance_toml is not None
+    assert 'kind = "explicit"' in report.provenance_toml
+    assert f'scope_root = "{tmp_path}"' in report.provenance_toml
+    assert 'project = "Layered"' in report.provenance_toml
+
+
+@pytest.mark.parametrize(
+    ("renderer", "expected_title"),
+    [
+        (render_config_init_text, "Initial TopMark Configuration (TOML):"),
+        (render_config_init_markdown, "# Initial TopMark Configuration (TOML)"),
+    ],
+)
+def test_config_init_renderers_include_fallback_warning(
+    renderer: _ConfigInitRenderer,
+    expected_title: str,
+) -> None:
+    """Config init renderers should preserve TOML and surface template fallbacks."""
+    report = ConfigInitHumanReport(
+        toml_text='project = "Fallback"\n',
+        error=_TemplateFallbackError("template missing"),
+        verbosity_level=1,
+        styled=False,
+    )
+
+    output: str = renderer(report)
+
+    assert expected_title in output
+    assert "falling back to synthesized default config: template missing" in output
+    assert 'project = "Fallback"' in output
+
+
+@pytest.mark.parametrize(
+    ("renderer", "expected_title"),
+    [
+        (render_config_defaults_text, "Default TopMark Configuration (TOML):"),
+        (render_config_defaults_markdown, "# Default TopMark Configuration (TOML)"),
+    ],
+)
+def test_config_defaults_renderers_include_toml_document(
+    renderer: _ConfigDefaultsRenderer,
+    expected_title: str,
+) -> None:
+    """Config defaults renderers should expose the generated TOML document."""
+    report = ConfigDefaultsHumanReport(
+        toml_text='project = "Defaults"\n',
+        verbosity_level=1,
+        styled=False,
+    )
+
+    output: str = renderer(report)
+
+    assert expected_title in output
+    assert 'project = "Defaults"' in output
+
+
+def test_render_config_init_text_without_fallback_omits_warning() -> None:
+    """TEXT config init should omit fallback warning when template loading succeeded."""
+    output: str = render_config_init_text(
+        ConfigInitHumanReport(
+            toml_text='project = "Clean"\n',
+            error=None,
+            verbosity_level=0,
+            styled=False,
+        )
+    )
+
+    assert 'project = "Clean"' in output
+    assert "falling back to synthesized default config" not in output
+
+
+def test_build_config_dump_human_report_handles_empty_layer_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Layered dump preparation should render a valid empty layers document defensively."""
+
+    def no_config_layers(
+        sources: list[ResolvedTopmarkTomlSource],
+    ) -> list[ConfigLayer]:
+        return []
+
+    monkeypatch.setattr(
+        shared_config,
+        "build_config_layers_from_resolved_toml_sources",
+        no_config_layers,
+    )
+
+    config: FrozenConfig = mutable_config_from_defaults().freeze()
+    report: ConfigDumpHumanReport = build_config_dump_human_report(
+        config=config,
+        resolved_toml=ResolvedTopmarkTomlSources(
+            sources=[],
+            writer_options=None,
+            strict=None,
+        ),
+        show_config_layers=True,
+        verbosity_level=0,
+        styled=False,
+    )
+
+    assert report.provenance_toml == "layers = []\n"
+
+
+def test_render_config_check_text_verbose_includes_diagnostics_files_and_toml() -> None:
+    """Verbose TEXT config check should include diagnostics, files, and merged TOML."""
+    output: str = render_config_check_text(
+        _check_report(
+            merged_toml='project = "Checked"\n',
+            verbosity_level=2,
+        )
+    )
+
+    assert "Diagnostics: 1 error(s), 1 warning(s), 1 information(s)" in output
+    assert "- error: invalid setting" in output
+    assert "Loaded config 1: topmark.toml" in output
+    assert "TopMark Config (TOML):" in output
+    assert 'project = "Checked"' in output
+    assert "❌ FAILED" in output
+
+
+def test_render_config_check_markdown_includes_diagnostics_files_and_toml() -> None:
+    """Markdown config check should include diagnostics, files, and merged TOML."""
+    output: str = render_config_check_markdown(
+        _check_report(
+            merged_toml='project = "Checked"\n',
+            verbosity_level=0,
+        )
+    )
+
+    assert "- **Status:** FAILED" in output
+    assert "### Diagnostics" in output
+    assert "- **error**: invalid setting" in output
+    assert "1. topmark.toml" in output
+    assert "### Effective merged TOML" in output
+    assert 'project = "Checked"' in output
+
+
+@pytest.mark.parametrize(
+    ("renderer", "separator"),
+    [
+        (render_config_dump_text, "TopMark Config Provenance Layers (TOML):"),
+        (render_config_dump_markdown, "---"),
+    ],
+)
+def test_config_dump_renderers_include_layered_and_flattened_documents(
+    renderer: _ConfigDumpRenderer,
+    separator: str,
+) -> None:
+    """Config dump renderers should show provenance before flattened TOML."""
+    report: ConfigDumpHumanReport = _dump_report(
+        show_config_layers=True,
+        provenance_toml='[[layers]]\nkind = "default"\n',
+        verbosity_level=0,
+    )
+
+    output: str = renderer(report)
+
+    assert separator in output
+    assert 'kind = "default"' in output
+    assert 'project = "Example"' in output
+    assert output.find('kind = "default"') < output.find('project = "Example"')
+
+
+def test_render_config_dump_markdown_without_layers_uses_single_dump_heading() -> None:
+    """Markdown config dump should have a single TOML heading without layer data."""
+    output: str = render_config_dump_markdown(
+        _dump_report(
+            show_config_layers=False,
+            provenance_toml=None,
+            verbosity_level=0,
+        )
+    )
+
+    assert "# TopMark Config Dump (TOML)" in output
+    assert "TopMark Config Provenance Layers" not in output
+    assert 'project = "Example"' in output

--- a/tests/presentation/test_config_rendering.py
+++ b/tests/presentation/test_config_rendering.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from typing import Protocol
 
 import pytest
+import tomlkit
 
 import topmark.presentation.shared.config as shared_config
 from topmark.config.io.deserializers import mutable_config_from_defaults
@@ -324,8 +325,17 @@ def test_build_config_dump_human_report_exports_file_backed_source_layer(
     )
 
     assert report.provenance_toml is not None
+
+    # Parse the rendered TOML before asserting path values. Comparing the raw
+    # serialized string is platform-dependent because TOML escapes Windows
+    # backslashes (e.g. `C:\\Users\\...`), whereas the parsed value preserves
+    # the original native path representation.
+    data: tomlkit.TOMLDocument = tomlkit.loads(report.provenance_toml)
+    assert data["layers"][1]["scope_root"] == str(tmp_path)
+
+    # These fields are platform-independent and may be asserted directly on the
+    # serialized TOML.
     assert 'kind = "explicit"' in report.provenance_toml
-    assert f'scope_root = "{tmp_path}"' in report.provenance_toml
     assert 'project = "Layered"' in report.provenance_toml
 
 

--- a/tests/presentation/test_diagnostic_rendering.py
+++ b/tests/presentation/test_diagnostic_rendering.py
@@ -48,7 +48,34 @@ class LooseDiagnostic:
     message: object
 
 
-def _log_with_entries(entries: list[tuple[DiagnosticLevel, str]]) -> MutableDiagnosticLog:
+@dataclass(frozen=True, slots=True)
+class StringValueLevel:
+    """Level-like object with a string value attribute."""
+
+    value: str
+
+
+@dataclass(frozen=True, slots=True)
+class NonStringValueLevel:
+    """Level-like object with a non-string value attribute."""
+
+    value: int
+
+
+@dataclass(frozen=True, slots=True)
+class StringOnlyLevel:
+    """Level-like object without a value attribute."""
+
+    name: str
+
+    def __str__(self) -> str:
+        """Return the human level string for fallback formatting."""
+        return self.name
+
+
+def _log_with_entries(
+    entries: list[tuple[DiagnosticLevel, str]],
+) -> MutableDiagnosticLog:
     """Build a mutable diagnostic log with stable insertion order."""
     log = MutableDiagnosticLog()
     for level, message in entries:
@@ -61,8 +88,14 @@ def test_human_diagnostics_text_summary_at_default_verbosity() -> None:
     output: str = render_human_diagnostics_text(
         counts=HumanDiagnosticCounts(error=1, warning=2, info=3),
         diagnostics=[
-            HumanDiagnosticLine(level="error", message="Invalid config"),
-            HumanDiagnosticLine(level="warning", message="Deprecated option"),
+            HumanDiagnosticLine(
+                level="error",
+                message="Invalid config",
+            ),
+            HumanDiagnosticLine(
+                level="warning",
+                message="Deprecated option",
+            ),
         ],
         verbosity_level=0,
     )
@@ -78,8 +111,14 @@ def test_human_diagnostics_markdown_renders_stable_document_output() -> None:
         title="Configuration diagnostics",
         counts=HumanDiagnosticCounts(error=1, warning=2, info=3),
         diagnostics=[
-            HumanDiagnosticLine(level="error", message="Invalid config"),
-            HumanDiagnosticLine(level="warning", message="Deprecated option"),
+            HumanDiagnosticLine(
+                level="error",
+                message="Invalid config",
+            ),
+            HumanDiagnosticLine(
+                level="warning",
+                message="Deprecated option",
+            ),
         ],
     )
 
@@ -103,8 +142,14 @@ def test_human_diagnostics_text_details_at_verbose_level() -> None:
     output: str = render_human_diagnostics_text(
         counts=HumanDiagnosticCounts(error=1, warning=1, info=0),
         diagnostics=[
-            HumanDiagnosticLine(level="error", message="Invalid config"),
-            HumanDiagnosticLine(level="warning", message="Deprecated option"),
+            HumanDiagnosticLine(
+                level="error",
+                message="Invalid config",
+            ),
+            HumanDiagnosticLine(
+                level="warning",
+                message="Deprecated option",
+            ),
         ],
         verbosity_level=1,
     )
@@ -143,18 +188,36 @@ def test_human_diagnostics_render_empty_when_no_diagnostics() -> None:
 def test_prepare_human_diagnostics_counts_known_levels() -> None:
     """Shared diagnostic preparation should count known diagnostic levels."""
     diagnostics: list[Diagnostic] = [
-        Diagnostic(level=DiagnosticLevel.ERROR, message="Broken"),
-        Diagnostic(level=DiagnosticLevel.WARNING, message="Deprecated"),
-        Diagnostic(level=DiagnosticLevel.INFO, message="FYI"),
+        Diagnostic(
+            level=DiagnosticLevel.ERROR,
+            message="Broken",
+        ),
+        Diagnostic(
+            level=DiagnosticLevel.WARNING,
+            message="Deprecated",
+        ),
+        Diagnostic(
+            level=DiagnosticLevel.INFO,
+            message="FYI",
+        ),
     ]
 
     human_diagnostics: HumanDiagnostics = prepare_human_diagnostics(diagnostics)
 
     assert human_diagnostics.counts == HumanDiagnosticCounts(error=1, warning=1, info=1)
     assert human_diagnostics.lines == [
-        HumanDiagnosticLine(level="error", message="Broken"),
-        HumanDiagnosticLine(level="warning", message="Deprecated"),
-        HumanDiagnosticLine(level="info", message="FYI"),
+        HumanDiagnosticLine(
+            level="error",
+            message="Broken",
+        ),
+        HumanDiagnosticLine(
+            level="warning",
+            message="Deprecated",
+        ),
+        HumanDiagnosticLine(
+            level="info",
+            message="FYI",
+        ),
     ]
 
 
@@ -163,8 +226,14 @@ def test_prepare_human_diagnostics_treats_unknown_levels_as_info() -> None:
     diagnostics: Iterable[Diagnostic] = cast(
         "Iterable[Diagnostic]",
         [
-            LooseDiagnostic(level=CustomLevel.NOTICE, message=123),
-            LooseDiagnostic(level="", message="empty level"),
+            LooseDiagnostic(
+                level=CustomLevel.NOTICE,
+                message=123,
+            ),
+            LooseDiagnostic(
+                level="",
+                message="empty level",
+            ),
         ],
     )
 
@@ -172,8 +241,53 @@ def test_prepare_human_diagnostics_treats_unknown_levels_as_info() -> None:
 
     assert human_diagnostics.counts == HumanDiagnosticCounts(error=0, warning=0, info=2)
     assert human_diagnostics.lines == [
-        HumanDiagnosticLine(level="notice", message="123"),
-        HumanDiagnosticLine(level="info", message="empty level"),
+        HumanDiagnosticLine(
+            level="notice",
+            message="123",
+        ),
+        HumanDiagnosticLine(
+            level="info",
+            message="empty level",
+        ),
+    ]
+
+
+def test_prepare_human_diagnostics_normalizes_level_like_objects() -> None:
+    """Level-like objects should fall back to stable human-facing strings."""
+    diagnostics: Iterable[Diagnostic] = cast(
+        "Iterable[Diagnostic]",
+        [
+            LooseDiagnostic(
+                level=StringValueLevel(value="debug"),
+                message="string value",
+            ),
+            LooseDiagnostic(
+                level=NonStringValueLevel(value=404),
+                message="numeric value",
+            ),
+            LooseDiagnostic(
+                level=StringOnlyLevel(name="notice"),
+                message="string fallback",
+            ),
+        ],
+    )
+
+    human_diagnostics: HumanDiagnostics = prepare_human_diagnostics(diagnostics)
+
+    assert human_diagnostics.counts == HumanDiagnosticCounts(error=0, warning=0, info=3)
+    assert human_diagnostics.lines == [
+        HumanDiagnosticLine(
+            level="debug",
+            message="string value",
+        ),
+        HumanDiagnosticLine(
+            level="nonstringvaluelevel(value=404)",
+            message="numeric value",
+        ),
+        HumanDiagnosticLine(
+            level="notice",
+            message="string fallback",
+        ),
     ]
 
 
@@ -193,9 +307,18 @@ def test_render_diagnostics_text_compact_error_warning_summary() -> None:
     """At verbosity 0, TEXT diagnostics should summarize high-severity entries only."""
     log: MutableDiagnosticLog = _log_with_entries(
         [
-            (DiagnosticLevel.ERROR, "Broken config"),
-            (DiagnosticLevel.WARNING, "Deprecated key"),
-            (DiagnosticLevel.INFO, "Extra detail"),
+            (
+                DiagnosticLevel.ERROR,
+                "Broken config",
+            ),
+            (
+                DiagnosticLevel.WARNING,
+                "Deprecated key",
+            ),
+            (
+                DiagnosticLevel.INFO,
+                "Extra detail",
+            ),
         ]
     )
 
@@ -212,8 +335,14 @@ def test_render_diagnostics_text_compact_info_only_summary() -> None:
     """At verbosity 0, TEXT diagnostics should include info when no higher severity exists."""
     log: MutableDiagnosticLog = _log_with_entries(
         [
-            (DiagnosticLevel.INFO, "First detail"),
-            (DiagnosticLevel.INFO, "Second detail"),
+            (
+                DiagnosticLevel.INFO,
+                "First detail",
+            ),
+            (
+                DiagnosticLevel.INFO,
+                "Second detail",
+            ),
         ]
     )
 
@@ -230,9 +359,18 @@ def test_render_diagnostics_text_verbose_renders_all_entries() -> None:
     """At verbosity >= 1, TEXT diagnostics should include one line per entry."""
     log: MutableDiagnosticLog = _log_with_entries(
         [
-            (DiagnosticLevel.ERROR, "Broken config"),
-            (DiagnosticLevel.WARNING, "Deprecated key"),
-            (DiagnosticLevel.INFO, "Extra detail"),
+            (
+                DiagnosticLevel.ERROR,
+                "Broken config",
+            ),
+            (
+                DiagnosticLevel.WARNING,
+                "Deprecated key",
+            ),
+            (
+                DiagnosticLevel.INFO,
+                "Extra detail",
+            ),
         ]
     )
 
@@ -261,9 +399,18 @@ def test_render_diagnostics_markdown_renders_error_warning_summary() -> None:
     """Markdown diagnostics should render a stable triage block and entries."""
     log: MutableDiagnosticLog = _log_with_entries(
         [
-            (DiagnosticLevel.ERROR, "Broken config"),
-            (DiagnosticLevel.WARNING, "Deprecated key"),
-            (DiagnosticLevel.INFO, "Extra detail"),
+            (
+                DiagnosticLevel.ERROR,
+                "Broken config",
+            ),
+            (
+                DiagnosticLevel.WARNING,
+                "Deprecated key",
+            ),
+            (
+                DiagnosticLevel.INFO,
+                "Extra detail",
+            ),
         ]
     )
 
@@ -288,8 +435,14 @@ def test_render_diagnostics_markdown_renders_info_only_summary() -> None:
     """Markdown diagnostics should include info counts when no higher severity exists."""
     log: MutableDiagnosticLog = _log_with_entries(
         [
-            (DiagnosticLevel.INFO, "First detail"),
-            (DiagnosticLevel.INFO, "Second detail"),
+            (
+                DiagnosticLevel.INFO,
+                "First detail",
+            ),
+            (
+                DiagnosticLevel.INFO,
+                "Second detail",
+            ),
         ]
     )
 

--- a/tests/presentation/test_markdown_utils.py
+++ b/tests/presentation/test_markdown_utils.py
@@ -1,0 +1,77 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_markdown_utils.py
+#   file_relpath : tests/presentation/test_markdown_utils.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Focused tests for low-level Markdown presentation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from topmark.presentation.markdown.utils import markdown_code_span
+from topmark.presentation.markdown.utils import markdown_escape
+from topmark.presentation.markdown.utils import render_markdown_table
+from topmark.presentation.markdown.utils import render_toml_markdown
+
+
+def test_markdown_code_span_grows_past_embedded_backticks() -> None:
+    """Inline code spans should survive filenames containing backticks."""
+    assert markdown_code_span("name`with``ticks") == "```name`with``ticks```"
+
+
+def test_markdown_escape_pads_edge_backticks() -> None:
+    """Legacy escape helper should pad text that starts or ends with a backtick."""
+    assert markdown_escape("`edge`") == "`` `edge` ``"
+
+
+def test_render_markdown_table_handles_empty_headers() -> None:
+    """An empty table shape should render as an empty fragment."""
+    assert render_markdown_table([], []) == ""
+
+
+def test_render_markdown_table_rejects_inconsistent_rows() -> None:
+    """Tables should fail loudly when row width differs from header width."""
+    with pytest.raises(ValueError, match="same number of columns"):
+        render_markdown_table(["A", "B"], [["only one cell"]])
+
+
+def test_render_markdown_table_supports_right_and_center_alignment() -> None:
+    """Markdown tables should render explicit right and center alignment markers."""
+    output: str = render_markdown_table(
+        ["Name", "Count", "Mode"],
+        [["alpha", "2", "wide"]],
+        align={1: "right", 2: "center"},
+    )
+
+    assert "| Name  | Count | Mode |" in output
+    assert "| ----- | ----: | :--: |" in output
+    assert "| alpha | 2     | wide |" in output
+
+
+def test_render_toml_markdown_normalizes_heading_bounds_and_fence() -> None:
+    """TOML Markdown rendering should clamp headings and avoid nested fences."""
+    output: str = render_toml_markdown(
+        heading="Config",
+        heading_level=9,
+        toml_text='key = "value"\n# ``` nested fence',
+    )
+
+    assert output.startswith("###### Config\n")
+    assert "````toml" in output
+    assert output.rstrip().endswith("````")
+
+
+def test_render_toml_markdown_allows_no_heading() -> None:
+    """TOML Markdown rendering should support code-block-only output."""
+    output: str = render_toml_markdown(
+        heading=None,
+        toml_text="key = true\n",
+    )
+
+    assert output == "```toml\nkey = true\n```\n"

--- a/tests/presentation/test_pipeline_rendering.py
+++ b/tests/presentation/test_pipeline_rendering.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -21,6 +22,7 @@ from tests.helpers.pipeline import make_pipeline_context
 from tests.helpers.pipeline import unsupported_output_format
 from tests.helpers.registry import make_file_type
 from tests.presentation.conftest import find_table_row
+from topmark.cli.errors import TopmarkCliPipelineError
 from topmark.config.io.deserializers import mutable_config_from_defaults
 from topmark.core.formats import OutputFormat
 from topmark.diagnostic.model import Diagnostic
@@ -40,6 +42,7 @@ from topmark.pipeline.status import PatchStatus
 from topmark.pipeline.status import PlanStatus
 from topmark.pipeline.status import ResolveStatus
 from topmark.pipeline.status import StripStatus
+from topmark.pipeline.status import WriteStatus
 from topmark.pipeline.views import DiffView
 from topmark.presentation.markdown.paths import render_path_display_markdown
 from topmark.presentation.markdown.pipeline import render_pipeline_apply_summary_markdown
@@ -125,6 +128,44 @@ def _add_diff(ctx: ProcessingContext) -> None:
     """Attach a deterministic unified diff to a context."""
     ctx.status.patch = PatchStatus.GENERATED
     ctx.views.diff = DiffView(text="--- old\n+++ new\n@@ -1 +1 @@\n-old\n+new\n")
+
+
+def _force_check_actionable_with_no_concrete_intent(
+    result: ProcessingResult,
+) -> ProcessingResult:
+    """Return a check-actionable result whose statuses imply no concrete intent."""
+    return replace(
+        result,
+        status=replace(
+            result.status,
+            header=HeaderStatus.PENDING,
+            strip=StripStatus.PENDING,
+        ),
+        outcome=replace(
+            result.outcome,
+            would_add_or_update=True,
+            effective_would_add_or_update=True,
+        ),
+    )
+
+
+def _force_strip_actionable_with_insert_intent(
+    result: ProcessingResult,
+) -> ProcessingResult:
+    """Return a strip-actionable result whose statuses imply insert intent."""
+    return replace(
+        result,
+        status=replace(
+            result.status,
+            header=HeaderStatus.MISSING,
+            strip=StripStatus.PENDING,
+        ),
+        outcome=replace(
+            result.outcome,
+            would_strip=True,
+            effective_would_strip=True,
+        ),
+    )
 
 
 def test_render_path_display_text_uses_regular_display_path(tmp_path: Path) -> None:
@@ -325,6 +366,100 @@ def test_render_pipeline_output_text_strip_guidance_uses_strip_command(
     assert "to strip the TopMark header from this file." in output
 
 
+def test_render_pipeline_output_text_apply_mode_reports_write_skipped(
+    tmp_path: Path,
+) -> None:
+    """TEXT apply-mode guidance should report defensive skipped writes."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "skipped.py",
+        apply_changes=True,
+    )
+    ctx.status.write = WriteStatus.SKIPPED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_text(
+        _make_report(
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "write was skipped" in output
+    assert "⚠️  Could not insert header (write skipped)." in output
+
+
+def test_render_pipeline_output_markdown_apply_mode_reports_write_failed(
+    tmp_path: Path,
+) -> None:
+    """Markdown apply-mode guidance should report failed writes explicitly."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "failed.py",
+        apply_changes=True,
+    )
+    ctx.status.write = WriteStatus.FAILED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "write failed" in output
+    assert "❌ Could not insert header: write failed" in output
+
+
+def test_render_pipeline_output_text_renders_hint_detail_at_double_verbose(
+    tmp_path: Path,
+) -> None:
+    """TEXT hints should reveal multiline details at ``-vv`` verbosity."""
+    ctx: ProcessingContext = _make_context(tmp_path / "hints.py")
+    ctx.diagnostic_hints.add(
+        make_hint(
+            axis=Axis.PLAN,
+            code=KnownCode.PLAN_INSERT,
+            message="Would insert header",
+            detail="first detail\nsecond detail",
+            cluster=Cluster.WOULD_CHANGE,
+            terminal=True,
+        )
+    )
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_text(
+        _make_report(
+            view_results=reduction.results,
+            verbosity_level=2,
+        )
+    )
+
+    assert "⏹ plan" in output
+    assert "(terminal)" in output
+    assert "first detail" in output
+    assert "second detail" in output
+    assert "use '-vv'" not in output
+
+
+def test_render_pipeline_output_text_empty_summary_reports_total_only() -> None:
+    """TEXT summary mode should render a total even when no rows are visible."""
+    output: str = render_pipeline_output_text(
+        _make_report(
+            view_results=[],
+            file_list_total=0,
+            summary_mode=True,
+        )
+    )
+
+    assert "Summary by outcome:" in output
+    assert "TOTAL" in output
+    assert ": 0" in output
+    assert "─" not in output
+
+
 def test_render_pipeline_output_markdown_per_file_includes_diagnostics_hints_and_diff(
     tmp_path: Path,
 ) -> None:
@@ -455,6 +590,272 @@ def test_render_pipeline_apply_summary_markdown_reports_noop_and_failed() -> Non
     assert "> ⚠️ `topmark strip`: failed to write **1** file(s). See log for details." in output
 
 
+def test_render_pipeline_output_markdown_check_guidance_uses_stdin_filename(
+    tmp_path: Path,
+) -> None:
+    """Markdown check guidance should render the STDIN apply command contract."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "stdin-buffer.py",
+        stdin_mode=True,
+        stdin_filename="logical/input.py",
+    )
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            view_results=reduction.results,
+        )
+    )
+
+    assert "`logical/input.py` (python)" in output
+    assert (
+        "Run `topmark check --apply --stdin-filename logical/input.py -` "
+        "to add a TopMark header to this file."
+    ) in output
+
+
+def test_render_pipeline_output_markdown_check_guidance_reports_update(
+    tmp_path: Path,
+) -> None:
+    """Markdown check guidance should distinguish update from insert intent."""
+    ctx: ProcessingContext = _make_context(tmp_path / "update.py")
+    ctx.status.header = HeaderStatus.DETECTED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            view_results=reduction.results,
+        )
+    )
+
+    assert "to update the TopMark header in this file." in output
+    assert "to add a TopMark header to this file." not in output
+
+
+def test_render_pipeline_output_markdown_strip_guidance_uses_strip_command(
+    tmp_path: Path,
+) -> None:
+    """Markdown strip rendering should produce strip-specific dry-run guidance."""
+    ctx: ProcessingContext = _make_context(tmp_path / "strip.md.py", pipeline_kind="strip")
+    ctx.status.header = HeaderStatus.DETECTED
+    ctx.status.strip = StripStatus.READY
+    ctx.status.plan = PlanStatus.PREVIEWED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            pipeline_kind="strip",
+            view_results=reduction.results,
+        )
+    )
+
+    assert "# TopMark strip Results" in output
+    assert "Run `topmark strip --apply" in output
+    assert "to strip the TopMark header from this file." in output
+
+
+def test_render_pipeline_output_markdown_strip_apply_mode_reports_write_skipped(
+    tmp_path: Path,
+) -> None:
+    """Markdown strip apply-mode guidance should report defensive skipped writes."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "strip-skipped.py",
+        pipeline_kind="strip",
+        apply_changes=True,
+    )
+    ctx.status.header = HeaderStatus.DETECTED
+    ctx.status.strip = StripStatus.READY
+    ctx.status.plan = PlanStatus.REMOVED
+    ctx.status.write = WriteStatus.SKIPPED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            pipeline_kind="strip",
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "write skipped" in output
+    assert "⚠️  Could not strip header (write skipped)." in output
+
+
+def test_render_pipeline_output_text_per_file_renders_diff_fences(
+    tmp_path: Path,
+) -> None:
+    """TEXT per-file output should render optional diff fences outside summary mode."""
+    ctx: ProcessingContext = _make_context(tmp_path / "diff-fences.py")
+    _add_diff(ctx)
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_text(
+        _make_report(
+            view_results=reduction.results,
+            show_diffs=True,
+        )
+    )
+
+    assert " diff - start " in output
+    assert "--- old" in output
+    assert "+new" in output
+    assert " diff - end " in output
+
+
+def test_render_pipeline_apply_summary_markdown_reports_written_and_failed() -> None:
+    """Markdown apply summary should report written and failed counts together."""
+    output: str = render_pipeline_apply_summary_markdown(
+        command_path="topmark check",
+        written=2,
+        failed=1,
+    )
+
+    assert "✅ `topmark check`: applied changes to **2** file(s)." in output
+    assert "> ⚠️ `topmark check`: failed to write **1** file(s). See log for details." in output
+
+
+def test_render_pipeline_output_text_check_guidance_reports_update(
+    tmp_path: Path,
+) -> None:
+    """TEXT check guidance should distinguish update from insert intent."""
+    ctx: ProcessingContext = _make_context(tmp_path / "text-update.py")
+    ctx.status.header = HeaderStatus.DETECTED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_text(
+        _make_report(
+            view_results=reduction.results,
+        )
+    )
+
+    assert "to update the TopMark header in this file." in output
+    assert "to add a TopMark header to this file." not in output
+
+
+def test_render_pipeline_output_markdown_check_apply_mode_reports_write_skipped(
+    tmp_path: Path,
+) -> None:
+    """Markdown check apply-mode guidance should report defensive skipped writes."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "markdown-skipped.py",
+        apply_changes=True,
+    )
+    ctx.status.write = WriteStatus.SKIPPED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "write skipped" in output
+    assert "⚠️  Could not insert header (write skipped)." in output
+
+
+def test_render_pipeline_output_markdown_strip_apply_mode_reports_write_failed(
+    tmp_path: Path,
+) -> None:
+    """Markdown strip apply-mode guidance should report defensive failed writes."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "strip-failed.py",
+        pipeline_kind="strip",
+        apply_changes=True,
+    )
+    ctx.status.header = HeaderStatus.DETECTED
+    ctx.status.strip = StripStatus.READY
+    ctx.status.plan = PlanStatus.REMOVED
+    ctx.status.write = WriteStatus.FAILED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            pipeline_kind="strip",
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "write failed" in output
+    assert "❌ Could not strip header: write failed" in output
+
+
+def test_render_pipeline_output_text_strip_apply_mode_reports_write_failed(
+    tmp_path: Path,
+) -> None:
+    """TEXT strip apply-mode guidance should report defensive failed writes."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "strip-failed-text.py",
+        pipeline_kind="strip",
+        apply_changes=True,
+    )
+    ctx.status.header = HeaderStatus.DETECTED
+    ctx.status.strip = StripStatus.READY
+    ctx.status.plan = PlanStatus.REMOVED
+    ctx.status.write = WriteStatus.FAILED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_text(
+        _make_report(
+            pipeline_kind="strip",
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "write failed" in output
+    assert "❌ Could not strip header: write failed" in output
+
+
+def test_pipeline_check_guidance_rejects_missing_concrete_intent(
+    tmp_path: Path,
+) -> None:
+    """Check guidance should reject actionable snapshots without insert/update intent."""
+    ctx: ProcessingContext = _make_context(tmp_path / "invalid-check.py")
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+    result: ProcessingResult = _force_check_actionable_with_no_concrete_intent(
+        reduction.results[0],
+    )
+    report: PipelineCommandHumanReport = _make_report(view_results=[result])
+
+    with pytest.raises(TopmarkCliPipelineError, match="Unexpected intent none"):
+        render_pipeline_output_text(report)
+
+    with pytest.raises(TopmarkCliPipelineError, match="Unexpected intent none"):
+        render_pipeline_output_markdown(report)
+
+
+def test_pipeline_strip_guidance_rejects_non_strip_intent(
+    tmp_path: Path,
+) -> None:
+    """Strip guidance should reject actionable snapshots without strip intent."""
+    ctx: ProcessingContext = _make_context(tmp_path / "invalid-strip.py")
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+    result: ProcessingResult = _force_strip_actionable_with_insert_intent(
+        reduction.results[0],
+    )
+    report: PipelineCommandHumanReport = _make_report(
+        pipeline_kind="strip",
+        view_results=[result],
+    )
+
+    with pytest.raises(TopmarkCliPipelineError, match="Unexpected intent insert"):
+        render_pipeline_output_text(report)
+
+    with pytest.raises(TopmarkCliPipelineError, match="Unexpected intent insert"):
+        render_pipeline_output_markdown(report)
+
+
 def test_pipeline_renderers_reject_invalid_pipeline_kind(tmp_path: Path) -> None:
     """Both renderers should reject invalid pipeline kinds defensively."""
     ctx: ProcessingContext = _make_context(tmp_path / "invalid.py")
@@ -471,6 +872,156 @@ def test_pipeline_renderers_reject_invalid_pipeline_kind(tmp_path: Path) -> None
 
     with pytest.raises(RuntimeError, match="Invalid pipeline kind selected"):
         render_pipeline_output_markdown(report)
+
+
+def test_render_pipeline_output_markdown_apply_mode_reports_insert_success(
+    tmp_path: Path,
+) -> None:
+    """Markdown check apply-mode guidance should report successful insert writes."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "inserted.py",
+        apply_changes=True,
+    )
+    ctx.status.write = WriteStatus.WRITTEN
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "➕ Adding header in" in output
+    assert "inserted.py" in output
+
+
+def test_render_pipeline_output_markdown_strip_apply_mode_reports_success(
+    tmp_path: Path,
+) -> None:
+    """Markdown strip apply-mode guidance should report successful removals."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "stripped.py",
+        pipeline_kind="strip",
+        apply_changes=True,
+    )
+    ctx.status.header = HeaderStatus.DETECTED
+    ctx.status.strip = StripStatus.READY
+    ctx.status.plan = PlanStatus.REMOVED
+    ctx.status.write = WriteStatus.WRITTEN
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            pipeline_kind="strip",
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "🧹 Stripping header in" in output
+    assert "stripped.py" in output
+
+
+def test_render_pipeline_output_markdown_missing_file_omits_file_type_label(
+    tmp_path: Path,
+) -> None:
+    """Markdown file summaries should omit file-type labels for missing synthetic files."""
+    ctx: ProcessingContext = _make_context(tmp_path / "missing.py")
+    ctx.file_type = None
+    ctx.status.fs = FsStatus.NOT_FOUND
+    ctx.status.header = HeaderStatus.PENDING
+    ctx.status.comparison = ComparisonStatus.SKIPPED
+    ctx.status.plan = PlanStatus.SKIPPED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            view_results=reduction.results,
+            report_scope=ReportScope.ALL,
+        )
+    )
+
+    assert "missing.py` - `" in output
+    assert "missing.py` (" not in output
+
+
+def test_render_pipeline_output_markdown_per_file_omits_empty_diff_block(
+    tmp_path: Path,
+) -> None:
+    """Markdown per-file output should not add a fenced block for an empty retained diff."""
+    ctx: ProcessingContext = _make_context(tmp_path / "empty-diff.py")
+    ctx.status.patch = PatchStatus.GENERATED
+    ctx.views.diff = DiffView(text="")
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_markdown(
+        _make_report(
+            view_results=reduction.results,
+            show_diffs=True,
+        )
+    )
+
+    assert "empty-diff.py" in output
+    assert "```diff" not in output
+
+
+def test_render_pipeline_apply_summary_markdown_reports_written_without_failures() -> None:
+    """Markdown apply summary should omit warning block when all writes succeeded."""
+    output: str = render_pipeline_apply_summary_markdown(
+        command_path="topmark check",
+        written=3,
+        failed=0,
+    )
+
+    assert "applied changes to **3** file(s)" in output
+    assert "failed to write" not in output
+
+
+def test_render_pipeline_diffs_helpers_return_empty_for_results_without_patches(
+    tmp_path: Path,
+) -> None:
+    """Standalone diff renderers should return an empty payload when no patch renders."""
+    from topmark.presentation.markdown.pipeline import render_pipeline_diffs_markdown
+    from topmark.presentation.text.pipeline import render_pipeline_diffs_text
+
+    ctx: ProcessingContext = _make_context(tmp_path / "no-patch.py")
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    assert render_pipeline_diffs_markdown(results=reduction.results) == ""
+    assert render_pipeline_diffs_text(results=reduction.results, styled=False) == ""
+
+
+def test_render_pipeline_output_text_strip_apply_mode_reports_write_skipped(
+    tmp_path: Path,
+) -> None:
+    """TEXT strip apply-mode guidance should report defensive skipped writes."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "strip-skipped-text.py",
+        pipeline_kind="strip",
+        apply_changes=True,
+    )
+    ctx.status.header = HeaderStatus.DETECTED
+    ctx.status.strip = StripStatus.READY
+    ctx.status.plan = PlanStatus.REMOVED
+    ctx.status.write = WriteStatus.SKIPPED
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_text(
+        _make_report(
+            pipeline_kind="strip",
+            view_results=reduction.results,
+            apply_changes=True,
+        )
+    )
+
+    assert "write was skipped" in output
+    assert "⚠️  Could not strip header (write skipped)." in output
 
 
 @pytest.mark.parametrize(

--- a/tests/presentation/test_probe_rendering.py
+++ b/tests/presentation/test_probe_rendering.py
@@ -1,0 +1,397 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_probe_rendering.py
+#   file_relpath : tests/presentation/test_probe_rendering.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Tests for human-facing probe presentation renderers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.helpers.pipeline import make_pipeline_context
+from topmark.config.io.deserializers import mutable_config_from_defaults
+from topmark.diagnostic.model import Diagnostic
+from topmark.diagnostic.model import DiagnosticLevel
+from topmark.pipeline.reduction import reduce_processing_contexts
+from topmark.pipeline.result import ProbeCandidateSnapshot
+from topmark.pipeline.result import ProbeMatchSnapshot
+from topmark.presentation.markdown.probe import render_probe_output_markdown
+from topmark.presentation.shared.pipeline import ProbeCommandHumanReport
+from topmark.presentation.shared.probe import format_probe_match_signals
+from topmark.presentation.text.probe import render_probe_output_text
+from topmark.resolution.probe import ResolutionProbeCandidate
+from topmark.resolution.probe import ResolutionProbeMatchSignals
+from topmark.resolution.probe import ResolutionProbeReason
+from topmark.resolution.probe import ResolutionProbeResult
+from topmark.resolution.probe import ResolutionProbeSelection
+from topmark.resolution.probe import ResolutionProbeStatus
+from topmark.runtime.model import RunOptions
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from topmark.config.model import FrozenConfig
+    from topmark.pipeline.context.model import ProcessingContext
+    from topmark.pipeline.reduction import ProcessingReduction
+    from topmark.pipeline.result import ProcessingResult
+
+
+def _candidate(
+    *,
+    qualified_key: str = "topmark:python",
+    local_key: str = "python",
+    score: int = 10,
+    selected: bool = True,
+    rank: int = 1,
+    content_error: str | None = None,
+) -> ResolutionProbeCandidate:
+    """Return a deterministic probe candidate."""
+    return ResolutionProbeCandidate(
+        qualified_key=qualified_key,
+        namespace="topmark",
+        local_key=local_key,
+        score=score,
+        selected=selected,
+        tie_break_rank=rank,
+        match=ResolutionProbeMatchSignals(
+            extension=True,
+            filename=False,
+            pattern=False,
+            content_probe_allowed=True,
+            content_match=content_error is None,
+            content_error=content_error,
+        ),
+    )
+
+
+def _selection(
+    *,
+    qualified_key: str = "topmark:python",
+    local_key: str = "python",
+    score: int | None = 10,
+) -> ResolutionProbeSelection:
+    """Return a deterministic probe selection."""
+    return ResolutionProbeSelection(
+        qualified_key=qualified_key,
+        namespace="topmark",
+        local_key=local_key,
+        score=score,
+    )
+
+
+def _processor_selection() -> ResolutionProbeSelection:
+    """Return a deterministic processor selection."""
+    return _selection(
+        qualified_key="topmark:pound",
+        local_key="pound",
+        score=None,
+    )
+
+
+def _probe_result(
+    path: Path,
+    *,
+    status: ResolutionProbeStatus = ResolutionProbeStatus.RESOLVED,
+    reason: ResolutionProbeReason = ResolutionProbeReason.SELECTED_HIGHEST_SCORE,
+    candidates: tuple[ResolutionProbeCandidate, ...] | None = None,
+    selected_file_type: ResolutionProbeSelection | None = None,
+    selected_processor: ResolutionProbeSelection | None = None,
+    use_default_file_type: bool = True,
+    use_default_processor: bool = True,
+) -> ResolutionProbeResult:
+    """Return a deterministic resolver probe result."""
+    return ResolutionProbeResult(
+        path=path,
+        status=status,
+        reason=reason,
+        candidates=candidates if candidates is not None else (_candidate(),),
+        selected_file_type=_selection()
+        if selected_file_type is None and use_default_file_type
+        else selected_file_type,
+        selected_processor=_processor_selection()
+        if selected_processor is None and use_default_processor
+        else selected_processor,
+    )
+
+
+def _probe_context(
+    path: Path,
+    *,
+    probe: ResolutionProbeResult | None,
+) -> ProcessingContext:
+    """Create a context reduced as a probe processing result."""
+    cfg: FrozenConfig = mutable_config_from_defaults().freeze()
+    ctx: ProcessingContext = make_pipeline_context(path, cfg)
+    ctx.run_options = RunOptions(pipeline_kind="probe")
+    ctx.resolution_probe = probe
+    return ctx
+
+
+def _result(ctx: ProcessingContext) -> ProcessingResult:
+    """Reduce one probe context to a durable processing result."""
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+    return reduction.results[0]
+
+
+def _report(
+    *,
+    view_results: Sequence[ProcessingResult],
+    verbosity_level: int,
+) -> ProbeCommandHumanReport:
+    """Build a shared probe presentation report."""
+    return ProbeCommandHumanReport(
+        verbosity_level=verbosity_level,
+        styled=False,
+        pipeline_kind="probe",
+        file_list_total=len(view_results),
+        view_results=view_results,
+    )
+
+
+def test_shared_probe_match_signal_formatter_includes_content_errors() -> None:
+    """Shared probe helper should keep TEXT and Markdown match signals consistent."""
+    candidate = ProbeCandidateSnapshot(
+        qualified_key="topmark:xml",
+        namespace="topmark",
+        local_key="xml",
+        score=7,
+        selected=False,
+        tie_break_rank=2,
+        match=ProbeMatchSnapshot(
+            extension=False,
+            filename=True,
+            pattern=True,
+            content_probe_allowed=False,
+            content_match=False,
+            content_error="UnicodeDecodeError",
+        ),
+    )
+
+    assert format_probe_match_signals(candidate) == (
+        "extension=false filename=true pattern=true content_probe=false "
+        "content_match=false content_error=UnicodeDecodeError"
+    )
+
+
+def test_render_probe_output_markdown_includes_missing_probe_sections(tmp_path: Path) -> None:
+    """Markdown probe output should make missing durable probe results explicit."""
+    result: ProcessingResult = _result(_probe_context(tmp_path / "missing.py", probe=None))
+
+    output: str = render_probe_output_markdown(
+        _report(view_results=[result], verbosity_level=0),
+    )
+
+    assert "# TopMark Resolution Probe Results" in output
+    assert "Probing **1** file(s)." in output
+    assert "## Files" in output
+    assert "### `" in output
+    assert "- **Status:** `probe-missing`" in output
+    assert "no resolution probe result was recorded" in output
+
+
+def test_render_probe_output_markdown_filtered_probe_omits_candidate_table(
+    tmp_path: Path,
+) -> None:
+    """Markdown filtered probe output should render `<none>` selections without a table."""
+    probe: ResolutionProbeResult = _probe_result(
+        tmp_path / "ignored.py",
+        status=ResolutionProbeStatus.FILTERED,
+        reason=ResolutionProbeReason.EXCLUDED_BY_PATH_FILTER,
+        candidates=(),
+        selected_file_type=None,
+        selected_processor=None,
+        use_default_file_type=False,
+        use_default_processor=False,
+    )
+    result: ProcessingResult = _result(_probe_context(tmp_path / "ignored.py", probe=probe))
+
+    output: str = render_probe_output_markdown(
+        _report(view_results=[result], verbosity_level=0),
+    )
+
+    assert "- **Status:** `filtered`" in output
+    assert "- **Reason:** `excluded_by_path_filter`" in output
+    assert "- **Selected file type:** `<none>`" in output
+    assert "- **Selected processor:** `<none>`" in output
+    assert "- **Candidates:** 0" in output
+    assert "#### Candidates" not in output
+
+
+def test_render_probe_output_markdown_renders_diagnostics_and_candidates(
+    tmp_path: Path,
+) -> None:
+    """Markdown probe output should include diagnostics and candidate match signals."""
+    probe: ResolutionProbeResult = _probe_result(
+        tmp_path / "demo.xml",
+        candidates=(
+            _candidate(
+                qualified_key="topmark:xml",
+                local_key="xml",
+                content_error="UnicodeDecodeError",
+            ),
+        ),
+        selected_file_type=_selection(
+            qualified_key="topmark:xml",
+            local_key="xml",
+            score=10,
+        ),
+    )
+    ctx: ProcessingContext = _probe_context(tmp_path / "demo.xml", probe=probe)
+    ctx.diagnostics.add(
+        Diagnostic(level=DiagnosticLevel.WARNING, message="content probe fell back"),
+    )
+    result: ProcessingResult = _result(ctx)
+
+    output: str = render_probe_output_markdown(
+        _report(view_results=[result], verbosity_level=0),
+    )
+
+    assert "#### Diagnostics" in output
+    assert "**[warning]** content probe fell back" in output
+    assert "#### Candidates" in output
+    assert "| Rank" in output
+    assert "| File Type" in output
+    assert "| Match Signals" in output
+    assert "`topmark:xml`" in output
+    assert "content_error=UnicodeDecodeError" in output
+
+
+def test_render_probe_output_text_reports_missing_probe_results(tmp_path: Path) -> None:
+    """TEXT probe output should make missing durable probe results explicit."""
+    result: ProcessingResult = _result(_probe_context(tmp_path / "missing.py", probe=None))
+
+    output: str = render_probe_output_text(
+        _report(view_results=[result], verbosity_level=0),
+    )
+
+    assert "missing.py:" in output
+    assert "probe-missing" in output
+    assert "no resolution probe result was recorded" in output
+
+
+def test_render_probe_output_text_verbose_filtered_probe_has_none_selections(
+    tmp_path: Path,
+) -> None:
+    """Verbose TEXT filtered output should include `<none>` selected details."""
+    probe: ResolutionProbeResult = _probe_result(
+        tmp_path / "filtered.py",
+        status=ResolutionProbeStatus.FILTERED,
+        reason=ResolutionProbeReason.EXCLUDED_BY_DISCOVERY_FILTER,
+        candidates=(),
+        selected_file_type=None,
+        selected_processor=None,
+        use_default_file_type=False,
+        use_default_processor=False,
+    )
+    result: ProcessingResult = _result(_probe_context(tmp_path / "filtered.py", probe=probe))
+
+    output: str = render_probe_output_text(
+        _report(view_results=[result], verbosity_level=1),
+    )
+
+    assert "filtered.py:" in output
+    assert "<filtered>" in output
+    assert "selected file type: <none>" in output
+    assert "selected processor: <none>" in output
+
+
+def test_render_probe_output_text_compact_filtered_probe_uses_filtered_label(
+    tmp_path: Path,
+) -> None:
+    """Compact TEXT probe output should distinguish filtered files from unknown files."""
+    probe: ResolutionProbeResult = _probe_result(
+        tmp_path / "ignored.py",
+        status=ResolutionProbeStatus.FILTERED,
+        reason=ResolutionProbeReason.EXCLUDED_BY_FILE_TYPE_FILTER,
+        candidates=(),
+        selected_file_type=None,
+        selected_processor=None,
+        use_default_file_type=False,
+        use_default_processor=False,
+    )
+    result: ProcessingResult = _result(_probe_context(tmp_path / "ignored.py", probe=probe))
+
+    output: str = render_probe_output_text(
+        _report(view_results=[result], verbosity_level=0),
+    )
+
+    assert "TopMark Resolution Probe Results" not in output
+    assert "ignored.py:" in output
+    assert "<filtered>" in output
+    assert "filtered: excluded_by_file_type_filter" in output
+
+
+def test_render_probe_output_text_verbose_no_processor_probe_has_none_processor(
+    tmp_path: Path,
+) -> None:
+    """Verbose TEXT probe output should report unbound selections without candidates."""
+    probe: ResolutionProbeResult = _probe_result(
+        tmp_path / "unbound.custom",
+        status=ResolutionProbeStatus.NO_PROCESSOR,
+        reason=ResolutionProbeReason.SELECTED_FILE_TYPE_HAS_NO_BOUND_PROCESSOR,
+        candidates=(),
+        selected_file_type=_selection(
+            qualified_key="topmark:custom",
+            local_key="custom",
+            score=None,
+        ),
+        selected_processor=None,
+        use_default_processor=False,
+    )
+    result: ProcessingResult = _result(_probe_context(tmp_path / "unbound.custom", probe=probe))
+
+    output: str = render_probe_output_text(
+        _report(view_results=[result], verbosity_level=2),
+    )
+
+    assert "📋 TopMark Resolution Probe Results" in output
+    assert "unbound.custom:" in output
+    assert "no_processor: processor=<none>" in output
+    assert "selected file type: topmark:custom" in output
+    assert "selected processor: <none>" in output
+    assert "  candidates: 0" in output
+    assert "  candidates:\n" not in output
+
+
+def test_render_probe_output_text_verbose_renders_candidates_and_diagnostics(
+    tmp_path: Path,
+) -> None:
+    """Verbose TEXT probe output should include candidate details and diagnostics."""
+    probe: ResolutionProbeResult = _probe_result(
+        tmp_path / "demo.py",
+        candidates=(
+            _candidate(content_error="UnicodeDecodeError"),
+            _candidate(
+                qualified_key="topmark:text",
+                local_key="text",
+                score=1,
+                selected=False,
+                rank=2,
+            ),
+        ),
+    )
+    ctx: ProcessingContext = _probe_context(tmp_path / "demo.py", probe=probe)
+    ctx.diagnostics.add(
+        Diagnostic(level=DiagnosticLevel.ERROR, message="probe warning promoted"),
+    )
+    result: ProcessingResult = _result(ctx)
+
+    output: str = render_probe_output_text(
+        _report(view_results=[result], verbosity_level=2),
+    )
+
+    assert "demo.py:" in output
+    assert "resolved: processor=pound, score=10" in output
+    assert "  candidates:" in output
+    assert "1. topmark:python score=10 (selected)" in output
+    assert "2. topmark:text score=1" in output
+    assert "content_error=UnicodeDecodeError" in output
+    assert "ℹ️  Diagnostics: 1 error" in output
+    assert "[error] probe warning promoted" in output

--- a/tests/presentation/test_version_rendering.py
+++ b/tests/presentation/test_version_rendering.py
@@ -1,0 +1,138 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_version_rendering.py
+#   file_relpath : tests/presentation/test_version_rendering.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Version presentation rendering contract tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from topmark.cli.errors import TopmarkCliVersionConversionError
+from topmark.core.constants import TOPMARK_VERSION
+from topmark.presentation.markdown.version import render_version_footer_markdown
+from topmark.presentation.markdown.version import render_version_markdown
+from topmark.presentation.shared.version import VersionHumanReport
+from topmark.presentation.shared.version import make_version_human_report
+from topmark.presentation.text.version import render_version_text
+from topmark.utils import version as version_utils
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+def _version_report(
+    *,
+    version_text: str = "1.2.3",
+    version_format: str = "semver",
+    error: TopmarkCliVersionConversionError | None = None,
+    verbosity_level: int = 0,
+    styled: bool = False,
+) -> VersionHumanReport:
+    """Create a small version report for renderer tests."""
+    return VersionHumanReport(
+        version_text=version_text,
+        version_format=version_format,
+        error=error,
+        verbosity_level=verbosity_level,
+        styled=styled,
+    )
+
+
+def test_render_version_text_verbose_includes_heading_and_indented_version() -> None:
+    """Verbose TEXT output should label the version format."""
+    output: str = render_version_text(
+        _version_report(
+            version_text="2.0.0-rc.1",
+            version_format="semver",
+            verbosity_level=1,
+        )
+    )
+
+    assert output.splitlines() == [
+        "TopMark version (semver):",
+        "    2.0.0-rc.1",
+    ]
+
+
+def test_render_version_text_includes_conversion_warning() -> None:
+    """TEXT output should preserve fallback conversion warnings."""
+    output: str = render_version_text(
+        _version_report(
+            version_text="1.2.3.post1",
+            version_format="pep440",
+            error=TopmarkCliVersionConversionError(
+                "Post-releases are not valid SemVer: '1.2.3.post1'"
+            ),
+        )
+    )
+
+    assert output.splitlines() == [
+        "1.2.3.post1",
+        "Warning: Post-releases are not valid SemVer: '1.2.3.post1'",
+    ]
+
+
+def test_render_version_markdown_includes_conversion_warning() -> None:
+    """Markdown version output should expose fallback conversion warnings."""
+    output: str = render_version_markdown(
+        _version_report(
+            version_text="1.2.3.post1",
+            version_format="pep440",
+            error=TopmarkCliVersionConversionError(
+                "Post-releases are not valid SemVer: '1.2.3.post1'"
+            ),
+            verbosity_level=2,
+        )
+    )
+
+    assert "# TopMark Version" in output
+    assert "**Version format:** `pep440`" in output
+    assert "**Version:** `1.2.3.post1`" in output
+    assert "> **Warning:** Post-releases are not valid SemVer: '1.2.3.post1'" in output
+    assert output.endswith("\n")
+
+
+def test_render_version_footer_markdown_uses_runtime_version() -> None:
+    """Markdown footers should include the runtime TopMark version."""
+    assert render_version_footer_markdown() == f"---\n_Generated with TopMark v{TOPMARK_VERSION}_"
+
+
+def test_render_version_markdown_without_warning_omits_warning_block() -> None:
+    """Markdown version output should omit warning blocks when conversion succeeds."""
+    output: str = render_version_markdown(
+        _version_report(
+            version_text="1.2.3",
+            version_format="pep440",
+            error=None,
+        )
+    )
+
+    assert "**Version:** `1.2.3`" in output
+    assert "> **Warning:**" not in output
+
+
+def test_make_version_human_report_wraps_semver_conversion_errors(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Shared reports should convert SemVer failures to CLI presentation errors."""
+    monkeypatch.setattr(version_utils, "TOPMARK_VERSION", "1.2.3.post4")
+
+    report: VersionHumanReport = make_version_human_report(
+        semver=True,
+        verbosity_level=2,
+        styled=True,
+    )
+
+    assert report.version_text == "1.2.3.post4"
+    assert report.version_format == "pep440"
+    assert report.verbosity_level == 2
+    assert report.styled is True
+    assert isinstance(report.error, TopmarkCliVersionConversionError)
+    assert str(report.error) == "Post-releases are not valid SemVer: '1.2.3.post4'"

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -1,0 +1,117 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_version.py
+#   file_relpath : tests/utils/test_version.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Version utility contract tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from topmark.utils import version as version_utils
+from topmark.utils.version import ComputedVersion
+from topmark.utils.version import check_python_version
+from topmark.utils.version import compute_version_text
+from topmark.utils.version import convert_pep440_to_semver
+
+if TYPE_CHECKING:
+    from pytest import CaptureFixture
+    from pytest import MonkeyPatch
+
+
+@pytest.mark.parametrize(
+    ("pep440_version", "expected_semver"),
+    [
+        ("1.2.3", "1.2.3"),
+        ("1.2.3a4", "1.2.3-alpha.4"),
+        ("1.2.3b4", "1.2.3-beta.4"),
+        ("1.2.3rc4", "1.2.3-rc.4"),
+        ("1.2.3.dev4", "1.2.3-dev.4"),
+        ("1.2.3rc4.dev5", "1.2.3-rc.4.dev.5"),
+        ("1.2.3+gabc123", "1.2.3+gabc123"),
+        ("1.2.3rc4.dev5+gabc123", "1.2.3-rc.4.dev.5+gabc123"),
+    ],
+)
+def test_convert_pep440_to_semver_supported_forms(
+    pep440_version: str,
+    expected_semver: str,
+) -> None:
+    """PEP 440 versions emitted by TopMark should map predictably to SemVer."""
+    assert convert_pep440_to_semver(pep440_version) == expected_semver
+
+
+@pytest.mark.parametrize("pep440_version", ["not-a-version", "1.2.3.post4"])
+def test_convert_pep440_to_semver_rejects_unsupported_forms(pep440_version: str) -> None:
+    """Unsupported PEP 440 forms should fail instead of emitting invalid SemVer."""
+    with pytest.raises(ValueError, match="PEP 440|Post-releases"):
+        convert_pep440_to_semver(pep440_version)
+
+
+def test_compute_version_text_returns_pep440_by_default(monkeypatch: MonkeyPatch) -> None:
+    """Default version computation should expose the raw PEP 440 version."""
+    monkeypatch.setattr(version_utils, "TOPMARK_VERSION", "1.2.3rc1")
+
+    result: ComputedVersion = compute_version_text(semver=False)
+
+    assert result == ComputedVersion(
+        version_text="1.2.3rc1",
+        version_format="pep440",
+        error=None,
+    )
+
+
+def test_compute_version_text_returns_semver_when_requested(monkeypatch: MonkeyPatch) -> None:
+    """SemVer version computation should return converted text on success."""
+    monkeypatch.setattr(version_utils, "TOPMARK_VERSION", "1.2.3rc1.dev4+gabc123")
+
+    result: ComputedVersion = compute_version_text(semver=True)
+
+    assert result == ComputedVersion(
+        version_text="1.2.3-rc.1.dev.4+gabc123",
+        version_format="semver",
+        error=None,
+    )
+
+
+def test_compute_version_text_falls_back_to_pep440_when_semver_fails(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """SemVer conversion failures should retain the PEP 440 version with an error."""
+    monkeypatch.setattr(version_utils, "TOPMARK_VERSION", "1.2.3.post4")
+
+    result: ComputedVersion = compute_version_text(semver=True)
+
+    assert result.version_text == "1.2.3.post4"
+    assert result.version_format == "pep440"
+    assert isinstance(result.error, ValueError)
+    assert str(result.error) == "Post-releases are not valid SemVer: '1.2.3.post4'"
+
+
+def test_check_python_version_accepts_supported_runtime() -> None:
+    """Supported Python runtimes should pass without output."""
+    check_python_version()
+
+
+def test_check_python_version_exits_for_unsupported_runtime(
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    """Unsupported Python runtimes should print a clear stderr error and exit."""
+    monkeypatch.setattr(version_utils.sys, "version_info", (3, 9, 0))
+    monkeypatch.setattr(version_utils.sys, "version", "3.9.0 (test build)")
+
+    with pytest.raises(SystemExit) as exc_info:
+        check_python_version()
+
+    assert exc_info.value.code == 1
+    captured: str = capsys.readouterr().err
+    assert "requires Python 3.10 or higher" in captured
+    assert "Current version: 3.9.0" in captured


### PR DESCRIPTION
## Summary

- expanded `topmark.presentation` regression coverage across TEXT, Markdown, and shared rendering helpers
- added focused contract tests for pipeline guidance, config output, probe output, version output, diagnostic rendering, and unified diff presentation
- added durable `ProcessingResult`-oriented rendering tests for edge-case check/strip guidance paths
- extracted shared probe match-signal formatting into `topmark.presentation.shared.probe`
- improved adjacent coverage outside `topmark.presentation`, including:
  - `topmark.cli.rendering.unified_diff`
  - `topmark.diagnostic.model`
  - `topmark.utils.version`

## Coverage impact

This PR materially improves presentation-layer coverage for issue #204:

- `presentation/markdown/pipeline.py`: 84.7% → 99.3%
- `presentation/text/pipeline.py`: 90.2% → 97.9%
- `presentation/markdown/config.py`: 70.5% → 98.7%
- `presentation/text/config.py`: 82.5% → 100.0%
- `presentation/markdown/probe.py`: 76.9% → 98.6%
- `presentation/text/probe.py`: 90.9% → 100.0%
- `presentation/markdown/version.py`: 84.6% → 100.0%
- `presentation/text/version.py`: 77.3% → 100.0%
- `presentation/shared/diagnostic.py`: 86.5% → 100.0%
- `presentation/markdown/utils.py`: 78.8% → 100.0%

Adjacent improvements:

- `cli/rendering/unified_diff.py`: 84.1% → 100.0%
- `diagnostic/model.py`: 92.6% → 100.0%
- `utils/version.py`: 78.9% → 100.0%

Overall coverage increased from 90.7% to 91.9%.

## Validation

- `pytest tests/presentation -q`
- targeted diagnostic, version, and unified-diff tests
- `ruff check`
- `pyright --pythonversion 3.10`
- `pyright --pythonversion 3.13`

Closes #204.