### PR TITLE
Consolidate shared pipeline summary rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -544,6 +544,9 @@ ______________________________________________________________________
   guarantees, including stable envelope structure and additive-schema compatibility expectations.
 - Added CLI stream-routing contract tests and small command-layer stream-emission helpers clarifying
   explicit STDOUT payload ownership for check/strip output.
+- Centralized shared pipeline summary preparation for TEXT and Markdown renderers, keeping compact
+  file-type, outcome, write/diff, and diagnostic triage semantics consistent while leaving styling
+  and Markdown escaping in the format-specific presentation layers.
 
 ### Notes - Unreleased
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -499,6 +499,10 @@ human-facing presentation:
 - Synthetic configuration-source identifiers are stable labels, not filesystem paths.
 - TEXT and Markdown output use shared display-path helpers so regular paths follow human-facing
   display policy and STDIN-backed processing shows the logical `--stdin-filename` when available.
+- TEXT and Markdown pipeline summaries share format-neutral summary preparation for file-type
+  labels, result buckets, write/diff markers, and diagnostic triage. Format-specific renderers
+  remain responsible for terminal styling, Markdown escaping, verbosity-specific nudges, and
+  document structure.
 - Unified diff file labels are human-facing display labels. They are not machine-readable path
   serialization fields and should not be treated like JSON or NDJSON path values.
 

--- a/src/topmark/presentation/markdown/pipeline.py
+++ b/src/topmark/presentation/markdown/pipeline.py
@@ -32,10 +32,8 @@ from topmark.cli.keys import CliCmd
 from topmark.cli.keys import CliOpt
 from topmark.core.logging import get_logger
 from topmark.pipeline.outcomes import ResultActionIntent
-from topmark.pipeline.outcomes import ResultBucket
 from topmark.pipeline.outcomes import collect_outcome_reason_counts
 from topmark.pipeline.outcomes import determine_result_action_intent
-from topmark.pipeline.outcomes import map_bucket
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import WriteStatus
@@ -46,19 +44,19 @@ from topmark.presentation.markdown.utils import markdown_code_span
 from topmark.presentation.markdown.utils import render_fenced_code_block_markdown
 from topmark.presentation.markdown.utils import render_markdown_table
 from topmark.presentation.shared.paths import get_display_path
-from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
-from topmark.presentation.shared.pipeline import get_file_type_label
+from topmark.presentation.shared.pipeline import summarize_pipeline_file
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Sequence
 
     from topmark.core.logging import TopmarkLogger
-    from topmark.diagnostic.model import DiagnosticStats
     from topmark.pipeline.hints import Hint
     from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.outcomes import OutcomeReasonCount
     from topmark.pipeline.result import ProcessingResult
+    from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
+    from topmark.presentation.shared.pipeline import PipelineFileSummary
 
 
 logger: TopmarkLogger = get_logger(__name__)
