### PR TITLE
Document machine-output compatibility policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,6 +407,10 @@ ______________________________________________________________________
   execution serial within individual jobs while using job-level parallelism.
 - Updated contributor and CI guidance to recommend the local pre-PR validation gate, document its
   relationship to GitHub CI, and cross-reference the relevant validation workflow documentation.
+- Documented the machine-readable JSON/NDJSON compatibility and evolution policy, including stable
+  compatibility guarantees, additive minor-release evolution, breaking-change boundaries,
+  unknown-field handling, JSON versus NDJSON operational differences, and the current absence of a
+  separate `schema_version` field.
 
 ### Internal - Unreleased
 
@@ -533,6 +537,8 @@ ______________________________________________________________________
 - Standardized Makefile `.PHONY` declarations by colocating them with their associated targets,
   reducing maintenance overhead for predominantly phony developer targets and aligning with the
   project's `mbake` formatting conventions.
+- Added focused machine-output contract tests covering documented JSON/NDJSON compatibility
+  guarantees, including stable envelope structure and additive-schema compatibility expectations.
 
 ### Notes - Unreleased
 

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -13,7 +13,7 @@ topmark:header:end
 # Machine-readable formats
 
 This page documents TopMark's stable **machine-readable output conventions** across commands for the
-1.x line.
+current major release line.
 
 {% include-markdown "\_snippets/terminology.md" %}
 
