### PR TITLE
Clarify stream-routing ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -411,6 +411,9 @@ ______________________________________________________________________
   compatibility guarantees, additive minor-release evolution, breaking-change boundaries,
   unknown-field handling, JSON versus NDJSON operational differences, and the current absence of a
   separate `schema_version` field.
+- Documented CLI stream-routing ownership, including STDOUT payload ownership, STDERR
+  diagnostics/signaling, machine-readable parseability, and human diff/content-to-STDOUT routing
+  behavior.
 
 ### Internal - Unreleased
 
@@ -539,6 +542,8 @@ ______________________________________________________________________
   project's `mbake` formatting conventions.
 - Added focused machine-output contract tests covering documented JSON/NDJSON compatibility
   guarantees, including stable envelope structure and additive-schema compatibility expectations.
+- Added CLI stream-routing contract tests and small command-layer stream-emission helpers clarifying
+  explicit STDOUT payload ownership for check/strip output.
 
 ### Notes - Unreleased
 

--- a/docs/dev/machine-formats.md
+++ b/docs/dev/machine-formats.md
@@ -72,6 +72,26 @@ Notes:
 - Markdown output is also independent from machine-readable formats and follows its own
   document-oriented contract.
 
+______________________________________________________________________
+
+## Stream ownership
+
+TopMark treats STDOUT as the primary payload stream. JSON and NDJSON output are emitted on STDOUT
+and must remain parseable without stripping banners, guidance, warnings, or other human-facing
+chatter. Commands route warnings and non-payload signaling to STDERR when those messages would
+otherwise pollute a machine payload.
+
+Human formats also use STDOUT for ordinary command payloads, such as TEXT/Markdown reports,
+configuration dumps, registry listings, and version information. Some human command modes reserve
+STDOUT for a different payload: `check --diff` and `strip --diff` emit unified diff text on STDOUT,
+and apply-mode content processing with `-` or `--write-mode=stdout` emits rewritten file content on
+STDOUT. In those modes, human reports, summaries, and guidance are routed to STDERR so the payload
+stream remains pipe-safe.
+
+Click parser errors are Click-owned and remain error-oriented. TopMark semantic diagnostics may be
+part of a requested human report when that report is the payload, but they must not be mixed into
+STDOUT for machine-readable payloads.
+
 This page describes the conventions shared across machine-readable formats.
 
 For the canonical field-level schema reference, see

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -275,6 +275,20 @@ contract.
 
 ______________________________________________________________________
 
+## STDOUT and STDERR
+
+STDOUT is the primary payload stream. Normal command payloads, including reports, configuration
+dumps, registry listings, version output, JSON, and NDJSON, are emitted on STDOUT. Diagnostics and
+signaling that should not be parsed as payload are emitted on STDERR.
+
+Machine-readable JSON and NDJSON keep STDOUT parseable. Warnings such as machine-summary diff
+suppression are therefore emitted on STDERR. For human `check --diff` / `strip --diff`, STDOUT is
+reserved for unified diff payloads and the human report is emitted on STDERR. For apply-mode content
+processing through STDIN or `--write-mode=stdout`, STDOUT is reserved for rewritten file content and
+human reports or summaries are emitted on STDERR.
+
+______________________________________________________________________
+
 ## File type filters
 
 {% include-markdown "\_snippets/file-type-identifiers.md" %}