@@ -268,35 +266,15 @@ def _render_file_summary_line_markdown(
     Returns:
         One-line Markdown summary for the file.
     """
-    # Shared helper keeps missing-file and unresolved-type labels consistent
-    # across TEXT and Markdown renderers.
-    ft_label: str | None = get_file_type_label(result)
+    summary: PipelineFileSummary = summarize_pipeline_file(result)
+    suffix: str = " - " + " - ".join(summary.secondary_parts) if summary.secondary_parts else ""
 
-    # Resolve the public bucket for this result using its own execution mode.
-    apply_changes: bool = result.execution_mode.apply_changes is True
-    bucket: ResultBucket = map_bucket(result, apply=apply_changes)
-    key: str = bucket.outcome.value
-    label: str = bucket.reason or "(no reason provided)"
-
-    # Secondary hints: write status > diff marker > diagnostics
-    parts: list[str] = []
-    if result.status.has_write_outcome():
-        parts.append(result.status.write.value)
-    elif result.detail.diff_text:
-        parts.append("diff")
-
-    if result.diagnostics:
-        # Compose a compact triage summary such as "1 error, 2 warnings".
-        stats: DiagnosticStats = result.diagnostics.stats()
-        triage_summary: str = stats.triage_summary()
-        if triage_summary:
-            parts.append(triage_summary)
-
-    suffix: str = (" - " + " - ".join(parts)) if parts else ""
-
-    if ft_label is not None:
-        return f"`{get_display_path(result)}` ({ft_label}) - `{key}`: {label}{suffix}"
-    return f"`{get_display_path(result)}` - `{key}`: {label}{suffix}"
+    if summary.file_type_label is not None:
+        return (
+            f"`{get_display_path(result)}` ({summary.file_type_label}) - "
+            f"`{summary.key}`: {summary.label}{suffix}"
+        )
+    return f"`{get_display_path(result)}` - `{summary.key}`: {summary.label}{suffix}"
 
 
 def _render_per_file_guidance_markdown(
@@ -347,13 +325,13 @@ def _render_per_file_guidance_markdown(
             blocks.append(f"  - {msg}")
 
         # 3. diagnostics block; Markdown shows diagnostics whenever present.
-        if len(result.diagnostics) > 0:
+        if result.diagnostics:
             diag_md: str = render_diagnostics_markdown(
                 diagnostics=result.diagnostics,
             ).rstrip()
-            if diag_md:
-                for line in diag_md.splitlines():
-                    blocks.append(f"  {line}" if line else "")
+            # Triage summary is nonempty if there are diagnostics:
+            for line in diag_md.splitlines():
+                blocks.append(f"  {line}" if line else "")
 
         # 4. hints; Markdown shows all hints whenever present.
         hints: list[Hint] = list(result.hints)

--- a/src/topmark/presentation/shared/pipeline.py
+++ b/src/topmark/presentation/shared/pipeline.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from topmark.pipeline.outcomes import map_bucket
 from topmark.pipeline.status import FsStatus
 
 if TYPE_CHECKING:
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
 
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.kinds import PipelineKindLiteral
+    from topmark.pipeline.outcomes import ResultBucket
     from topmark.pipeline.reporting import ReportScope
     from topmark.pipeline.result import ProcessingResult
 
@@ -99,6 +101,32 @@ class PipelineCommandHumanReport:
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
+class PipelineFileSummary:
+    """Format-neutral one-line pipeline summary data.
+
+    The summary captures the common semantic fields used by TEXT and Markdown
+    per-file renderers. Format-specific renderers remain responsible for path
+    decoration, Markdown escaping, terminal styling, and verbosity-specific
+    nudges.
+
+    Attributes:
+        file_type_label: Human-facing file-type label, or `None` when omitted.
+        bucket: Public result bucket for the result execution mode.
+        key: Bucket outcome value for compact human display.
+        label: Bucket reason for compact human display.
+        secondary_parts: Additional compact suffix entries, in priority order.
+        diagnostic_total: Number of diagnostics attached to the result.
+    """
+
+    file_type_label: str | None
+    bucket: ResultBucket
+    key: str
+    label: str
+    secondary_parts: tuple[str, ...]
+    diagnostic_total: int
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
 class PipelineCommandHumanOutput:
     """Rendered human pipeline command output split by output stream.
 
@@ -149,3 +177,45 @@ def get_file_type_label(
     if ctx.status.fs == FsStatus.NOT_FOUND:
         return None
     return "<unknown>"
+
+
+def summarize_pipeline_file(
+    result: ProcessingResult,
+) -> PipelineFileSummary:
+    """Build format-neutral compact summary data for one pipeline result.
+
+    TEXT and Markdown per-file renderers intentionally differ in styling,
+    escaping, and progressive disclosure. This helper centralizes the shared
+    semantic selection so both renderers describe write status, diffs, and
+    diagnostics consistently without sharing terminal or Markdown concerns.
+
+    Args:
+        result: Durable processing result to summarize.
+
+    Returns:
+        Presentation-ready summary data for human renderers.
+    """
+    apply_changes: bool = result.execution_mode.apply_changes is True
+    bucket: ResultBucket = map_bucket(result, apply=apply_changes)
+
+    secondary_parts: list[str] = []
+    if result.status.has_write_outcome():
+        secondary_parts.append(result.status.write.value)
+    elif result.detail.diff_text:
+        secondary_parts.append("diff")
+
+    diagnostic_total: int = 0
+    if result.diagnostics:
+        diagnostic_total = result.diagnostics.stats().total
+        triage_summary: str = result.diagnostics.stats().triage_summary()
+        # Triage summary is nonempty if there are diagnostics:
+        secondary_parts.append(triage_summary)
+
+    return PipelineFileSummary(
+        file_type_label=get_file_type_label(result),
+        bucket=bucket,
+        key=bucket.outcome.value,
+        label=bucket.reason or "(no reason provided)",
+        secondary_parts=tuple(secondary_parts),
+        diagnostic_total=diagnostic_total,
+    )

--- a/src/topmark/presentation/text/pipeline.py
+++ b/src/topmark/presentation/text/pipeline.py
@@ -43,9 +43,7 @@ from topmark.core.logging import get_logger
 from topmark.core.presentation import StyleRole
 from topmark.pipeline.hints import Cluster
 from topmark.pipeline.outcomes import ResultActionIntent
-from topmark.pipeline.outcomes import ResultBucket
 from topmark.pipeline.outcomes import determine_result_action_intent
-from topmark.pipeline.outcomes import map_bucket
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.status import HeaderStatus
 from topmark.pipeline.status import WriteStatus
@@ -53,8 +51,7 @@ from topmark.presentation.shared.outcomes import collect_outcome_counts_styled
 from topmark.presentation.shared.outcomes import get_outcome_style_role
 from topmark.presentation.shared.paths import get_display_path
 from topmark.presentation.shared.paths import render_path_display_text
-from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
-from topmark.presentation.shared.pipeline import get_file_type_label
+from topmark.presentation.shared.pipeline import summarize_pipeline_file
 from topmark.presentation.text.diagnostic import render_diagnostics_text
 
 if TYPE_CHECKING:
@@ -62,11 +59,12 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from topmark.core.logging import TopmarkLogger
-    from topmark.diagnostic.model import DiagnosticStats
     from topmark.pipeline.hints import Hint
     from topmark.pipeline.kinds import PipelineKindLiteral
     from topmark.pipeline.outcomes import OutcomeReasonCount
     from topmark.pipeline.result import ProcessingResult
+    from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
+    from topmark.presentation.shared.pipeline import PipelineFileSummary
 
 
 logger: TopmarkLogger = get_logger(__name__)
@@ -87,7 +85,11 @@ _HINT_CLUSTER_STYLE_ROLE: Final[dict[str, StyleRole]] = {
 # ---- Hint rendering ----
 
 
-def _hint_styler(cluster: str | None, *, styled: bool) -> TextStyler:
+def _hint_styler(
+    cluster: str | None,
+    *,
+    styled: bool,
+) -> TextStyler:
     """Return the semantic text styler for a hint cluster.
 
     Args:
@@ -97,8 +99,14 @@ def _hint_styler(cluster: str | None, *, styled: bool) -> TextStyler:
     Returns:
         Text styler for the hint cluster.
     """
-    role: StyleRole = _HINT_CLUSTER_STYLE_ROLE.get(cluster or "", StyleRole.MUTED)
-    return style_for_role(role, styled=styled)
+    role: StyleRole = _HINT_CLUSTER_STYLE_ROLE.get(
+        cluster or "",
+        StyleRole.MUTED,
+    )
+    return style_for_role(
+        role,
+        styled=styled,
+    )
 
 
 def _render_hint_text(
@@ -120,8 +128,14 @@ def _render_hint_text(
         Rendered text for one hint entry.
     """
     # Style helpers already respect the selected color policy.
-    muted_styler: TextStyler = style_for_role(StyleRole.MUTED, styled=styled)
-    hint_styler: TextStyler = _hint_styler(hint.cluster, styled=styled)
+    muted_styler: TextStyler = style_for_role(
+        StyleRole.MUTED,
+        styled=styled,
+    )
+    hint_styler: TextStyler = _hint_styler(
+        hint.cluster,
+        styled=styled,
+    )
 
     lines: list[str] = []
 
@@ -181,8 +195,14 @@ def _render_pipeline_banner_text(
         TEXT banner shown before verbose pipeline command output.
     """
     # Style helpers already respect the selected color policy.
-    heading_styler: TextStyler = style_for_role(StyleRole.HEADING_TITLE, styled=styled)
-    info_styler: TextStyler = style_for_role(StyleRole.INFO, styled=styled)
+    heading_styler: TextStyler = style_for_role(
+        StyleRole.HEADING_TITLE,
+        styled=styled,
+    )
+    info_styler: TextStyler = style_for_role(
+        StyleRole.INFO,
+        styled=styled,
+    )
 
     return "\n".join(
         [
@@ -257,7 +277,10 @@ def _render_check_guidance_message_text(
             else f"✏️  Updating header in {path_label}"
         )
 
-    apply_cmd: str = _render_apply_command_text(command=CliCmd.CHECK, result=result)
+    apply_cmd: str = _render_apply_command_text(
+        command=CliCmd.CHECK,
+        result=result,
+    )
 
     if intent == ResultActionIntent.INSERT:
         action: str = "add a TopMark header to this file"
@@ -303,7 +326,10 @@ def _render_strip_guidance_message_text(
 
         return f"🧹 Stripping header in {path_label}"
 
-    apply_cmd: str = _render_apply_command_text(command=CliCmd.STRIP, result=result)
+    apply_cmd: str = _render_apply_command_text(
+        command=CliCmd.STRIP,
+        result=result,
+    )
 
     if intent == ResultActionIntent.STRIP:
         action: str = "strip the TopMark header from this file"
@@ -339,71 +365,50 @@ def _render_file_summary_line_text(
     parts: list[str] = [f"{get_display_path(result)}:"]
 
     # Style helpers already respect the selected color policy.
-    muted_styler: TextStyler = style_for_role(StyleRole.MUTED, styled=styled)
+    muted_styler: TextStyler = style_for_role(
+        StyleRole.MUTED,
+        styled=styled,
+    )
 
-    # Shared helper keeps missing-file and unresolved-type labels consistent
-    # across TEXT and Markdown renderers.
-    ft_label: str | None = get_file_type_label(result)
-    if ft_label is not None:
-        parts.append(muted_styler(ft_label))
+    summary: PipelineFileSummary = summarize_pipeline_file(result)
+    if summary.file_type_label is not None:
+        parts.append(muted_styler(summary.file_type_label))
         parts.append("-")
 
-    # Resolve the public bucket for this result using its own execution mode and
-    # style the summary from its semantic outcome role.
-    apply_changes: bool = result.execution_mode.apply_changes is True
-    bucket: ResultBucket = map_bucket(result, apply=apply_changes)
-    key: str = bucket.outcome.value
-    label: str = bucket.reason or "(no reason provided)"
-
-    # Retrieve the bucket's text styler based on the bucket outcome's semantic style role:
+    # Retrieve the bucket's text styler based on the bucket outcome's semantic style role.
     outcome_styler: TextStyler = style_for_role(
-        get_outcome_style_role(bucket.outcome),
+        get_outcome_style_role(summary.bucket.outcome),
         styled=styled,
     )
 
     parts.append(
         outcome_styler(
-            f"{key}: {label}",
+            f"{summary.key}: {summary.label}",
         )
     )
 
-    # Secondary hints: write status > diff marker > diagnostics
-    if result.status.has_write_outcome():
+    for secondary_part in summary.secondary_parts:
         parts.append("-")
-        write_styler: TextStyler = style_for_role(
-            result.status.write.role,
-            styled=styled,
-        )
-        parts.append(
-            write_styler(
-                result.status.write.value,
+        if secondary_part == result.status.write.value and result.status.has_write_outcome():
+            write_styler: TextStyler = style_for_role(
+                result.status.write.role,
+                styled=styled,
             )
-        )
-    elif result.detail.diff_text:
-        parts.append("-")
-        diff_styler: TextStyler = style_for_role(
-            StyleRole.WOULD_CHANGE,
-            styled=styled,
-        )
-        parts.append(
-            diff_styler(
-                "diff",
+            parts.append(write_styler(secondary_part))
+        elif secondary_part == "diff" and result.detail.diff_text:
+            diff_styler: TextStyler = style_for_role(
+                StyleRole.WOULD_CHANGE,
+                styled=styled,
             )
-        )
+            parts.append(diff_styler(secondary_part))
+        else:
+            parts.append(secondary_part)
 
     diag_show_hint: str = ""
-    if result.diagnostics:
-        # Compose a compact triage summary such as "1 error, 2 warnings".
-        stats: DiagnosticStats = result.diagnostics.stats()
-        triage_summary: str = stats.triage_summary()
-        if triage_summary:
-            parts.append("-")
-            parts.append(triage_summary)
-
-        if verbosity_level <= 0 and stats.total > 0:
-            diag_show_hint = muted_styler(
-                f" (use '{CliShortOpt.VERBOSE}' to view)",
-            )
+    if verbosity_level <= 0 and summary.diagnostic_total > 0:
+        diag_show_hint = muted_styler(
+            f" (use '{CliShortOpt.VERBOSE}' to view)",
+        )
 
     return " ".join(parts) + diag_show_hint
 
@@ -440,8 +445,14 @@ def _render_per_file_guidance_text(
     parts: list[str] = []
 
     # Style helpers already respect the selected color policy.
-    muted_styler: TextStyler = style_for_role(StyleRole.MUTED, styled=styled)
-    emphasis_styler: TextStyler = style_for_role(StyleRole.EMPHASIS, styled=styled)
+    muted_styler: TextStyler = style_for_role(
+        StyleRole.MUTED,
+        styled=styled,
+    )
+    emphasis_styler: TextStyler = style_for_role(
+        StyleRole.EMPHASIS,
+        styled=styled,
+    )
 
     # Use the Box Drawing Light Horizontal character (U+2500) for a solid line
     diff_start_fence: Final[str] = " diff - start ".center(line_width, "─")
@@ -605,7 +616,10 @@ def _render_pipeline_diffs_text(
     diffs_end_fence: Final[str] = " diffs - end ".center(line_width, "─")
 
     # Style helpers already respect the selected color policy.
-    diff_fence_style: TextStyler = style_for_role(StyleRole.DIFF_LINE_NO, styled=styled)
+    diff_fence_style: TextStyler = style_for_role(
+        StyleRole.DIFF_LINE_NO,
+        styled=styled,
+    )
 
     parts.append(
         diff_fence_style(
@@ -682,9 +696,18 @@ def _render_summary_counts_text(
         TEXT summary grouped by outcome and reason.
     """
     # Style helpers already respect the selected color policy.
-    heading_styler: TextStyler = style_for_role(StyleRole.HEADING_TITLE, styled=styled)
-    emphasis_styler: TextStyler = style_for_role(StyleRole.EMPHASIS, styled=styled)
-    italic_styler: TextStyler = style_for_role(StyleRole.ITALIC, styled=styled)
+    heading_styler: TextStyler = style_for_role(
+        StyleRole.HEADING_TITLE,
+        styled=styled,
+    )
+    emphasis_styler: TextStyler = style_for_role(
+        StyleRole.EMPHASIS,
+        styled=styled,
+    )
+    italic_styler: TextStyler = style_for_role(
+        StyleRole.ITALIC,
+        styled=styled,
+    )
 
     parts: list[str] = []
 
@@ -755,7 +778,10 @@ def render_pipeline_output_text(
         raise RuntimeError(f"Invalid pipeline kind selected: {report.pipeline_kind}")
 
     # Style helpers already respect the selected color policy.
-    warning_styler: TextStyler = style_for_role(StyleRole.WARNING, styled=report.styled)
+    warning_styler: TextStyler = style_for_role(
+        StyleRole.WARNING,
+        styled=report.styled,
+    )
 
     parts: list[str] = []
 
@@ -835,8 +861,14 @@ def render_pipeline_apply_summary_text(
     """
     parts: list[str] = []
     # Style helpers already respect the selected color policy.
-    changed_styler: TextStyler = style_for_role(StyleRole.CHANGED, styled=styled)
-    warning_styler: TextStyler = style_for_role(StyleRole.WARNING, styled=styled)
+    changed_styler: TextStyler = style_for_role(
+        StyleRole.CHANGED,
+        styled=styled,
+    )
+    warning_styler: TextStyler = style_for_role(
+        StyleRole.WARNING,
+        styled=styled,
+    )
 
     if written:
         msg: str = f"\n✅ {command_path}: applied changes to {written} file(s)."

--- a/tests/presentation/test_pipeline_rendering.py
+++ b/tests/presentation/test_pipeline_rendering.py
@@ -31,7 +31,6 @@ from topmark.pipeline.hints import Axis
 from topmark.pipeline.hints import Cluster
 from topmark.pipeline.hints import KnownCode
 from topmark.pipeline.hints import make_hint
-from topmark.pipeline.reduction import ProcessingReduction
 from topmark.pipeline.reduction import reduce_processing_contexts
 from topmark.pipeline.reporting import ReportScope
 from topmark.pipeline.status import ComparisonStatus
@@ -46,13 +45,16 @@ from topmark.pipeline.status import WriteStatus
 from topmark.pipeline.views import DiffView
 from topmark.presentation.markdown.paths import render_path_display_markdown
 from topmark.presentation.markdown.pipeline import render_pipeline_apply_summary_markdown
+from topmark.presentation.markdown.pipeline import render_pipeline_diffs_markdown
 from topmark.presentation.markdown.pipeline import render_pipeline_output_markdown
 from topmark.presentation.output.pipeline import render_pipeline_command_human_output
 from topmark.presentation.shared.paths import get_display_path
 from topmark.presentation.shared.paths import render_path_display_text
 from topmark.presentation.shared.pipeline import PipelineCommandHumanReport
 from topmark.presentation.shared.pipeline import get_file_type_label
+from topmark.presentation.shared.pipeline import summarize_pipeline_file
 from topmark.presentation.text.pipeline import render_pipeline_apply_summary_text
+from topmark.presentation.text.pipeline import render_pipeline_diffs_text
 from topmark.presentation.text.pipeline import render_pipeline_output_text
 from topmark.runtime.model import RunOptions
 
@@ -63,7 +65,9 @@ if TYPE_CHECKING:
     from topmark.config.model import FrozenConfig
     from topmark.pipeline.context.model import ProcessingContext
     from topmark.pipeline.kinds import PipelineKindLiteral
+    from topmark.pipeline.reduction import ProcessingReduction
     from topmark.pipeline.result import ProcessingResult
+    from topmark.presentation.shared.pipeline import PipelineFileSummary
 
 
 def _make_context(
@@ -124,7 +128,9 @@ def _make_report(
     )
 
 
-def _add_diff(ctx: ProcessingContext) -> None:
+def _add_diff(
+    ctx: ProcessingContext,
+) -> None:
     """Attach a deterministic unified diff to a context."""
     ctx.status.patch = PatchStatus.GENERATED
     ctx.views.diff = DiffView(text="--- old\n+++ new\n@@ -1 +1 @@\n-old\n+new\n")
@@ -168,14 +174,18 @@ def _force_strip_actionable_with_insert_intent(
     )
 
 
-def test_render_path_display_text_uses_regular_display_path(tmp_path: Path) -> None:
+def test_render_path_display_text_uses_regular_display_path(
+    tmp_path: Path,
+) -> None:
     """TEXT path labels should quote regular display paths without STDIN annotation."""
     ctx: ProcessingContext = _make_context(tmp_path / "regular.py")
 
     assert render_path_display_text(ctx) == f"'{ctx.path}'"
 
 
-def test_render_path_display_text_uses_stdin_filename(tmp_path: Path) -> None:
+def test_render_path_display_text_uses_stdin_filename(
+    tmp_path: Path,
+) -> None:
     """TEXT path labels should show the logical stdin filename in STDIN mode."""
     ctx: ProcessingContext = _make_context(
         tmp_path / "materialized-stdin.py",
@@ -186,14 +196,18 @@ def test_render_path_display_text_uses_stdin_filename(tmp_path: Path) -> None:
     assert render_path_display_text(ctx) == "'logical/input.py' (via STDIN)"
 
 
-def test_render_path_display_markdown_uses_regular_display_path(tmp_path: Path) -> None:
+def test_render_path_display_markdown_uses_regular_display_path(
+    tmp_path: Path,
+) -> None:
     """Markdown path labels should render regular display paths as code spans."""
     ctx: ProcessingContext = _make_context(tmp_path / "regular.py")
 
     assert render_path_display_markdown(ctx) == f"`{ctx.path}`"
 
 
-def test_render_path_display_markdown_uses_stdin_filename(tmp_path: Path) -> None:
+def test_render_path_display_markdown_uses_stdin_filename(
+    tmp_path: Path,
+) -> None:
     """Markdown path labels should show the logical stdin filename in STDIN mode."""
     ctx: ProcessingContext = _make_context(
         tmp_path / "materialized-stdin.py",
@@ -204,7 +218,9 @@ def test_render_path_display_markdown_uses_stdin_filename(tmp_path: Path) -> Non
     assert render_path_display_markdown(ctx) == "`logical/input.py` _(via STDIN)_"
 
 
-def test_shared_display_path_uses_stdin_filename_for_stdin_context(tmp_path: Path) -> None:
+def test_shared_display_path_uses_stdin_filename_for_stdin_context(
+    tmp_path: Path,
+) -> None:
     """Shared path rendering should prefer logical STDIN filenames."""
     ctx: ProcessingContext = _make_context(
         tmp_path / "stdin-buffer.py",
@@ -236,7 +252,84 @@ def test_shared_file_type_label_falls_back_to_unknown_for_unresolved_type(
     assert get_file_type_label(ctx) == "<unknown>"
 
 
-def test_render_pipeline_output_text_compact_check_guidance(tmp_path: Path) -> None:
+def test_shared_pipeline_file_summary_centralizes_compact_suffixes(
+    tmp_path: Path,
+) -> None:
+    """Shared summary data should capture suffix semantics without format details."""
+    ctx: ProcessingContext = _make_context(tmp_path / "summary-shared.py")
+    _add_diff(ctx)
+    ctx.diagnostics.add(
+        Diagnostic(level=DiagnosticLevel.WARNING, message="Check this file"),
+    )
+
+    result: ProcessingResult = reduce_processing_contexts([ctx]).results[0]
+
+    summary: PipelineFileSummary = summarize_pipeline_file(result)
+
+    assert summary.file_type_label == "python"
+    assert summary.key == "would insert"
+    assert summary.label == "header missing, changes found"
+    assert summary.secondary_parts == ("diff", "1 warning")
+    assert summary.diagnostic_total == 1
+
+
+def test_shared_pipeline_file_summary_prioritizes_write_status_over_diff(
+    tmp_path: Path,
+) -> None:
+    """Write outcomes should remain the primary compact suffix for both renderers."""
+    ctx: ProcessingContext = _make_context(
+        tmp_path / "written.py",
+        apply_changes=True,
+    )
+    _add_diff(ctx)
+    ctx.status.write = WriteStatus.WRITTEN
+
+    result: ProcessingResult = reduce_processing_contexts([ctx]).results[0]
+
+    summary: PipelineFileSummary = summarize_pipeline_file(result)
+
+    assert summary.secondary_parts == ("changes written to file",)
+    assert summary.diagnostic_total == 0
+
+
+@pytest.mark.parametrize(
+    (
+        "diagnostic_level",
+        "expected_triage_summary",
+        "expected_secondary_parts",
+        "expected_diagnostic_total",
+    ),
+    [
+        (None, "", (), 0),
+        (DiagnosticLevel.WARNING, "1 warning", ("1 warning",), 1),
+    ],
+)
+def test_shared_pipeline_file_summary_reports_diagnostic_summary(
+    tmp_path: Path,
+    diagnostic_level: DiagnosticLevel | None,
+    expected_triage_summary: str,
+    expected_secondary_parts: tuple[str, ...],
+    expected_diagnostic_total: int,
+) -> None:
+    """Shared summary data should report diagnostics only when present."""
+    ctx: ProcessingContext = _make_context(tmp_path / "diagnostics-summary.py")
+    if diagnostic_level is not None:
+        ctx.diagnostics.add(
+            Diagnostic(level=diagnostic_level, message="Check this file"),
+        )
+
+    result: ProcessingResult = reduce_processing_contexts([ctx]).results[0]
+
+    summary: PipelineFileSummary = summarize_pipeline_file(result)
+
+    assert result.diagnostics.stats().triage_summary() == expected_triage_summary
+    assert summary.secondary_parts == expected_secondary_parts
+    assert summary.diagnostic_total == expected_diagnostic_total
+
+
+def test_render_pipeline_output_text_compact_check_guidance(
+    tmp_path: Path,
+) -> None:
     """Compact TEXT check output should include summary, diff hint, and apply guidance."""
     ctx: ProcessingContext = _make_context(tmp_path / "demo.py")
     _add_diff(ctx)
@@ -299,7 +392,9 @@ def test_render_pipeline_output_text_verbose_includes_banner_diagnostics_and_hin
     assert "use '-vv' to display detailed hints" in output
 
 
-def test_render_pipeline_output_text_summary_with_diff_section(tmp_path: Path) -> None:
+def test_render_pipeline_output_text_summary_with_diff_section(
+    tmp_path: Path,
+) -> None:
     """TEXT summary mode should render optional diffs plus grouped outcome counts."""
     ctx: ProcessingContext = _make_context(tmp_path / "summary.py")
     _add_diff(ctx)
@@ -503,7 +598,9 @@ def test_render_pipeline_output_markdown_per_file_includes_diagnostics_hints_and
     assert "+new" in output
 
 
-def test_render_pipeline_output_markdown_summary_table_and_total(tmp_path: Path) -> None:
+def test_render_pipeline_output_markdown_summary_table_and_total(
+    tmp_path: Path,
+) -> None:
     """Markdown summary mode should render grouped outcome table and total."""
     ctx: ProcessingContext = _make_context(tmp_path / "summary.md.py")
 
@@ -522,7 +619,9 @@ def test_render_pipeline_output_markdown_summary_table_and_total(tmp_path: Path)
     assert "Total files: **5**" in output
 
 
-def test_render_pipeline_output_markdown_summary_diff_section(tmp_path: Path) -> None:
+def test_render_pipeline_output_markdown_summary_diff_section(
+    tmp_path: Path,
+) -> None:
     """Markdown summary mode should render the separate diff section when requested."""
     path: Path = tmp_path / "diffs.py"
     ctx: ProcessingContext = _make_context(path)
@@ -707,6 +806,28 @@ def test_render_pipeline_output_text_per_file_renders_diff_fences(
     assert " diff - end " in output
 
 
+def test_render_pipeline_output_text_per_file_omits_empty_diff_block(
+    tmp_path: Path,
+) -> None:
+    """TEXT per-file output should not add diff fences for an empty retained diff."""
+    ctx: ProcessingContext = _make_context(tmp_path / "empty-diff-text.py")
+    ctx.status.patch = PatchStatus.GENERATED
+    ctx.views.diff = DiffView(text="")
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_output_text(
+        _make_report(
+            view_results=reduction.results,
+            show_diffs=True,
+        )
+    )
+
+    assert "empty-diff-text.py" in output
+    assert " diff - start " not in output
+    assert " diff - end " not in output
+
+
 def test_render_pipeline_apply_summary_markdown_reports_written_and_failed() -> None:
     """Markdown apply summary should report written and failed counts together."""
     output: str = render_pipeline_apply_summary_markdown(
@@ -856,7 +977,9 @@ def test_pipeline_strip_guidance_rejects_non_strip_intent(
         render_pipeline_output_markdown(report)
 
 
-def test_pipeline_renderers_reject_invalid_pipeline_kind(tmp_path: Path) -> None:
+def test_pipeline_renderers_reject_invalid_pipeline_kind(
+    tmp_path: Path,
+) -> None:
     """Both renderers should reject invalid pipeline kinds defensively."""
     ctx: ProcessingContext = _make_context(tmp_path / "invalid.py")
 
@@ -986,14 +1109,35 @@ def test_render_pipeline_diffs_helpers_return_empty_for_results_without_patches(
     tmp_path: Path,
 ) -> None:
     """Standalone diff renderers should return an empty payload when no patch renders."""
-    from topmark.presentation.markdown.pipeline import render_pipeline_diffs_markdown
-    from topmark.presentation.text.pipeline import render_pipeline_diffs_text
-
     ctx: ProcessingContext = _make_context(tmp_path / "no-patch.py")
     reduction: ProcessingReduction = reduce_processing_contexts([ctx])
 
     assert render_pipeline_diffs_markdown(results=reduction.results) == ""
     assert render_pipeline_diffs_text(results=reduction.results, styled=False) == ""
+
+
+def test_render_pipeline_diffs_text_supports_line_numbers(
+    tmp_path: Path,
+) -> None:
+    """Standalone TEXT diff rendering should support optional line numbers."""
+    ctx: ProcessingContext = _make_context(tmp_path / "numbered-diff.py")
+    _add_diff(ctx)
+
+    reduction: ProcessingReduction = reduce_processing_contexts([ctx])
+
+    output: str = render_pipeline_diffs_text(
+        results=reduction.results,
+        styled=False,
+        show_line_numbers=True,
+    )
+
+    assert " diff - start " not in output
+    assert " diff - end " not in output
+    assert "0001|--- old" in output
+    assert "0002|+++ new" in output
+    assert "0005|+new" in output
+    assert "--- old" in output
+    assert "+new" in output
 
 
 def test_render_pipeline_output_text_strip_apply_mode_reports_write_skipped(


### PR DESCRIPTION
## Summary

Closes #193.

This PR completes the architectural review of the Markdown rendering subsystem initiated under the reporting and rendering review umbrella (#190). The goal was to improve internal presentation layering and reduce duplication without changing any documented CLI output contracts or presentation behavior.

## What changed

### Shared presentation architecture

- Introduced a shared `PipelineFileSummary` presentation model.
- Centralized compact per-file summary preparation in `presentation/shared`.
- Removed duplicated summary-selection logic previously implemented independently by the TEXT and Markdown pipeline renderers.
- Kept format-specific responsibilities where they belong:
  - TEXT styling remains in the TEXT renderer.
  - Markdown escaping and document structure remain in the Markdown renderer.
  - Stream routing remains outside the presentation layer.

### Renderer cleanup

- Simplified the Markdown and TEXT pipeline renderers by consuming the shared summary model.
- Removed unreachable defensive branches around diagnostic summary rendering after confirming the diagnostic contracts guarantee non-empty summaries whenever diagnostics are present.

### Tests

Expanded presentation-layer regression coverage by adding tests for:

- shared pipeline summary generation;
- write-status vs. diff summary precedence;
- diagnostic summary generation;
- standalone TEXT diff rendering;
- optional TEXT diff line numbering;
- empty retained diff handling.

## Documentation

Updated the presentation architecture documentation to describe the shared summary layer and renderer responsibilities.

## Coverage

Presentation coverage improved while reducing duplicated implementation:

| Module | Before | After |
|--------|-------:|------:|
| `presentation/markdown/pipeline.py` | 99.3% | **100.0%** |
| `presentation/shared/pipeline.py` | 100.0% | **100.0%** (expanded helper set) |
| `presentation/text/pipeline.py` | 97.9% | **99.1%** |

Overall project metrics also improved:

- missed lines: **846 → 845**
- partial branches: **428 → 423**
- presentation regression tests: **1850 → 1856**

## Validation

- `make pre-pr`
- full test suite
- Ruff
- Pyright (3.10 and 3.13)
- documentation formatting

All checks passed.