@@ -89,6 +89,30 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
+## Compatibility boundary
+
+The machine-readable compatibility contract is documented in
+[Machine-readable output](../usage/machine-output.md#compatibility-and-evolution-policy). This
+developer page explains the implementation conventions behind that contract, but it does not freeze
+undocumented serializer internals.
+
+For the current major release line:
+
+- documented JSON envelope keys and NDJSON record-envelope fields are stable;
+- documented payload fields keep their type and meaning;
+- additional fields, record kinds, diagnostics, and enum-like string values are additive
+  minor-release evolution;
+- consumers are expected to ignore unknown fields and skip unknown NDJSON `kind` values;
+- removals, renames, type changes, semantic repurposing, or baseline envelope-shape changes require
+  a major release or an explicit breaking-change signal.
+
+There is no dedicated `schema_version` field today. Shared `meta.version` reports the TopMark
+package version, not a separate schema version. If schema-level negotiation becomes necessary later,
+adding a `schema_version` field is additive; consumers should already tolerate it as an unknown
+field.
+
+______________________________________________________________________
+
 ## Machine-stable guarantees
 
 The `json` and `ndjson` formats are designed for CI, scripting, and programmatic use.
@@ -102,7 +126,7 @@ Stability guarantees:
   processing paths, not a guarantee that original invocation spellings are preserved.
 - Header metadata path fields describe the selected processing target and are serialized with POSIX
   `/` separators when TopMark renders headers.
-- New fields may be added over time as additive 1.x evolution.
+- New fields may be added over time as additive current-major evolution.
 - Existing fields are not removed or renamed without a breaking-change signal.
 - Resolved file type identities are emitted using canonical qualified keys when available.
 - Configuration provenance payloads use configuration-source identities; runtime processing payloads
@@ -224,7 +248,7 @@ ______________________________________________________________________
 
 ## NDJSON envelope contract
 
-Each NDJSON line is a JSON object with a stable 1.x envelope:
+Each NDJSON line is a JSON object with a stable current-major envelope:
 
 ```jsonc
 {"kind": "<kind>", "meta": { ... }, "<kind>": { ... } }
@@ -400,9 +424,9 @@ Diagnostics emitted in machine-readable output represent the flattened compatibi
 from staged config-validation logs. Internally, these diagnostics may originate from TOML-source,
 merged-config, or runtime applicability validation.
 
-For the stable 1.x line, this flattened compatibility view is the machine-readable compatibility
-contract for configuration-loading diagnostics. Machine-readable output intentionally does **not**
-serialize stage-local validation structure; the emitted diagnostic entry shape remains
+For the stable current-major line, this flattened compatibility view is the machine-readable
+compatibility contract for configuration-loading diagnostics. Machine-readable output intentionally
+does **not** serialize stage-local validation structure; the emitted diagnostic entry shape remains
 `{level, message}`.
 
 Diagnostics may include warnings for unknown, malformed, or ambiguous file type identifiers detected
@@ -632,9 +656,9 @@ Example [`config check`](../usage/commands/config/check.md) NDJSON prefix:
 }}
 ```
 
-For the stable 1.x line, this boundary is intentional: staged validation remains an internal
-representation, while machine-readable output exposes the flattened compatibility diagnostics
-contract.
+For the stable current-major line, this boundary is intentional: staged validation remains an
+internal representation, while machine-readable output exposes the flattened compatibility
+diagnostics contract.
 
 For [`config dump --show-layers`](../usage/commands/config/dump.md), machine-readable output
 preserves the same logical ordering as the human-facing layered export:

--- a/docs/usage/machine-output.md
+++ b/docs/usage/machine-output.md
@@ -13,7 +13,7 @@ topmark:header:end
 # Machine-readable output
 
 This document describes the stable machine-readable JSON and NDJSON formats emitted by TopMark for
-the 1.x line.
+the current major release line.
 
 It is intended for integrators and tooling authors who consume TopMark programmatically.
 
@@ -76,6 +76,70 @@ Notes:
   render unified diffs for human review. JSON and NDJSON expose structured diff payloads in detail
   mode instead of treating unified diff blocks as normal report text. Display-path labels remain a
   human presentation concern and are not part of the JSON/NDJSON machine-readable path contract.
+
+______________________________________________________________________
+
+## Compatibility and evolution policy
+
+TopMark treats documented `json` and `ndjson` output as a public machine-readable contract for the
+current major release line. The contract is intentionally narrower than the implementation:
+consumers may rely on the fields and meanings documented on this page, but should not treat
+incidental object ordering, undocumented helper fields, or internal Python module layout as stable.
+
+Stable contract surface:
+
+- `json` output is one complete JSON document per invocation with a top-level `meta` object and
+  command-specific documented payload keys.
+- `ndjson` output is a sequence of newline-delimited JSON objects. Each record has `kind`, `meta`,
+  and a payload stored under the key named by `kind`.
+- Baseline `meta` fields are `tool`, `version`, and `platform`. Some command families also emit
+  `detail_level` to describe a machine-facing projection such as `brief` or `long`.
+- Documented command-specific payload fields, path serialization rules, diagnostics shapes, summary
+  rows, result payloads, probe payloads, registry identities, version payloads, and diff payloads
+  are stable for the current major release line.
+- String values documented as identifiers, record kinds, domains, detail levels, outcomes,
+  diagnostic levels, and canonical registry keys are stable once emitted, but new values may be
+  added in minor releases.
+
+Allowed additive evolution in minor releases:
+
+- adding new fields to existing JSON objects or NDJSON payloads;
+- adding new command-specific top-level JSON payload keys where the existing documented keys keep
+  their meanings;
+- adding new NDJSON record kinds;
+- adding new enum-like string values such as `kind`, `domain`, diagnostic levels, outcomes, reasons,
+  file-type identifiers, or registry identifiers;
+- adding new diagnostics, warnings, or partial-result records for situations that were previously
+  less precisely reported.
+
+Breaking changes that require a major release or an explicit breaking-change signal include:
+
+- removing or renaming documented fields;
+- changing the type or meaning of a documented field;
+- moving a documented payload to a different container key;
+- changing the baseline NDJSON envelope shape;
+- changing documented path serialization semantics for machine-readable path fields;
+- reusing an existing `kind`, `domain`, or documented enum-like string value for a different
+  meaning;
+- changing whether a documented result, diagnostic, summary, or diff payload is emitted for an
+  already documented command mode.
+
+Consumer guidance:
+
+- Ignore unknown fields.
+- In NDJSON, skip or log unknown `kind` values unless the consumer explicitly needs them.
+- In JSON, read documented top-level keys and tolerate additional top-level keys.
+- Treat enum-like string values as open sets unless this page explicitly says otherwise.
+- Check the process exit code separately from parsing machine-readable payloads.
+- Treat diagnostics as advisory structured records that may accompany partial results. A command can
+  emit valid configuration diagnostics even when validation prevents normal `probes`, `results`, or
+  `summary` payloads from being emitted.
+
+TopMark does not currently emit a separate `schema_version` field in machine-readable output. The
+package `meta.version`, the documented command shape, and the current major release line together
+define the compatibility boundary. A future `schema_version` field may be added as an additive field
+if TopMark needs schema-level negotiation independent from the package version. Consumers should
+therefore ignore an unknown `schema_version` field if one appears in a future minor release.
 
 ______________________________________________________________________
 
@@ -186,8 +250,8 @@ package-local schema modules such as:
 
 ### Naming conventions
 
-The machine-readable output naming audit for the stable 1.x line adopts the following conventions
-across domains:
+The machine-readable output naming audit for the stable current major line adopts the following
+conventions across domains:
 
 - Shared envelope and metadata keys are owned by
   \[`topmark.core.machine.schemas`\][topmark.core.machine.schemas].
@@ -205,7 +269,7 @@ across domains:
   - `detail_level` is emitted only by command families whose machine-readable output exposes a brief
     vs long projection
 
-These conventions are part of the stable 1.x machine-readable output contract.
+These conventions are part of the stable current-major machine-readable output contract.
 
 ### File type identity fields
 
@@ -789,9 +853,9 @@ These diagnostics may originate from staged config-loading validation logs for:
 - merged-config diagnostics
 - runtime applicability diagnostics
 
-For the stable 1.x line, the machine-readable contract for configuration-loading diagnostics is this
-flattened compatibility view. Stage-local validation structure remains internal and is not
-serialized directly.
+For the stable current major line, the machine-readable contract for configuration-loading
+diagnostics is this flattened compatibility view. Stage-local validation structure remains internal
+and is not serialized directly.
 
 JSON shape:
 
@@ -806,7 +870,7 @@ JSON shape:
 ```
 
 The individual diagnostic entry shape is intentionally fixed at `{level, message}` for the stable
-1.x line.
+current major line.
 
 Example JSON diagnostics payload:
 
@@ -1024,8 +1088,9 @@ from TOML source configuration (`[config].strict`) and may be overridden by CLI 
 strictness is evaluated across staged config-loading validation, while `config_diagnostics` remains
 the flattened compatibility view exposed in machine-readable output.
 
-For the stable 1.x line, this is the explicit contract decision: staged config-loading validation
-remains internal, and machine-readable output serializes only the flattened compatibility view.
+For the stable current major line, this is the explicit contract decision: staged config-loading
+validation remains internal, and machine-readable output serializes only the flattened compatibility
+view.
 
 Machine-readable output for [`config check`](../usage/commands/config/check.md) is unaffected by
 TEXT verbosity or quiet mode.
@@ -1299,7 +1364,8 @@ ______________________________________________________________________
 ## Backwards compatibility and evolution
 
 TopMark's machine-readable output schema is part of its stable integration surface. For the stable
-1.x line, documented JSON and NDJSON shapes are treated as machine-readable compatibility contracts.
+current major line, documented JSON and NDJSON shapes are treated as machine-readable compatibility
+contracts.
 
 Consumers should:
 
@@ -1308,16 +1374,16 @@ Consumers should:
 - Rely on `kind` for NDJSON.
 - Treat unknown fields as optional/ignorable.
 - Prefer parsing and schema-tolerant logic over strict string matching.
-- Assume additive fields may appear over time within the 1.x compatibility model.
+- Assume additive fields may appear over time within the current-major compatibility model.
 - Prefer canonical identity fields such as `qualified_key`, `file_type_key`, and `processor_key`
   over display-oriented names.
 - Treat filesystem `path`, `discovery_anchor`, `origin`, and `scope_root` fields as serialized
   processing/provenance paths, not as lossless echoes of the original invocation spelling.
 
 Consumers should not infer the original workspace-root discovery-anchor spelling from
-machine-readable payloads. The stable 1.x contract serializes the resolved discovery anchor in
-`config_provenance.discovery_anchor` when provenance is requested, plus discovered configuration
-sources and scope roots where applicable.
+machine-readable payloads. The stable current-major contract serializes the resolved discovery
+anchor in `config_provenance.discovery_anchor` when provenance is requested, plus discovered
+configuration sources and scope roots where applicable.
 
 Breaking machine-readable output changes should be signaled through Conventional Commits using the
 `!` marker and documented in the changelog.

--- a/tests/cli/machine/test_contract_policy.py
+++ b/tests/cli/machine/test_contract_policy.py
@@ -1,0 +1,183 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_contract_policy.py
+#   file_relpath : tests/cli/machine/test_contract_policy.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""Cross-command machine-output compatibility policy tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.cli.conftest import assert_SUCCESS
+from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
+from tests.cli.conftest import run_cli
+from tests.cli.conftest import run_cli_in
+from tests.helpers.json import parse_json_object
+from tests.helpers.ndjson import assert_ndjson_meta
+from tests.helpers.ndjson import parse_ndjson_records
+from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
+from topmark.core.formats import OutputFormat
+from topmark.core.machine.schemas import MachineKey
+from topmark.core.typing_guards import as_object_dict
+from topmark.core.typing_guards import is_mapping
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(
+            [
+                CliCmd.VERSION,
+                CliOpt.OUTPUT_FORMAT,
+                OutputFormat.JSON.value,
+            ],
+            id="version",
+        ),
+        pytest.param(
+            [
+                CliCmd.CONFIG,
+                CliCmd.CONFIG_DEFAULTS,
+                CliOpt.OUTPUT_FORMAT,
+                OutputFormat.JSON.value,
+            ],
+            id="config-defaults",
+        ),
+        pytest.param(
+            [
+                CliCmd.REGISTRY,
+                CliCmd.REGISTRY_FILETYPES,
+                CliOpt.OUTPUT_FORMAT,
+                OutputFormat.JSON.value,
+            ],
+            id="registry-filetypes",
+        ),
+    ],
+)
+def test_json_outputs_keep_baseline_meta_contract(args: list[str]) -> None:
+    """Representative JSON commands should expose the documented baseline metadata."""
+    result: Result = run_cli(args)
+    assert_SUCCESS(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    meta_obj: object | None = payload.get(MachineKey.META.value)
+    assert is_mapping(meta_obj)
+
+    meta: dict[str, object] = as_object_dict(meta_obj)
+    assert isinstance(meta.get("tool"), str)
+    assert isinstance(meta.get("version"), str)
+    assert isinstance(meta.get("platform"), str)
+
+
+def test_processing_json_summary_keeps_baseline_meta_contract(tmp_path: Path) -> None:
+    """Processing JSON summary output should expose the documented baseline metadata."""
+    source: Path = tmp_path / "example.py"
+    source.write_text('print("hello")\n', encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+            source.name,
+        ],
+    )
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+
+    payload: dict[str, object] = parse_json_object(result.output)
+    meta_obj: object | None = payload.get(MachineKey.META.value)
+    assert is_mapping(meta_obj)
+
+    meta: dict[str, object] = as_object_dict(meta_obj)
+    assert isinstance(meta.get("tool"), str)
+    assert isinstance(meta.get("version"), str)
+    assert isinstance(meta.get("platform"), str)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(
+            [
+                CliCmd.VERSION,
+                CliOpt.OUTPUT_FORMAT,
+                OutputFormat.NDJSON.value,
+            ],
+            id="version",
+        ),
+        pytest.param(
+            [
+                CliCmd.CONFIG,
+                CliCmd.CONFIG_DEFAULTS,
+                CliOpt.OUTPUT_FORMAT,
+                OutputFormat.NDJSON.value,
+            ],
+            id="config-defaults",
+        ),
+        pytest.param(
+            [
+                CliCmd.REGISTRY,
+                CliCmd.REGISTRY_FILETYPES,
+                CliOpt.OUTPUT_FORMAT,
+                OutputFormat.NDJSON.value,
+            ],
+            id="registry-filetypes",
+        ),
+    ],
+)
+def test_ndjson_outputs_keep_kind_meta_and_payload_container_contract(args: list[str]) -> None:
+    """Representative NDJSON commands should keep the baseline record envelope."""
+    result: Result = run_cli(args)
+    assert_SUCCESS(result)
+
+    _assert_ndjson_record_envelopes(parse_ndjson_records(result.output))
+
+
+def test_processing_ndjson_summary_keeps_kind_meta_and_payload_container_contract(
+    tmp_path: Path,
+) -> None:
+    """Processing NDJSON summary output should keep the baseline record envelope."""
+    source: Path = tmp_path / "example.py"
+    source.write_text('print("hello")\n', encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.NDJSON.value,
+            source.name,
+        ],
+    )
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+
+    _assert_ndjson_record_envelopes(parse_ndjson_records(result.output))
+
+
+def _assert_ndjson_record_envelopes(records: list[dict[str, object]]) -> None:
+    """Assert the documented NDJSON `kind` + `meta` + payload-container shape."""
+    assert records
+    for record in records:
+        kind_obj: object | None = record.get(MachineKey.KIND.value)
+        assert isinstance(kind_obj, str)
+        assert_ndjson_meta(
+            record.get(MachineKey.META.value),
+            expected_detail_level="brief",
+        )
+        assert kind_obj in record


### PR DESCRIPTION
## Summary

- Documented the machine-readable JSON/NDJSON compatibility and evolution policy.
- Clarified stable versus command-specific machine-output fields, additive evolution rules, breaking-change boundaries, unknown-field handling, diagnostics, summaries, paths, diff records, and JSON versus NDJSON behavior.
- Added focused machine-output contract tests covering documented JSON/NDJSON compatibility guarantees.
- Updated the changelog under Documentation and Internal rather than Changed, since this PR documents and tests the existing contract rather than changing machine-output behavior.

## Validation

- `uv run pytest tests/cli/machine/test_contract_policy.py -q`
- `uv run ruff check tests/cli/machine/test_contract_policy.py`
- `uv run pyright --pythonversion 3.10 tests/cli/machine/test_contract_policy.py`
- `uv run pyright --pythonversion 3.13 tests/cli/machine/test_contract_policy.py`
- `uv run mdformat --check docs/usage/machine-output.md docs/dev/machine-formats.md CHANGELOG.md`

Closes #205.