--- a/src/topmark/cli/cmd_common.py
+++ b/src/topmark/cli/cmd_common.py
@@ -256,53 +256,54 @@ def exit_if_no_files(file_list: list[Path], *, console: ConsoleProtocol, styled:
     return False
 
 
-def maybe_route_console_to_stderr(
+def resolve_human_console(
     ctx: click.Context,
     *,
     run_options: RunOptions,
     enable_color: bool,
 ) -> ConsoleProtocol:
-    """Route human-facing console output to stderr when stdout is reserved.
+    """Return the console that should receive human-facing command output.
 
-    TopMark reserves STDOUT for machine-consumable payloads in these situations:
+    Most commands use the console initialized by `init_common_state()`, which
+    writes regular human output to STDOUT and diagnostics to STDERR. Some
+    pipeline invocations reserve STDOUT for a primary payload that must remain
+    pipe-safe:
 
-    - diff-producing human runs, where STDOUT carries unified diff output;
-    - content-on-STDIN mode (a lone `-` path) when ``--apply`` is set; and
-    - ``--write-mode=stdout`` with ``--apply``, where STDOUT carries rewritten
-        file content.
+    - unified diff output for diff-producing human runs;
+    - rewritten content produced from content-on-STDIN when ``--apply`` is set;
+    - rewritten content produced by ``--write-mode=stdout`` when ``--apply`` is set.
 
-    In these cases, the command must keep STDOUT clean for the payload stream so
-    that output can be piped safely. Human-facing output (summaries, warnings,
-    diagnostics) is therefore routed to STDERR.
-
-    The function updates the console stored on the shared typed CLI state when
-    rerouting is needed and returns the effective console instance.
+    When STDOUT is reserved for one of those payloads, this helper replaces the
+    shared human console with a STDERR-backed console. Command code should keep
+    any previously captured machine-output console unchanged so JSON and NDJSON
+    emitters can continue writing their payloads to STDOUT.
 
     Args:
-        ctx: Current Click context.
+        ctx: Current Click context carrying the shared typed CLI state.
         run_options: Invocation-wide runtime options for the current run.
         enable_color: Whether color output is enabled for this invocation.
 
     Returns:
-        The effective console instance to use for human-facing output.
+        The console to use for human-facing reports, summaries, warnings, and
+        diagnostics in the current command invocation.
     """
-    reserves_stdout_for_payload: bool = run_options.emit_diff or (
+    stdout_reserved_for_payload: bool = run_options.emit_diff or (
         bool(run_options.apply_changes)
         and (run_options.stdin_mode or run_options.output_target == OutputTarget.STDOUT)
     )
 
-    if reserves_stdout_for_payload:
-        console = Console(
-            enable_color=enable_color,
-            out=sys.stderr,
-            err=sys.stderr,
-        )
-        state: TopmarkCliState = get_cli_state(ctx)
-        state.console = console
-        return console
+    state: TopmarkCliState = get_cli_state(ctx)
+    if not stdout_reserved_for_payload:
+        # Use the console initialized by `init_common_state`.
+        return state.console
 
-    # Fall back to the console initialized by `init_common_state`.
-    return get_cli_state(ctx).console
+    console = Console(
+        enable_color=enable_color,
+        out=sys.stderr,
+        err=sys.stderr,
+    )
+    state.console = console
+    return console
 
 
 def maybe_exit_on_error(*, code: ExitCode | None, temp_path: Path | None) -> None:

--- a/src/topmark/cli/commands/check.py
+++ b/src/topmark/cli/commands/check.py
@@ -61,7 +61,7 @@ from topmark.cli.cmd_common import exit_for_config_validation_error
 from topmark.cli.cmd_common import exit_if_no_files
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
-from topmark.cli.cmd_common import maybe_route_console_to_stderr
+from topmark.cli.cmd_common import resolve_human_console
 from topmark.cli.emitters.machine import emit_processing_results_machine
 from topmark.cli.help import HelpExample
 from topmark.cli.help import render_examples_epilog
@@ -88,6 +88,7 @@ from topmark.cli.options import render_diff_options
 from topmark.cli.options import shared_policy_options
 from topmark.cli.state import TopmarkCliState
 from topmark.cli.state import bootstrap_cli_state
+from topmark.cli.streaming import emit_stdout_payload
 from topmark.cli.validators import apply_color_policy_for_output_format
 from topmark.cli.validators import validate_diff_apply_mutual_exclusion
 from topmark.cli.validators import validate_stdin_dash_requires_piped_input
@@ -425,7 +426,7 @@ def check_command(
     #
     # Console selection must happen after planning inputs because stdin mode affects routing.
     machine_console: ConsoleProtocol = state.console
-    console: ConsoleProtocol = maybe_route_console_to_stderr(
+    console: ConsoleProtocol = resolve_human_console(
         ctx,
         run_options=run_options,
         enable_color=enable_color,
@@ -565,8 +566,7 @@ def check_command(
             fmt=fmt,
         )
 
-        if output.stdout:
-            click.echo(output.stdout)
+        emit_stdout_payload(output.stdout)
 
         if (fmt == OutputFormat.TEXT and not state.quiet and output.stderr) or (
             fmt == OutputFormat.MARKDOWN and output.stderr

--- a/src/topmark/cli/commands/config_dump.py
+++ b/src/topmark/cli/commands/config_dump.py
@@ -33,7 +33,7 @@ import rich_click
 
 from topmark.cli.cmd_common import build_resolved_toml_sources_and_config_for_plan
 from topmark.cli.cmd_common import init_common_state
-from topmark.cli.cmd_common import maybe_route_console_to_stderr
+from topmark.cli.cmd_common import resolve_human_console
 from topmark.cli.emitters.machine import emit_config_machine
 from topmark.cli.help import HelpExample
 from topmark.cli.help import render_examples_epilog
@@ -276,16 +276,13 @@ def config_dump_command(
 
     logger.debug("run options: %s", run_options)
 
-    # Content-to-STDOUT modes: keep stdout clean for the rewritten file content.
+    # Resolve the console for human-facing output.
     #
-    # - STDIN content mode emits the updated file to stdout when --apply is set.
-    # - write_mode="stdout" also emits updated content to stdout.
-    #
-    # In both cases, route all human-facing console output (summaries, warnings,
-    # diagnostics) to stderr.
-    #
-    # Console selection must happen after planning inputs because stdin mode affects routing.
-    console: ConsoleProtocol = maybe_route_console_to_stderr(
+    # `config dump` is not a mutating pipeline command and does not emit
+    # rewritten-content payloads. It still uses the shared resolver so
+    # STDIN-backed pattern-source handling follows the same stream-routing
+    # decision point as pipeline commands.
+    console: ConsoleProtocol = resolve_human_console(
         ctx,
         run_options=run_options,
         enable_color=enable_color,

--- a/src/topmark/cli/commands/probe.py
+++ b/src/topmark/cli/commands/probe.py
@@ -57,7 +57,7 @@ from topmark.cli.cmd_common import exit_for_config_validation_error
 from topmark.cli.cmd_common import exit_if_no_files
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
-from topmark.cli.cmd_common import maybe_route_console_to_stderr
+from topmark.cli.cmd_common import resolve_human_console
 from topmark.cli.emitters.machine import emit_probe_results_machine
 from topmark.cli.help import HelpExample
 from topmark.cli.help import render_examples_epilog
@@ -321,16 +321,12 @@ def probe_command(
 
     logger.debug("run options: %s", run_options)
 
-    # Content-to-STDOUT modes: keep stdout clean for the rewritten file content.
+    # Resolve the console for human-facing output.
     #
-    # - STDIN content mode emits the updated file to stdout when --apply is set.
-    # - write_mode="stdout" also emits updated content to stdout.
-    #
-    # In both cases, route all human-facing console output (summaries, warnings,
-    # diagnostics) to stderr.
-    #
-    # Console selection must happen after planning inputs because stdin mode affects routing.
-    console: ConsoleProtocol = maybe_route_console_to_stderr(
+    # `probe` normally writes reports to the shared console. The helper keeps
+    # the command aligned with the CLI stream-routing policy and remains the
+    # single place where any future payload-routing rules would be applied.
+    console: ConsoleProtocol = resolve_human_console(
         ctx,
         run_options=run_options,
         enable_color=enable_color,

--- a/src/topmark/cli/commands/strip.py
+++ b/src/topmark/cli/commands/strip.py
@@ -57,7 +57,7 @@ from topmark.cli.cmd_common import exit_for_config_validation_error
 from topmark.cli.cmd_common import exit_if_no_files
 from topmark.cli.cmd_common import init_common_state
 from topmark.cli.cmd_common import maybe_exit_on_error
-from topmark.cli.cmd_common import maybe_route_console_to_stderr
+from topmark.cli.cmd_common import resolve_human_console
 from topmark.cli.emitters.machine import emit_processing_results_machine
 from topmark.cli.help import HelpExample
 from topmark.cli.help import render_examples_epilog
@@ -82,6 +82,7 @@ from topmark.cli.options import render_diff_options
 from topmark.cli.options import shared_policy_options
 from topmark.cli.state import TopmarkCliState
 from topmark.cli.state import bootstrap_cli_state
+from topmark.cli.streaming import emit_stdout_payload
 from topmark.cli.validators import apply_color_policy_for_output_format
 from topmark.cli.validators import validate_diff_apply_mutual_exclusion
 from topmark.cli.validators import validate_stdin_dash_requires_piped_input
@@ -384,7 +385,7 @@ def strip_command(
     #
     # Console selection must happen after planning inputs because stdin mode affects routing.
     machine_console: ConsoleProtocol = state.console
-    console: ConsoleProtocol = maybe_route_console_to_stderr(
+    console: ConsoleProtocol = resolve_human_console(
         ctx,
         run_options=run_options,
         enable_color=enable_color,
@@ -524,8 +525,7 @@ def strip_command(
             fmt=fmt,
         )
 
-        if output.stdout:
-            click.echo(output.stdout)
+        emit_stdout_payload(output.stdout)
 
         if (fmt == OutputFormat.TEXT and not state.quiet and output.stderr) or (
             fmt == OutputFormat.MARKDOWN and output.stderr

--- a/src/topmark/cli/streaming.py
+++ b/src/topmark/cli/streaming.py
@@ -1,0 +1,37 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : streaming.py
+#   file_relpath : src/topmark/cli/streaming.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""CLI stream-emission helpers.
+
+This module contains small command-layer helpers for payload streams whose
+ownership must remain explicit. It intentionally sits above the low-level
+console abstraction: helpers here describe CLI output intent, while
+`topmark.cli.console` describes concrete console behavior.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+def emit_stdout_payload(payload: str, *, nl: bool = True) -> None:
+    """Emit a command payload that intentionally owns STDOUT.
+
+    Use this for payload text that must be written to STDOUT independently of
+    the human report console, such as unified diff output. Do not use it for
+    diagnostics, warnings, status messages, or machine-output emitters that
+    already receive an explicit console.
+
+    Args:
+        payload: Payload text to emit. Empty strings are ignored.
+        nl: Whether Click should append a trailing newline.
+    """
+    if payload:
+        click.echo(payload, nl=nl)

--- a/tests/cli/test_stream_routing.py
+++ b/tests/cli/test_stream_routing.py
@@ -1,0 +1,145 @@
+# topmark:header:start
+#
+#   project      : TopMark
+#   file         : test_stream_routing.py
+#   file_relpath : tests/cli/test_stream_routing.py
+#   license      : MIT
+#   copyright    : (c) 2025 Olivier Biot
+#
+# topmark:header:end
+
+"""CLI stdout/stderr stream-routing contract tests.
+
+These tests pin the architectural split reviewed for GitHub issue 207:
+primary command payloads are emitted on STDOUT, while diagnostics and
+signaling that must not pollute payloads are emitted on STDERR.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.cli.conftest import assert_SUCCESS
+from tests.cli.conftest import assert_SUCCESS_or_WOULD_CHANGE
+from tests.cli.conftest import run_cli
+from tests.cli.conftest import run_cli_in
+from tests.helpers.json import parse_json_object
+from tests.helpers.ndjson import parse_ndjson_records
+from topmark.cli.keys import CliCmd
+from topmark.cli.keys import CliOpt
+from topmark.core.constants import TOPMARK_START_MARKER
+from topmark.core.formats import OutputFormat
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param([CliCmd.VERSION], id="version-text"),
+        pytest.param(
+            [CliCmd.VERSION, CliOpt.OUTPUT_FORMAT, OutputFormat.JSON.value],
+            id="version-json",
+        ),
+        pytest.param(
+            [CliCmd.CONFIG, CliCmd.CONFIG_DEFAULTS],
+            id="config-defaults-text",
+        ),
+        pytest.param(
+            [CliCmd.CONFIG, CliCmd.CONFIG_DEFAULTS, CliOpt.OUTPUT_FORMAT, OutputFormat.JSON.value],
+            id="config-defaults-json",
+        ),
+        pytest.param(
+            [
+                CliCmd.REGISTRY,
+                CliCmd.REGISTRY_FILETYPES,
+                CliOpt.OUTPUT_FORMAT,
+                OutputFormat.JSON.value,
+            ],
+            id="registry-filetypes-json",
+        ),
+    ],
+)
+def test_content_commands_emit_payload_on_stdout_without_stderr(argv: list[str]) -> None:
+    """Content-oriented commands should keep their normal payload on STDOUT."""
+    result: Result = run_cli(argv)
+
+    assert_SUCCESS(result)
+    assert result.stdout
+    assert result.stderr == ""
+
+
+def test_processing_machine_summary_diff_keeps_stdout_parseable_and_warns_on_stderr(
+    tmp_path: Path,
+) -> None:
+    """Machine summaries keep STDOUT parseable while diff suppression warns on STDERR."""
+    path: Path = tmp_path / "example.py"
+    path.write_text('print("hello")\n', encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [
+            CliCmd.CHECK,
+            CliOpt.RENDER_DIFF,
+            CliOpt.RESULTS_SUMMARY_MODE,
+            CliOpt.OUTPUT_FORMAT,
+            OutputFormat.JSON.value,
+            path.name,
+        ],
+    )
+
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+    parse_json_object(result.stdout)
+    assert "--diff does not emit per-file diff payloads" in result.stderr
+    assert "Note:" not in result.stdout
+
+
+def test_human_diff_routes_report_to_stderr_and_diff_payload_to_stdout(tmp_path: Path) -> None:
+    """Human `--diff` reserves STDOUT for unified diff payloads."""
+    path: Path = tmp_path / "example.py"
+    path.write_text('print("hello")\n', encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [CliCmd.CHECK, CliOpt.RENDER_DIFF, path.name],
+    )
+
+    assert_SUCCESS_or_WOULD_CHANGE(result)
+    assert result.stdout.startswith(f"--- {path.name} (current)\t")
+    assert f"\n+++ {path.name} (updated)\t" in result.stdout
+    assert TOPMARK_START_MARKER in result.stdout
+    assert "TopMark" in result.stderr
+
+
+def test_apply_stdin_content_routes_rewritten_file_to_stdout_and_report_to_stderr() -> None:
+    """Apply mode for content-on-STDIN keeps rewritten content isolated on STDOUT."""
+    result: Result = run_cli(
+        [CliCmd.CHECK, CliOpt.APPLY_CHANGES, "-", CliOpt.STDIN_FILENAME, "x.py"],
+        input_text='print("hello")\n',
+    )
+
+    assert_SUCCESS(result)
+    assert TOPMARK_START_MARKER in result.stdout
+    assert 'print("hello")' in result.stdout
+    assert "x.py: python - inserted" in result.stderr
+
+
+def test_probe_ndjson_payload_stays_on_stdout(tmp_path: Path) -> None:
+    """Probe machine output emits parseable NDJSON on STDOUT without STDERR chatter."""
+    path: Path = tmp_path / "example.py"
+    path.write_text('print("hello")\n', encoding="utf-8")
+
+    result: Result = run_cli_in(
+        tmp_path,
+        [CliCmd.PROBE, CliOpt.OUTPUT_FORMAT, OutputFormat.NDJSON.value, path.name],
+    )
+
+    assert_SUCCESS(result)
+    records: list[dict[str, object]] = parse_ndjson_records(result.stdout)
+    assert records
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary

- Documents the CLI stream-routing ownership model for STDOUT payloads and STDERR diagnostics/signaling.
- Adds focused stream-routing contract tests for machine parseability, human diff output, content-on-STDIN apply output, and representative content commands.
- Introduces `topmark.cli.streaming.emit_stdout_payload()` for explicit command-layer STDOUT payload emission.
- Renames `maybe_route_console_to_stderr()` to `resolve_human_console()` and updates check, strip, probe, and config dump command code/comments accordingly.
- Updates the Unreleased changelog entries under Documentation and Internal.

## Rationale

GitHub issue #207 identified that TopMark’s observed output behavior was mostly consistent, but the command layer still made some stream ownership decisions implicitly.

This change keeps behavior unchanged while making the architecture explicit:

- primary payload output is emitted on STDOUT;
- diagnostics and non-payload signaling use STDERR when needed;
- machine JSON/NDJSON output remains parseable on STDOUT;
- human `check --diff` / `strip --diff` reserve STDOUT for unified diff payloads;
- apply-mode content processing through STDIN or `--write-mode=stdout` reserves STDOUT for rewritten content.

## Validation

- `uv run pytest tests/cli/test_stream_routing.py -q`
- `uv run pytest tests/cli/machine -q`
- `uv run pytest tests/cli -q`
- `uv run pytest tests -q`
- `uv run ruff check`
- `uv run pyright --pythonversion 3.10`
- `uv run pyright --pythonversion 3.13`
- `uv run mdformat --check docs/usage/cli.md docs/dev/machine-formats.md CHANGELOG.md`

Closes #207